### PR TITLE
changes keep rule for pods and services

### DIFF
--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -262,6 +262,11 @@ config:
       kubernetes_sd_configs:
         - role: endpoints
       relabel_configs:
+        - action: drop
+          source_labels: [__meta_kubernetes_pod_container_init]
+          regex: true
+        - action: keep_if_equal
+          source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_container_port_number]
         - source_labels:
             [__meta_kubernetes_service_annotation_prometheus_io_scrape]
           action: keep
@@ -314,6 +319,11 @@ config:
       kubernetes_sd_configs:
         - role: endpoints
       relabel_configs:
+        - action: drop
+          source_labels: [__meta_kubernetes_pod_container_init]
+          regex: true
+        - action: keep_if_equal
+          source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_container_port_number]
         - source_labels:
             [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
           action: keep
@@ -389,6 +399,11 @@ config:
       kubernetes_sd_configs:
         - role: pod
       relabel_configs:
+        - action: drop
+          source_labels: [__meta_kubernetes_pod_container_init]
+          regex: true
+        - action: keep_if_equal
+          source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_container_port_number]
         - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
           action: keep
           regex: true


### PR DESCRIPTION
https://github.com/VictoriaMetrics/helm-charts/issues/65

if prometheus_io_port annotation is defined, it keeps only targets if prometheus_io_port matches pod_container_port

prometheus_io_scrape must present as well

target ports from init containers is dropped

https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/app/vmagent\#troubleshooting