### PR TITLE
fix: remove duplicated key affinity in sts

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -26,10 +26,6 @@ spec:
       labels:
         {{- include "victoria-metrics.vmstorage.labels" . | nindent 8 }}
     spec:
-{{- if .Values.vmstorage.affinity }}
-      affinity:
-{{ toYaml .Values.vmstorage.affinity | indent 8 }}
-{{- end }}
 {{- if .Values.vmstorage.priorityClassName }}
       priorityClassName: "{{ .Values.vmstorage.priorityClassName }}"
 {{- end }}

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -26,10 +26,6 @@ spec:
       labels:
         {{- include "victoria-metrics.server.labels" . | nindent 8 }}
     spec:
-{{- if .Values.server.affinity }}
-      affinity:
-{{ toYaml .Values.server.affinity | indent 8 }}
-{{- end }}
 {{- if .Values.server.priorityClassName }}
       priorityClassName: "{{ .Values.server.priorityClassName }}"
 {{- end }}


### PR DESCRIPTION
This PR is fixing yaml linter error : `error    duplication of key "affinity" in mapping  (key-duplicates)`
