### PR TITLE
[victoria-metrics-single] - Create missing ingress and update README.md

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.32.8
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.4.1
+version: 0.4.2

--- a/charts/victoria-metrics-cluster/templates/vmselect-ingress.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-ingress.yaml
@@ -22,7 +22,7 @@ spec:
         - path: {{ .path }}
           backend:
             serviceName: {{ $serviceName }}
-            servicePort: http
+            servicePort: {{ .port | default "http"}}
     {{- end -}}
 {{- if .Values.vmselect.ingress.tls }}
   tls:

--- a/charts/victoria-metrics-cluster/templates/vmselect-service-headless.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service-headless.yaml
@@ -11,7 +11,7 @@ metadata:
 {{- if .Values.vmselect.statefulSet.service.labels }}
 {{ toYaml .Values.vmselect.statefulSet.service.labels | indent 4}}
 {{- end }}
-  name: {{ template "victoria-metrics.vmselect.fullname" . }}
+  name: {{ template "victoria-metrics.vmselect.fullname" . }}-headless
 spec:
   clusterIP: None
   ports:

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.32.8
 description: Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.0.1
+version: 0.0.2

--- a/charts/victoria-metrics-single/README.md
+++ b/charts/victoria-metrics-single/README.md
@@ -1,1 +1,80 @@
-TBD
+# Victoria Metrics Helm Chart for Single Version
+
+## Prerequisites Details
+* [Victoria Metrics helm repository](https://github.com/VictoriaMetrics/helm-charts/#usage) is added.
+* PV support on underlying infrastructure
+
+
+## Chart Details
+This chart will do the following:
+
+* Rollout victoria metrics single 
+
+## Installing the Chart
+
+### 
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install -n my-release vm/victoria-metrics-single
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the victoria metrics cluster chart and their default values.
+
+| Parameter               | Description                           | Default                                                    |
+| ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
+| `server.enabled`           | Enable deployment of server component. Deployed as StatefulSet                 | `true`                       |
+| `server.name`              | Server container name                   | `server`                                                    |
+| `server.image.repository`  | Image repository                 | `victoriametrics/victoria-metrics`                                                   |
+| `server.image.tag`         | Image tag              | `v1.32.8`                                                        |
+| `server.image.pullPolicy`  | Image pull policy                      | `IfNotPresent`                                                   |
+| `server.priorityClassName` | Name of Priority Class | `""`                                |
+| `server.fullnameOverride`  | Overrides the full name of server component  | `""`                                |
+| `server.retentionPeriod`  | Data retention period in month  | `1`                                |
+| `server.extraArgs`         | Extra command line arguments for server component               | `{}`
+| `server.tolerations`       | Array of tolerations object. [https://kubernetes.io/docs/concepts/configuration/assign-pod-node/](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)                | `{}`                                 |
+| `server.nodeSelector`      | Pod's node selector. [https://kubernetes.io/docs/user-guide/node-selection/](https://kubernetes.io/docs/user-guide/node-selection/)| `{}`
+| `server. affinity `      | Pod affinity| `{}`
+| `server.persistentVolume.enabled` | Create/use Persistent Volume Claim for server component. Empty dir if false  | `true`|
+| `server.persistentVolume.accessModes`      | Array of access modes       | `["ReadWriteOnce"]`                                                       |
+| `server.persistentVolume.annotations`      | Persistant volume annotations      | `{}`                                                       |
+| `server.persistentVolume.existingClaim`         | Existing Claim name        | `""`                                                       |
+| `server.persistentVolume.size`     | Size of the volume. Better to set the same as resource limit memory property    | `16Gi`                          |
+| `server.persistentVolume.mountPath`        | Mount path       | `""/storage`                                                 |
+| `server.persistentVolume.subPath`        | Mount subpath       | `""`                                                 |
+| `server.podAnnotations`    | Pod's annotations     | `{}`                                                     |
+| `server.podManagementPolicy`    | Pod's management policy     | `OrderedReady`                                                     |
+| `server.resources`         | Resource object    | `{}`                                                     |
+| `server.securityContext`   | Pod's security context. [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)      | `{}`                                                      |
+| `server.ingress.enabled`        | Enable deployment of ingress for server component | `false`                                                     |
+| `server.ingress.annotations`    | Ingress annotations       | `{}`                                                     |
+| `server.ingress.extraLabels`    | Ingress extra labels       | `{}`                                                     |
+| `server.ingress.hosts`         | Array of host objects          | `[]`                                                     |
+| `server.ingress.tls`              | Array of TLS objects              | `[]`                                          |
+| `server.service.annotations` | Service annotations       | `{}`                                                      |
+| `server.service.labels`      | Service lables            | `{}`                                                     |
+| `server.service.clusterIP`   | Service ClusterIP | `""`                                                       |
+| `server.service.externalIPs`  | Service External IPs. [ https://kubernetes.io/docs/user-guide/services/#external-ips]( https://kubernetes.io/docs/user-guide/services/#external-ips)                     | `[]`                                                      |
+| `server.service.loadBalancerIP`               | Service load balacner IP             | `"`                                                     |
+| `server.service.loadBalancerSourceRanges`     | Load balancer source range     | `[]`                                                     |
+| `server.service.servicePort`        | Service port | `8428`                                                     |
+| `server.service.type`           | Service type     | `ClusterIP`                                                     |
+| `server.serviceMonitor.enabled` | Enable deployment of Service Monitor for server component. This is Prometheus operator object      | `false`     |
+| `server.serviceMonitor.extraLabels`  | Service Monitor labels        | `{}`                                                    |
+| `server.serviceMonitor.annotations`       | Service Monitor annotations | `{}`                                    |
+| `server.serviceMonitor.interval`       | Commented. Prometheus scare interval for server component| `15s`                                    |
+| `server.serviceMonitor.scrapeTimeout`       | Commented. Prometheus pre-scrape timeout for server component| `5s`                                    |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install -n my-release -f values.yaml vm/victoria-metrics-single
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+

--- a/charts/victoria-metrics-single/templates/server-ingress.yaml
+++ b/charts/victoria-metrics-single/templates/server-ingress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.server.enabled .Values.server.ingress.enabled  }}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+{{- if .Values.server.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.server.ingress.annotations | indent 4 }}
+{{- end }}
+  labels:
+  {{- include "victoria-metrics.server.labels" . | nindent 4 }}
+  {{ if .Values.server.ingress.extraLabels }}
+{{ toYaml .Values.server.ingress.extraLabels | indent 4 }}
+  {{ end }}
+  name: {{ template "victoria-metrics.server.fullname" . }}
+spec:
+  rules:
+  {{- $serviceName := include "victoria-metrics.server.fullname" . }}
+  {{- range .Values.server.ingress.hosts }}
+  - host: {{ .name }}
+    http:
+      paths:
+        - path: {{ .path }}
+          backend:
+            serviceName: {{ $serviceName }}
+            servicePort: {{ .port | default "http"}}
+    {{- end -}}
+{{- if .Values.server.ingress.tls }}
+  tls:
+{{ toYaml .Values.server.ingress.tls | indent 4 }}
+{{- end -}}
+{{- end -}}

--- a/charts/victoria-metrics-single/templates/server-service-headless.yaml
+++ b/charts/victoria-metrics-single/templates/server-service-headless.yaml
@@ -1,22 +1,22 @@
-{{- if and .Values.server.enabled .Values.server.statefulSet.enabled -}}
+{{- if .Values.server.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.server.statefulSet.service.annotations }}
+{{- if .Values.server.service.annotations }}
   annotations:
-{{ toYaml .Values.server.statefulSet.service.annotations | indent 4}}
+{{ toYaml .Values.server.service.annotations | indent 4}}
 {{- end }}
   labels:
   {{- include "victoria-metrics.server.labels" . | nindent 4 }}
-{{- if .Values.server.statefulSet.service.labels }}
-{{ toYaml .Values.server.statefulSet.service.labels | indent 4}}
+{{- if .Values.server.service.labels }}
+{{ toYaml .Values.server.service.labels | indent 4}}
 {{- end }}
   name: {{ template "victoria-metrics.server.fullname" . }}
 spec:
   clusterIP: None
   ports:
     - name: http
-      port: {{ .Values.server.statefulSet.service.servicePort }}
+      port: {{ .Values.server.service.servicePort }}
       protocol: TCP
       targetPort: http
 {{- if .Values.server.extraArgs.graphiteListenAddr }}

--- a/charts/victoria-metrics-single/templates/server-service-headless.yaml
+++ b/charts/victoria-metrics-single/templates/server-service-headless.yaml
@@ -11,7 +11,7 @@ metadata:
 {{- if .Values.server.service.labels }}
 {{ toYaml .Values.server.service.labels | indent 4}}
 {{- end }}
-  name: {{ template "victoria-metrics.server.fullname" . }}
+  name: {{ template "victoria-metrics.server.fullname" . }}-headless
 spec:
   clusterIP: None
   ports:

--- a/charts/victoria-metrics-single/templates/server-service.yaml
+++ b/charts/victoria-metrics-single/templates/server-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.server.enabled (not .Values.server.statefulSet.enabled) -}}
+{{- if .Values.server.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -119,15 +119,7 @@ server:
     loadBalancerSourceRanges: []
     servicePort: 8428
     type: ClusterIP
-  statefulSet:
-    ## Creates statefulset instead of deployment, useful when you want to keep the cache
-    enabled: true
-    podManagementPolicy: OrderedReady
-    ## Headless service for statefulset
-    service:
-      annotations: {}
-      labels: {}
-      servicePort: 8428
+
   terminationGracePeriodSeconds: 60
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
Hi @valyala and @tenmozes 

Here is a PR to create an ingress when deploying `victoria-metrics-single`.

I also removed the `statefulSet` configuration considering the deployement is always a stateful set for `victoria-metrics-single`

I defined a suffix `-headless` for headless services (seems the [convention](https://github.com/helm/charts/blob/2584adbdab1f09db084ade5f3034e826da67a13f/stable/prometheus/templates/alertmanager-statefulset.yaml))
I updated the `README.md` (it was empty) and fix minor issue in `victoria-metrics-cluster`.

Nicolas