### PR TITLE
Making it possible to set namespace on ServiceMonitor manifest

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.34.3
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.4.1
+version: 0.4.2

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the victoria metrics cl
 | `vmselect.persistentVolume.size`     | Size of the volume. Better to set the same as resource limit memory property    | `2Gi`                          |
 | `vmselect.persistentVolume.subPath`        | Mount subpath       | `""`                                                 |
 | `vmselect.serviceMonitor.enabled` | Enable deployment of Service Monitor for vmselect component. This is Prometheus operatior object      | `false`     |
+| `vmselect.serviceMonitor.namespace` | Target namespace of ServiceMonitor manifest |  |
 | `vmselect.serviceMonitor.extraLabels`  | Service Monitor labels        | `{}`                                                    |
 | `vmselect.serviceMonitor.annotations`       | Service Monitor annotations | `{}`                                    |
 | `vmselect.serviceMonitor.interval`       | Commented. Prometheus scare interval for vmselect component| `15s`                                    |
@@ -99,6 +100,7 @@ The following table lists the configurable parameters of the victoria metrics cl
 | `vminsert.ingress.hosts`         | Array of host objects          | `[]`                                                     |
 | `vminsert.ingress.tls`              | Array of TLS objects              | `[]`                                          |
 | `vminsert.serviceMonitor.enabled` | Enable deployment of Service Monitor for vminsert component. This is Prometheus operatior object      | `false`     |
+| `vminsert.serviceMonitor.namespace` | Target namespace of ServiceMonitor manifest |  |
 | `vminsert.serviceMonitor.extraLabels`  | Service Monitor labels        | `{}`                                                    |
 | `vminsert.serviceMonitor.annotations`       | Service Monitor annotations | `{}`                                    |
 | `vminsert.serviceMonitor.interval`       | Commented. Prometheus scare interval for vminsert component| `15s`                                    |
@@ -134,6 +136,7 @@ The following table lists the configurable parameters of the victoria metrics cl
 | `vmstorage.service.vmselectPort`      | Port for accepting connections from vmselect           | `8401`                                                     |
 | `vmstorage.terminationGracePeriodSeconds`      | Pod's termination grace period in seconds          | `60`                                                     |
 | `vmstorage.serviceMonitor.enabled` | Enable deployment of Service Monitor for vmstorage component. This is Prometheus operatior object      | `false`     |
+| `vmstorage.serviceMonitor.namespace` | Target namespace of ServiceMonitor manifest |  |
 | `vmstorage.serviceMonitor.extraLabels`  | Service Monitor labels        | `{}`                                                    |
 | `vmstorage.serviceMonitor.annotations`       | Service Monitor annotations | `{}`                                    |
 | `vmstorage.serviceMonitor.interval`       | Commented. Prometheus scare interval for vmstorage component| `15s`                                    |

--- a/charts/victoria-metrics-cluster/templates/vminsert-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-service-monitor.yaml
@@ -12,6 +12,9 @@ metadata:
 {{ toYaml .Values.vminsert.serviceMonitor.extraLabels | indent 4 }}
   {{- end }}
   name: {{ template "victoria-metrics.vminsert.fullname" . }}
+  {{- if .Values.vminsert.serviceMonitor.namespace }}
+  namespace: {{ .Values.vminsert.serviceMonitor.namespace }}
+  {{- end }}
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/victoria-metrics-cluster/templates/vmselect-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service-monitor.yaml
@@ -12,6 +12,9 @@ metadata:
 {{ toYaml .Values.vmselect.serviceMonitor.extraLabels | indent 4 }}
   {{- end }}
   name: {{ template "victoria-metrics.vmselect.fullname" . }}
+  {{- if .Values.vmselect.serviceMonitor.namespace }}
+  namespace: {{ .Values.vmselect.serviceMonitor.namespace }}
+  {{- end }}
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/victoria-metrics-cluster/templates/vmstorage-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-service-monitor.yaml
@@ -12,6 +12,9 @@ metadata:
 {{ toYaml .Values.vmstorage.serviceMonitor.extraLabels | indent 4 }}
   {{- end }}
   name: {{ template "victoria-metrics.vmstorage.fullname" . }}
+  {{- if .Values.vmstorage.serviceMonitor.namespace }}
+  namespace: {{ .Values.vmstorage.serviceMonitor.namespace }}
+  {{- end }}
 spec:
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
It is often common practice to place the ServiceMonitor manifest in another namespace, e.g., `monitoring`. Thus, it would be nice to have the ability to optionally set the target namespace for the ServiceMonitor.