### PR TITLE
fix: change format of extraArgs field

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.30.5
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.3.0
+version: 0.4.0

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -34,7 +34,7 @@ The following table lists the configurable parameters of the victoria metrics cl
 | `vmselect.image.pullPolicy`  | Image pull policy                      | `IfNotPresent`                                                   |
 | `vmselect.priorityClassName` | Name of Priority Class | `""`                                |
 | `vmselect.fullnameOverride`  | Overrides the full name of vmselect component  | `""`                                |
-| `vmselect.extraArgs`         | Extra command line arguments for vmselect component               | `{}`
+| `vmselect.extraArgs`         | Extra command line arguments for vmselect component               | `[]`
 | `vmselect.tolerations`       | Array of tolerations object. [https://kubernetes.io/docs/concepts/configuration/assign-pod-node/](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)                | `{}`                                 |
 | `vmselect.nodeSelector`      | Pod's node selector. [https://kubernetes.io/docs/user-guide/node-selection/](https://kubernetes.io/docs/user-guide/node-selection/)| `{}`
 | `vmselect. affinity `      | Pod affinity| `{}`
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the victoria metrics cl
 | `vminsert.image.pullPolicy`  | Image pull policy                      | `IfNotPresent`                                                   |
 | `vminsert.priorityClassName` | Name of Priority Class | `""`                                |
 | `vminsert.fullnameOverride`  | Overrides the full name of vminsert component  | `""`                                |
-| `vminsert.extraArgs`         | Extra command line arguments for vminsert component               | `{}`
+| `vminsert.extraArgs`         | Extra command line arguments for vminsert component               | `[]`
 | `vminsert.tolerations`       | Array of tolerations object. [https://kubernetes.io/docs/concepts/configuration/assign-pod-node/](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)                | `{}`                                 |
 | `vminsert.nodeSelector`      | Pod's node selector. [https://kubernetes.io/docs/user-guide/node-selection/](https://kubernetes.io/docs/user-guide/node-selection/)| `{}`
 | `vmselect. affinity `      | Pod affinity| `{}`
@@ -111,7 +111,7 @@ The following table lists the configurable parameters of the victoria metrics cl
 | `vmstorage.priorityClassName` | Name of Priority Class | `""`                                |
 | `vmstorage.fullnameOverride`  | Overrides the full name of vmstorage component  | `""`                                |
 | `vmstorage.retentionPeriod`   | Data retention period in month | `1`                                |
-| `vmstorage.extraArgs`         | Extra command line arguments for vmstorage component               | `{}`
+| `vmstorage.extraArgs`         | Extra command line arguments for vmstorage component               | `[]`
 | `vmstorage.tolerations`       | Array of tolerations object. [https://kubernetes.io/docs/concepts/configuration/assign-pod-node/](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)                | `{}`                                 |
 | `vmstorage.nodeSelector`      | Pod's node selector. [https://kubernetes.io/docs/user-guide/node-selection/](https://kubernetes.io/docs/user-guide/node-selection/)| `{}`
 | `vmstorage.affinity `         | Pod affinity| `{}` |

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           args:
           {{- include "victoria-metrics.vminsert.vmstorage-pod-fqdn" . | nindent 12 }}
           {{- range $key, $value := .Values.vminsert.extraArgs }}
-            - --{{ $key }}={{ $value }}
+            - {{ printf "--%s" $value | quote }}
           {{- end }}
           ports:
             - name: http

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - {{ printf "%s=%s" "--cacheDataPath" .Values.vmselect.cacheMountPath | quote}}
           {{- include "victoria-metrics.vmselect.vmstorage-pod-fqdn" . | nindent 12 }}
           {{- range $key, $value := .Values.vmselect.extraArgs }}
-            - --{{ $key }}={{ $value }}
+            - {{ printf "--%s" $value | quote }}
           {{- end }}
           ports:
             - name: http

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -32,7 +32,7 @@ spec:
             - {{ printf "%s=%s" "--cacheDataPath" .Values.vmselect.cacheMountPath | quote}}
           {{- include "victoria-metrics.vmselect.vmstorage-pod-fqdn" . | nindent 12 }}
           {{- range $key, $value := .Values.vmselect.extraArgs }}
-            - --{{ $key }}={{ $value }}
+            - {{ printf "--%s" $value | quote }}
           {{- end }}
           ports:
             - name: http

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -43,7 +43,7 @@ spec:
             - {{ printf "%s=%d" "--retentionPeriod" (int .Values.vmstorage.retentionPeriod) | quote}}
             - {{ printf "%s=%s" "--storageDataPath" .Values.vmstorage.persistentVolume.mountPath | quote}}
           {{- range $key, $value := .Values.vmstorage.extraArgs }}
-            - --{{ $key }}={{ $value }}
+            - {{ printf "--%s" $value | quote }}
           {{- end }}
           ports:
             - name: http

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -29,7 +29,7 @@ vmselect:
     pullPolicy: IfNotPresent
   priorityClassName: ""
   fullnameOverride: ""
-  extraArgs: {}
+  extraArgs: []
 
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
@@ -132,7 +132,7 @@ vminsert:
     pullPolicy: IfNotPresent
   priorityClassName: ""
   fullnameOverride: ""
-  extraArgs: {}
+  extraArgs: []
 
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
@@ -204,7 +204,7 @@ vmstorage:
   retentionPeriod: 1
   ## Additional vmstorage container arguments
   ##
-  extraArgs: {}
+  extraArgs: []
   ## Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##


### PR DESCRIPTION
https://github.com/VictoriaMetrics/helm-charts/issues/8

I updated the format from map to array.

Set values with helm command line:
```
helm template test . --set "vmstorage.extraArgs={search.maxUniqueTimeseries=1000000,foo=bar}"

containers:
  - name: victoria-metrics-cluster-vmstorage
     ...
     args:
       - "--retentionPeriod=1"
       - "--storageDataPath=/storage"
       - "--search.maxUniqueTimeseries=1000000"
       - "--foo=bar"
```

Set values with values file:
```
helm template test . -f test-values.yml

containers:
  - name: victoria-metrics-cluster-vmstorage
     ...
     args:
       - "--retentionPeriod=1"
       - "--storageDataPath=/storage"
       - "--search.maxUniqueTimeseries=1000000"
       - "--foo=bar"
```
