### PR TITLE
Add missing namespace to single chart

### DIFF
--- a/charts/victoria-metrics-single/templates/server-service-headless.yaml
+++ b/charts/victoria-metrics-single/templates/server-service-headless.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.server.statefulSet.service.annotations }}
   annotations:
 {{ toYaml .Values.server.statefulSet.service.annotations | indent 4}}

--- a/charts/victoria-metrics-single/templates/server-service.yaml
+++ b/charts/victoria-metrics-single/templates/server-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.server.service.annotations }}
   annotations:
 {{ toYaml .Values.server.service.annotations | indent 4}}

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.server.annotations }}
   annotations:
 {{ toYaml .Values.server.annotations | indent 4 }}


### PR DESCRIPTION
Current single chart is missing namespace for statefulset, and service objects.

Maybe other charts here are also missing it, but haven't had the time to inspect.