### PR TITLE
Add optional pod labels

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.40.0
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.6.3
+version: 0.6.4

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "victoria-metrics.vminsert.labels" . | nindent 4 }}
-{{- if .Values.vminsert.labels }}
+{{- with .Values.vminsert.extraLabels }}
 {{ toYaml .Values.vminsert.labels | indent 4 }}
 {{- end }}
   name: {{ template "victoria-metrics.vminsert.fullname" . }}
@@ -26,7 +26,7 @@ spec:
     {{- end }}
       labels:
         {{- include "victoria-metrics.vminsert.labels" . | nindent 8 }}
-{{- if .Values.vminsert.labels }}
+{{- with .Values.vminsert.extraLabels }}
 {{ toYaml .Values.vminsert.labels | indent 8 }}
 {{- end }}
     spec:

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     {{- include "victoria-metrics.vminsert.labels" . | nindent 4 }}
+{{- if .Values.vminsert.labels }}
+{{ toYaml .Values.vminsert.labels | indent 4 }}
+{{- end }}
   name: {{ template "victoria-metrics.vminsert.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -23,6 +26,9 @@ spec:
     {{- end }}
       labels:
         {{- include "victoria-metrics.vminsert.labels" . | nindent 8 }}
+{{- if .Values.vminsert.labels }}
+{{ toYaml .Values.vminsert.labels | indent 8 }}
+{{- end }}
     spec:
 {{- if .Values.vminsert.priorityClassName }}
       priorityClassName: "{{ .Values.vminsert.priorityClassName }}"

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
+{{- if .Values.vmselect.labels }}
+{{ toYaml .Values.vmselect.labels | indent 4 }}
+{{- end }}
   name: {{ template "victoria-metrics.vmselect.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -23,6 +26,9 @@ spec:
     {{- end }}
       labels:
         {{- include "victoria-metrics.vmselect.labels" . | nindent 8 }}
+{{- if .Values.vmselect.labels }}
+{{ toYaml .Values.vmselect.labels | indent 8 }}
+{{- end }}
     spec:
 {{- if .Values.vmselect.priorityClassName }}
       priorityClassName: "{{ .Values.vmselect.priorityClassName }}"

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
-{{- if .Values.vmselect.labels }}
+{{- with .Values.vmselect.extraLabels }}
 {{ toYaml .Values.vmselect.labels | indent 4 }}
 {{- end }}
   name: {{ template "victoria-metrics.vmselect.fullname" . }}
@@ -26,7 +26,7 @@ spec:
     {{- end }}
       labels:
         {{- include "victoria-metrics.vmselect.labels" . | nindent 8 }}
-{{- if .Values.vmselect.labels }}
+{{- with .Values.vmselect.extraLabels }}
 {{ toYaml .Values.vmselect.labels | indent 8 }}
 {{- end }}
     spec:

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
+{{- if .Values.vmselect.labels }}
+{{ toYaml .Values.vmselect.labels | indent 4 }}
+{{- end }}
   name: {{ template "victoria-metrics.vmselect.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -25,6 +28,9 @@ spec:
     {{- end }}
       labels:
         {{- include "victoria-metrics.vmselect.labels" . | nindent 8 }}
+{{- if .Values.vmselect.labels }}
+{{ toYaml .Values.vmselect.labels | indent 8 }}
+{{- end }}
     spec:
 {{- if .Values.vmselect.priorityClassName }}
       priorityClassName: "{{ .Values.vmselect.priorityClassName }}"

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
-{{- if .Values.vmselect.labels }}
+{{- with .Values.vmselect.extraLabels }}
 {{ toYaml .Values.vmselect.labels | indent 4 }}
 {{- end }}
   name: {{ template "victoria-metrics.vmselect.fullname" . }}
@@ -28,7 +28,7 @@ spec:
     {{- end }}
       labels:
         {{- include "victoria-metrics.vmselect.labels" . | nindent 8 }}
-{{- if .Values.vmselect.labels }}
+{{- with .Values.vmselect.extraLabels }}
 {{ toYaml .Values.vmselect.labels | indent 8 }}
 {{- end }}
     spec:

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     {{- include "victoria-metrics.vmstorage.labels" . | nindent 4 }}
+{{- if .Values.vmstorage.labels }}
+{{ toYaml .Values.vmstorage.labels | indent 4 }}
+{{- end }}
   name: {{ template "victoria-metrics.vmstorage.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -25,6 +28,9 @@ spec:
     {{- end }}
       labels:
         {{- include "victoria-metrics.vmstorage.labels" . | nindent 8 }}
+{{- if .Values.vmstorage.labels }}
+{{ toYaml .Values.vmstorage.labels | indent 8 }}
+{{- end }}
     spec:
 {{- if .Values.vmstorage.priorityClassName }}
       priorityClassName: "{{ .Values.vmstorage.priorityClassName }}"

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "victoria-metrics.vmstorage.labels" . | nindent 4 }}
-{{- if .Values.vmstorage.labels }}
+{{- with .Values.vmstorage.extraLabels }}
 {{ toYaml .Values.vmstorage.labels | indent 4 }}
 {{- end }}
   name: {{ template "victoria-metrics.vmstorage.fullname" . }}
@@ -28,7 +28,7 @@ spec:
     {{- end }}
       labels:
         {{- include "victoria-metrics.vmstorage.labels" . | nindent 8 }}
-{{- if .Values.vmstorage.labels }}
+{{- with .Values.vmstorage.extraLabels }}
 {{ toYaml .Values.vmstorage.labels | indent 8 }}
 {{- end }}
     spec:

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -34,7 +34,7 @@ vmselect:
   suppresStorageFQDNsRender: false
   extraArgs: {}
   annotations: {}
-  labels: {}
+  extraLabels: {}
 
   ## See `kubectl explain poddisruptionbudget.spec` for more
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
@@ -147,7 +147,7 @@ vminsert:
   fullnameOverride: ""
   extraArgs: {}
   annotations: {}
-  labels: {}
+  extraLabels: {}
   ## If true suppress rendering `--stroageNodes`, they can be re-defined in exrtaArgs
   suppresStorageFQDNsRender: false
 
@@ -286,7 +286,7 @@ vmstorage:
 
   podAnnotations: {}
   annotations: {}
-  labels: {}
+  extraLabels: {}
   replicaCount: 2
   podManagementPolicy: OrderedReady
 

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -34,6 +34,7 @@ vmselect:
   suppresStorageFQDNsRender: false
   extraArgs: {}
   annotations: {}
+  labels: {}
 
   ## See `kubectl explain poddisruptionbudget.spec` for more
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
@@ -146,6 +147,7 @@ vminsert:
   fullnameOverride: ""
   extraArgs: {}
   annotations: {}
+  labels: {}
   ## If true suppress rendering `--stroageNodes`, they can be re-defined in exrtaArgs
   suppresStorageFQDNsRender: false
 
@@ -212,7 +214,6 @@ vminsert:
     annotations: {}
 #    interval: 15s
 #    scrapeTimeout: 5s
-
 
 vmstorage:
   enabled: true
@@ -285,6 +286,7 @@ vmstorage:
 
   podAnnotations: {}
   annotations: {}
+  labels: {}
   replicaCount: 2
   podManagementPolicy: OrderedReady
 


### PR DESCRIPTION
This change adds optional pod labels to vmselect, vminsert and vmstorage.

I bumped the version in case of issues.

