### PR TITLE
Fix kubelest cadvisor forbidden scrape problem

### DIFF
--- a/charts/victoria-metrics-agent/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrole.yaml
@@ -15,6 +15,7 @@ rules:
   resources:
   - nodes
   - nodes/proxy
+  - nodes/metrics
   - services
   - endpoints
   - pods


### PR DESCRIPTION
GCE k8s cluster a have got error:

```
1s, error="unexpected status code returned when scraping \"https://10.138.0.121:10250/metrics\": 403; expecting 200; response body: \"Forbidden (user=system:serviceaccount:devops:vmagent-gcp-stg-victoria-metrics-agent, verb=get, resource=nodes, subresource=metrics)\""
```

add one more resource to cluster role 