### PR TITLE
Fix server deployment upgrade requiring a manual pod delete

### DIFF
--- a/charts/victoria-metrics-single/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-single/templates/server-deployment.yaml
@@ -14,6 +14,11 @@ spec:
     matchLabels:
       {{- include "victoria-metrics.server.matchLabels" . | nindent 6 }}
   replicas: 1
+{{- if .Values.server.persistentVolume.enabled }}
+  strategy:
+    # Must be "Recreate" when we have a persistent volume
+    type: Recreate
+{{- end }}
   template:
     metadata:
     {{- if .Values.server.podAnnotations }}


### PR DESCRIPTION
When a pvc is attached, the deployment won't be able to create a new pod
after an upgrade until the first pod dies/is deleted. Changing the deployment
strategy to 'Recreate' allows upgrades to proceed as expected.