### PR TITLE
Add RBAC and PSP

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.29.3
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.1.1
+version: 0.3.0

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.29.3
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.1.0
+version: 0.1.1

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -7,10 +7,39 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "victoria-metrics.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "victoria-metrics.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account
+*/}}
+{{- define "victoria-metrics.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "victoria-metrics.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -85,10 +85,6 @@ app: {{ .Values.vminsert.name }}
 {{ include "victoria-metrics.common.matchLabels" . }}
 {{- end -}}
 
-{{- define "victoria-metrics.rbac.labels" -}}
-{{ include "victoria-metrics.common.matchLabels" . }}
-{{ include "victoria-metrics.common.metaLabels" . }}
-{{- end -}}
 
 {{/*
 Create a fully qualified vmstorage name.

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -85,7 +85,6 @@ app: {{ .Values.vminsert.name }}
 {{ include "victoria-metrics.common.matchLabels" . }}
 {{- end -}}
 
-
 {{/*
 Create a fully qualified vmstorage name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -85,6 +85,11 @@ app: {{ .Values.vminsert.name }}
 {{ include "victoria-metrics.common.matchLabels" . }}
 {{- end -}}
 
+{{- define "victoria-metrics.rbac.labels" -}}
+{{ include "victoria-metrics.common.matchLabels" . }}
+{{ include "victoria-metrics.common.metaLabels" . }}
+{{- end -}}
+
 {{/*
 Create a fully qualified vmstorage name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/charts/victoria-metrics-cluster/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rbac.create (not .Values.rbac.namespaced) }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: {{ template "victoria-metrics.name" . }}
+    chart: {{ template "victoria-metrics.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ template "victoria-metrics.fullname" . }}-clusterrole
+rules: []
+{{- end}}

--- a/charts/victoria-metrics-cluster/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrole.yaml
@@ -7,10 +7,17 @@ metadata:
     chart: {{ template "victoria-metrics.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.annotations }}
+{{- with .Values.rbac.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
   name: {{ template "victoria-metrics.fullname" . }}-clusterrole
+{{- if .Values.rbac.pspEnabled }}
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [{{ template "victoria-metrics.fullname" . }}]
+{{- else }}
 rules: []
-{{- end}}
+{{- end }}
+{{- end }}

--- a/charts/victoria-metrics-cluster/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app: {{ template "victoria-metrics.name" . }}
-    chart: {{ template "victoria-metrics.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+  {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
+  {{- if .Values.rbac.extraLabels }}
+  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+  {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/victoria-metrics-cluster/templates/clusterrolebinding.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrolebinding.yaml
@@ -4,10 +4,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "victoria-metrics.fullname" . }}-clusterrolebinding
   labels:
-    app: {{ template "victoria-metrics.name" . }}
-    chart: {{ template "victoria-metrics.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+  {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
+  {{- if .Values.rbac.extraLabels }}
+  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+  {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/victoria-metrics-cluster/templates/clusterrolebinding.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create (not .Values.rbac.namespaced) }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "victoria-metrics.fullname" . }}-clusterrolebinding
+  labels:
+    app: {{ template "victoria-metrics.name" . }}
+    chart: {{ template "victoria-metrics.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "victoria-metrics.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "victoria-metrics.fullname" . }}-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/victoria-metrics-cluster/templates/clusterrolebinding.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ template "victoria-metrics.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.annotations }}
+{{- with .Values.rbac.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
@@ -12,6 +12,9 @@ metadata:
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    {{- if .Values.rbac.annotations }}
+    {{ toYaml .Values.rbac.annotations | indent 4}}
+    {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "victoria-metrics.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "victoria-metrics.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+  {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
+  {{- if .Values.rbac.extraLabels }}
+  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+  {{- end }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'

--- a/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "victoria-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "victoria-metrics.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    # Default set from Docker, without DAC_OVERRIDE or CHOWN
+    - FOWNER
+    - FSETID
+    - KILL
+    - SETGID
+    - SETUID
+    - SETPCAP
+    - NET_BIND_SERVICE
+    - NET_RAW
+    - SYS_CHROOT
+    - MKNOD
+    - AUDIT_WRITE
+    - SETFCAP
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/victoria-metrics-cluster/templates/role.yaml
+++ b/charts/victoria-metrics-cluster/templates/role.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "victoria-metrics.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "victoria-metrics.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+  {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
+  {{- if .Values.rbac.extraLabels }}
+  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+  {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/victoria-metrics-cluster/templates/role.yaml
+++ b/charts/victoria-metrics-cluster/templates/role.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "victoria-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "victoria-metrics.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+rules:
+{{- if .Values.rbac.pspEnabled }}
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [{{ template "victoria-metrics.fullname" . }}]
+{{- else }}
+rules: []
+{{- end }}
+{{- end }}

--- a/charts/victoria-metrics-cluster/templates/role.yaml
+++ b/charts/victoria-metrics-cluster/templates/role.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- with .Values.annotations }}
+{{- with .Values.rbac.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/victoria-metrics-cluster/templates/rolebinding.yaml
+++ b/charts/victoria-metrics-cluster/templates/rolebinding.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "victoria-metrics.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "victoria-metrics.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+  {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
+  {{- if .Values.rbac.extraLabels }}
+  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+  {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/victoria-metrics-cluster/templates/rolebinding.yaml
+++ b/charts/victoria-metrics-cluster/templates/rolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "victoria-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "victoria-metrics.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "victoria-metrics.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "victoria-metrics.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/victoria-metrics-cluster/templates/rolebinding.yaml
+++ b/charts/victoria-metrics-cluster/templates/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- with .Values.annotations }}
+{{- with .Values.rbac.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/victoria-metrics-cluster/templates/serviceaccount.yaml
+++ b/charts/victoria-metrics-cluster/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "victoria-metrics.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ template "victoria-metrics.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/victoria-metrics-cluster/templates/serviceaccount.yaml
+++ b/charts/victoria-metrics-cluster/templates/serviceaccount.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "victoria-metrics.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+  {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
+  {{- if .Values.serviceAccount.extraLabels }}
+  {{ toYaml .Values.serviceAccount.extraLabels | indent 4}}
+  {{- end }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -60,6 +60,9 @@ spec:
       securityContext:
 {{ toYaml .Values.vminsert.securityContext | indent 8 }}
     {{- end }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
+    {{- end }}
     {{- if .Values.vminsert.tolerations }}
       tolerations:
 {{ toYaml .Values.vminsert.tolerations | indent 8 }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -64,6 +64,9 @@ spec:
       securityContext:
 {{ toYaml .Values.vmselect.securityContext | indent 8 }}
     {{- end }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
+    {{- end }}
     {{- if .Values.vmselect.tolerations }}
       tolerations:
 {{ toYaml .Values.vmselect.tolerations | indent 8 }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -101,6 +101,9 @@ spec:
       securityContext:
 {{ toYaml .Values.vmstorage.securityContext | indent 8 }}
     {{- end }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
+    {{- end }}
     {{- if .Values.vmstorage.tolerations }}
       tolerations:
 {{ toYaml .Values.vmstorage.tolerations | indent 8 }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -7,6 +7,16 @@
 ##
 clusterDomainSuffix: cluster.local
 
+rbac:
+  create: true
+  pspEnabled: true
+  namespaced: false
+
+serviceAccount:
+  create: true
+  # name: 
+  # annotations: {}
+
 vmselect:
   enabled: true
   name: vmselect

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -11,6 +11,7 @@ rbac:
   create: true
   pspEnabled: true
   namespaced: false
+  # annotations: {}
 
 serviceAccount:
   create: true

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -11,11 +11,13 @@ rbac:
   create: true
   pspEnabled: true
   namespaced: false
+  extraLabels: {}
   # annotations: {}
 
 serviceAccount:
   create: true
   # name: 
+  extraLabels: {}
   # annotations: {}
 
 vmselect:


### PR DESCRIPTION
This tries to update and add the necessary things to install the VM chart on clusters with RBAC and PodSecurityPolicy enabled.

I have tested this on K8s v1.14.8 running on Azure AKS with PSP enabled.

I have taken most of the config from the `stable/grafana` chart.

Here is a default install with RBAC and PSP enabled:

```
helm3 upgrade --install vm0 charts/victoria-metrics-cluster

$ kubectl get pods -w
NAME                                                     READY   STATUS    RESTARTS   AGE
vm0-victoria-metrics-cluster-vminsert-6646dc68c5-bqr2m   1/1     Running   0          9m57s
vm0-victoria-metrics-cluster-vminsert-6646dc68c5-jppmn   1/1     Running   0          9m57s
vm0-victoria-metrics-cluster-vmselect-67c5988fd9-jmwqf   1/1     Running   0          9m57s
vm0-victoria-metrics-cluster-vmselect-67c5988fd9-z5bk9   1/1     Running   0          9m57s
vm0-victoria-metrics-cluster-vmstorage-0                 1/1     Running   0          9m57s
vm0-victoria-metrics-cluster-vmstorage-1                 1/1     Running   0          8m58s

$ kubectl describe pod vm1-victoria-metrics-cluster-vminsert-798645c97d-8r4k7
Annotations:        kubernetes.io/psp: vm1-victoria-metrics-cluster
```

And namespaced:
```
$ kubectl create ns vm
$ helm3 upgrade --namespace vm --install vm1 charts/victoria-metrics-cluster --set rbac.namespaced=true

$ kubectl get pods -n vm -w
NAME                                                    READY   STATUS    RESTARTS   AGE
vm1-victoria-metrics-cluster-vminsert-b8fbb6858-6mslb   1/1     Running   0          23s
vm1-victoria-metrics-cluster-vminsert-b8fbb6858-fcz7g   1/1     Running   0          23s
vm1-victoria-metrics-cluster-vmselect-96df864b8-dkcl6   1/1     Running   0          23s
vm1-victoria-metrics-cluster-vmselect-96df864b8-r9n85   1/1     Running   0          23s
vm1-victoria-metrics-cluster-vmstorage-0                1/1     Running   0          23s
vm1-victoria-metrics-cluster-vmstorage-1                1/1     Running   0          0s
```

Right now all components use the same config. We could probably add more fine-grained control but I think this should be a good place to start iterating from at least :)