### PR TITLE
Allow regular service to be used with StatefulSet

### DIFF
--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.39.2
 description: Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.5.17
+version: 0.6.0

--- a/charts/victoria-metrics-single/templates/server-service-headless.yaml
+++ b/charts/victoria-metrics-single/templates/server-service-headless.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- if .Values.server.statefulSet.service.labels }}
 {{ toYaml .Values.server.statefulSet.service.labels | indent 4}}
 {{- end }}
-  name: {{ template "victoria-metrics.server.fullname" . }}
+  name: {{ template "victoria-metrics.server.fullname" . }}-headless
 spec:
   clusterIP: None
   ports:

--- a/charts/victoria-metrics-single/templates/server-service.yaml
+++ b/charts/victoria-metrics-single/templates/server-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.server.enabled (not .Values.server.statefulSet.enabled) -}}
+{{- if .Values.server.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "victoria-metrics.server.labels" . | nindent 4 }}
   name: {{ template "victoria-metrics.server.fullname" . }}
 spec:
-  serviceName: {{ template "victoria-metrics.server.fullname" . }}
+  serviceName: {{ template "victoria-metrics.server.fullname" . }}-headless
   selector:
     matchLabels:
       {{- include "victoria-metrics.server.matchLabels" . | nindent 6 }}


### PR DESCRIPTION
A headless service is required for the statefulset itself, but unfortunately, a headless service doesn't support all the features of regular services. (Like LoadBalancer type, with static IP)

This change renames the headless service to "fullname-headless" and additionally creates the regular service for statefulsets.

I bumped the minor version to signal users that there are potentially breaking changes.