### PR TITLE
PodDisruptionBudget for VM, vmagent and vmalert

### DIFF
--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: victoria-metrics-agent
 description: Victoria Metrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
-version: 0.4.7
+version: 0.4.8
 appVersion: v1.38.1

--- a/charts/victoria-metrics-agent/templates/pdb.yaml
+++ b/charts/victoria-metrics-agent/templates/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "chart.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- if .Values.podDisruptionBudget.labels }}
+{{ toYaml .Values.podDisruptionBudget.labels | indent 4}}
+  {{- end }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/victoria-metrics-agent/templates/pdb.yaml
+++ b/charts/victoria-metrics-agent/templates/pdb.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-  {{- if .Values.podDisruptionBudget.labels }}
-{{ toYaml .Values.podDisruptionBudget.labels | indent 4}}
+  {{- with .Values.podDisruptionBudget.labels }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.podDisruptionBudget.minAvailable }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -26,6 +26,14 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+## See `kubectl explain poddisruptionbudget.spec` for more
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  enabled: true
+  # minAvailable: 1
+  # maxUnavailable: 1
+  labels: {}
+
 # WARN: need to specify at least one remote write url
 remoteWriteUrls: []
 # remoteWriteUrls:

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -29,7 +29,7 @@ serviceAccount:
 ## See `kubectl explain poddisruptionbudget.spec` for more
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 podDisruptionBudget:
-  enabled: true
+  enabled: false
   # minAvailable: 1
   # maxUnavailable: 1
   labels: {}

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: victoria-metrics-alert
 description: Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.0.18
+version: 0.0.19
 appVersion: v1.38.1

--- a/charts/victoria-metrics-alert/templates/server-pdb.yaml
+++ b/charts/victoria-metrics-alert/templates/server-pdb.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.server.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "vmalert.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- if .Values.server.podDisruptionBudget.labels }}
+{{ toYaml .Values.server.podDisruptionBudget.labels | indent 4}}
+  {{- end }}
+spec:
+{{- if .Values.server.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.server.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.server.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.server.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "vmalert.server.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/victoria-metrics-alert/templates/server-pdb.yaml
+++ b/charts/victoria-metrics-alert/templates/server-pdb.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vmalert.server.labels" . | nindent 4 }}
-  {{- if .Values.server.podDisruptionBudget.labels }}
-{{ toYaml .Values.server.podDisruptionBudget.labels | indent 4}}
+  {{- with .Values.server.podDisruptionBudget.labels }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.server.podDisruptionBudget.minAvailable }}

--- a/charts/victoria-metrics-alert/templates/server-pdb.yaml
+++ b/charts/victoria-metrics-alert/templates/server-pdb.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "vmalert.server.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "vmalert.server.labels" . | nindent 4 }}
   {{- if .Values.server.podDisruptionBudget.labels }}
 {{ toYaml .Values.server.podDisruptionBudget.labels | indent 4}}
   {{- end }}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -22,6 +22,15 @@ server:
     pullPolicy: IfNotPresent
   nameOverride: ""
   fullnameOverride: ""
+
+  ## See `kubectl explain poddisruptionbudget.spec` for more
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  podDisruptionBudget:
+    enabled: true
+    # minAvailable: 1
+    # maxUnavailable: 1
+    labels: {}
+
   replicaCount: 1
   # vmalert reads metrics from source, next section represents its configuration. It can be any service which supports
   # MetricsQL or PromQL.

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -26,7 +26,7 @@ server:
   ## See `kubectl explain poddisruptionbudget.spec` for more
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   podDisruptionBudget:
-    enabled: true
+    enabled: false
     # minAvailable: 1
     # maxUnavailable: 1
     labels: {}

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.38.1
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.5.18
+version: 0.5.19

--- a/charts/victoria-metrics-cluster/templates/vminsert-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-pdb.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "victoria-metrics.vminsert.labels" . | nindent 4 }}
-  {{- if .Values.vminsert.podDisruptionBudget.labels }}
-{{ toYaml .Values.vminsert.podDisruptionBudget.labels | indent 4}}
+  {{- with .Values.vminsert.podDisruptionBudget.labels }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.vminsert.podDisruptionBudget.minAvailable }}

--- a/charts/victoria-metrics-cluster/templates/vminsert-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-pdb.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.vminsert.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "victoria-metrics.vminsert.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "victoria-metrics.vminsert.labels" . | nindent 4 }}
+  {{- if .Values.vminsert.podDisruptionBudget.labels }}
+{{ toYaml .Values.vminsert.podDisruptionBudget.labels | indent 4}}
+  {{- end }}
+spec:
+{{- if .Values.vminsert.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.vminsert.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.vminsert.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.vminsert.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "victoria-metrics.vminsert.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-pdb.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.vmselect.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "victoria-metrics.vmselect.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
+  {{- if .Values.vmselect.podDisruptionBudget.labels }}
+{{ toYaml .Values.vmselect.podDisruptionBudget.labels | indent 4}}
+  {{- end }}
+spec:
+{{- if .Values.vmselect.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.vmselect.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.vmselect.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.vmselect.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "victoria-metrics.vmselect.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-pdb.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
-  {{- if .Values.vmselect.podDisruptionBudget.labels }}
-{{ toYaml .Values.vmselect.podDisruptionBudget.labels | indent 4}}
+  {{- with .Values.vmselect.podDisruptionBudget.labels }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.vmselect.podDisruptionBudget.minAvailable }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.vmstorage.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "victoria-metrics.vmstorage.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
+  {{- if .Values.vmstorage.podDisruptionBudget.labels }}
+{{ toYaml .Values.vmstorage.podDisruptionBudget.labels | indent 4}}
+  {{- end }}
+spec:
+{{- if .Values.vmstorage.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.vmstorage.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.vmstorage.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.vmstorage.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "victoria-metrics.vmstorage.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
-  {{- if .Values.vmstorage.podDisruptionBudget.labels }}
-{{ toYaml .Values.vmstorage.podDisruptionBudget.labels | indent 4}}
+  {{- with .Values.vmstorage.podDisruptionBudget.labels }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.vmstorage.podDisruptionBudget.minAvailable }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -16,7 +16,7 @@ rbac:
 
 serviceAccount:
   create: true
-  # name: 
+  # name:
   extraLabels: {}
   # annotations: {}
 
@@ -31,6 +31,14 @@ vmselect:
   fullnameOverride: ""
   extraArgs: {}
   annotations: {}
+
+  ## See `kubectl explain poddisruptionbudget.spec` for more
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  podDisruptionBudget:
+    enabled: false
+    # minAvailable: 1
+    # maxUnavailable: 1
+    labels: {}
 
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
@@ -136,6 +144,14 @@ vminsert:
   extraArgs: {}
   annotations: {}
 
+  ## See `kubectl explain poddisruptionbudget.spec` for more
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  podDisruptionBudget:
+    enabled: false
+    # minAvailable: 1
+    # maxUnavailable: 1
+    labels: {}
+
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
   tolerations: []
@@ -208,6 +224,15 @@ vmstorage:
   ## Additional vmstorage container arguments
   ##
   extraArgs: {}
+
+  ## See `kubectl explain poddisruptionbudget.spec` for more
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  podDisruptionBudget:
+    enabled: false
+    # minAvailable: 1
+    # maxUnavailable: 1
+    labels: {}
+
   ## Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##


### PR DESCRIPTION
Allow enabling PodDisruptionBudget for:
- VM cluster (vmselect, vmstorage and vminsert)
- vmagent
- vmalert