### PR TITLE
fix extraLabels indentation

### DIFF
--- a/charts/victoria-metrics-cluster/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}
-  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+{{ toYaml .Values.rbac.extraLabels | indent 4}}
   {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:

--- a/charts/victoria-metrics-cluster/templates/clusterrolebinding.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}
-  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+{{ toYaml .Values.rbac.extraLabels | indent 4}}
   {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:

--- a/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}
-  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+{{ toYaml .Values.rbac.extraLabels | indent 4}}
   {{- end }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'

--- a/charts/victoria-metrics-cluster/templates/role.yaml
+++ b/charts/victoria-metrics-cluster/templates/role.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}
-  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+{{ toYaml .Values.rbac.extraLabels | indent 4}}
   {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:

--- a/charts/victoria-metrics-cluster/templates/rolebinding.yaml
+++ b/charts/victoria-metrics-cluster/templates/rolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}
-  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+{{ toYaml .Values.rbac.extraLabels | indent 4}}
   {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:

--- a/charts/victoria-metrics-cluster/templates/serviceaccount.yaml
+++ b/charts/victoria-metrics-cluster/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.serviceAccount.extraLabels }}
-  {{ toYaml .Values.serviceAccount.extraLabels | indent 4}}
+{{ toYaml .Values.serviceAccount.extraLabels | indent 4}}
   {{- end }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/victoria-metrics-cluster/templates/vminsert-ingress.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.vminsert.labels" . | nindent 4 }}
   {{ if .Values.vminsert.ingress.extraLabels }}
-  {{ toYaml .Values.vminsert.ingress.extraLabels | indent 4 }}
+{{ toYaml .Values.vminsert.ingress.extraLabels | indent 4 }}
   {{ end }}
   name: {{ template "victoria-metrics.vminsert.fullname" . }}
 spec:

--- a/charts/victoria-metrics-cluster/templates/vmselect-ingress.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
   {{ if .Values.vmselect.ingress.extraLabels }}
-  {{ toYaml .Values.vmselect.ingress.extraLabels | indent 4 }}
+{{ toYaml .Values.vmselect.ingress.extraLabels | indent 4 }}
   {{ end }}
   name: {{ template "victoria-metrics.vmselect.fullname" . }}
 spec:

--- a/charts/victoria-metrics-single/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-single/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}
-  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+{{ toYaml .Values.rbac.extraLabels | indent 4}}
   {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:

--- a/charts/victoria-metrics-single/templates/clusterrolebinding.yaml
+++ b/charts/victoria-metrics-single/templates/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}
-  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+{{ toYaml .Values.rbac.extraLabels | indent 4}}
   {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:

--- a/charts/victoria-metrics-single/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-single/templates/podsecuritypolicy.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}
-  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+{{ toYaml .Values.rbac.extraLabels | indent 4}}
   {{- end }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'

--- a/charts/victoria-metrics-single/templates/role.yaml
+++ b/charts/victoria-metrics-single/templates/role.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}
-  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+{{ toYaml .Values.rbac.extraLabels | indent 4}}
   {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:

--- a/charts/victoria-metrics-single/templates/rolebinding.yaml
+++ b/charts/victoria-metrics-single/templates/rolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}
-  {{ toYaml .Values.rbac.extraLabels | indent 4}}
+{{ toYaml .Values.rbac.extraLabels | indent 4}}
   {{- end }}
 {{- with .Values.rbac.annotations }}
   annotations:

--- a/charts/victoria-metrics-single/templates/serviceaccount.yaml
+++ b/charts/victoria-metrics-single/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.serviceAccount.extraLabels }}
-  {{ toYaml .Values.serviceAccount.extraLabels | indent 4}}
+{{ toYaml .Values.serviceAccount.extraLabels | indent 4}}
   {{- end }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:


### PR DESCRIPTION
This is related to #6, using extraLabels will give the `error converting YAML to JSON` error because the first label has an extra indent.