### PR TITLE
Promote rbac.authorization.k8s.io to v1

### DIFF
--- a/charts/victoria-metrics-agent/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "chart.fullname" . }}-clusterrole

--- a/charts/victoria-metrics-alert/templates/role.yaml
+++ b/charts/victoria-metrics-alert/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name:  {{ template "vmalert.server.fullname" . }}

--- a/charts/victoria-metrics-alert/templates/rolebinding.yaml
+++ b/charts/victoria-metrics-alert/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "vmalert.server.fullname" . }}

--- a/charts/victoria-metrics-cluster/templates/role.yaml
+++ b/charts/victoria-metrics-cluster/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "victoria-metrics.fullname" . }}

--- a/charts/victoria-metrics-cluster/templates/rolebinding.yaml
+++ b/charts/victoria-metrics-cluster/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "victoria-metrics.fullname" . }}

--- a/charts/victoria-metrics-single/templates/role.yaml
+++ b/charts/victoria-metrics-single/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "victoria-metrics.fullname" . }}

--- a/charts/victoria-metrics-single/templates/rolebinding.yaml
+++ b/charts/victoria-metrics-single/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "victoria-metrics.fullname" . }}


### PR DESCRIPTION
`rbac.authorization.k8s.io/v1beta1` was deprecated in k8s 1.17, and will no longer be served in v1.22.
In the VictoriaMetrics' charts we can see a mix of both `v1beta1` and `v1`. I think it's time to promote everything to `v1`.
![image](https://user-images.githubusercontent.com/46579601/95441903-62447d00-0963-11eb-91fc-009313cc518d.png)
