### PR TITLE
Update vmselect-statefulset.yaml

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -71,6 +71,9 @@ spec:
       securityContext:
 {{ toYaml .Values.vmselect.securityContext | indent 8 }}
     {{- end }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
+    {{- end }}
     {{- if .Values.vmselect.tolerations }}
       tolerations:
 {{ toYaml .Values.vmselect.tolerations | indent 8 }}


### PR DESCRIPTION
Hey everyone,

I just discovered that Pod Security Policy is not working for vmselect as the Service Account was missing.

Therefore it used the default Service Account which had no permission to use the created PSP.

I would love to see this upstream - let me know if I should change something.