### PR TITLE
[agent] Support Arbitrary Volumes

### DIFF
--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: victoria-metrics-agent
 description: Victoria Metrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
-version: 0.6.0
+version: 0.6.1
 appVersion: v1.44.0

--- a/charts/victoria-metrics-agent/templates/deployment.yaml
+++ b/charts/victoria-metrics-agent/templates/deployment.yaml
@@ -76,6 +76,9 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -105,4 +108,7 @@ spec:
         - name: {{ .name }}
           hostPath:
             path: {{ .hostPath }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -69,6 +69,19 @@ extraHostPathMounts:
   #   hostPath: /etc/kubernetes/certs
   #   readOnly: true
 
+# Extra Volumes for the pod
+extraVolumes:
+  []
+  # - name: example
+  #   configMap:
+  #     name: example
+
+# Extra Volume Mounts for the container
+extraVolumeMounts:
+  []
+  # - name: example
+  #   mountPath: /example
+
 podSecurityContext:
   {}
   # fsGroup: 2000


### PR DESCRIPTION
Instead of just host mounts. This allows you to mount, for example, CA
certificates for self-signed TLS scrape targets

```
$ cat test.yaml
# Extra Volumes for the pod
extraVolumes:
  - name: example
    configMap:
      name: example

# Extra Volume Mounts for the container
extraVolumeMounts:
  - name: example
    mountPath: /example

$ helm template . -f test.yaml --show-only templates/deployment.yaml
---
# Source: victoria-metrics-agent/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: RELEASE-NAME-victoria-metrics-agent
  namespace: default
  labels:
    helm.sh/chart: victoria-metrics-agent-0.6.1
    app.kubernetes.io/name: victoria-metrics-agent
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "v1.44.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: victoria-metrics-agent
      app.kubernetes.io/instance: RELEASE-NAME
  template:
    metadata:
      labels:
        app.kubernetes.io/name: victoria-metrics-agent
        app.kubernetes.io/instance: RELEASE-NAME
      annotations:
        checksum/config: 56588b706dc93b04906926d1b480618a56cc403776278ffd6b1f97697e2315f5
    spec:
      serviceAccountName: RELEASE-NAME-victoria-metrics-agent
      securityContext:
        {}
      containers:
        - name: victoria-metrics-agent
          securityContext:
            {}
          image: "victoriametrics/vmagent:v1.44.0"
          workingDir: /
          args:
            - -promscrape.config=/config/scrape.yml
            - -remoteWrite.tmpDataPath=/tmpData
            - -envflag.enable=true
            - -envflag.prefix=VM_
            - -loggerFormat=json
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 8429
          readinessProbe:
            httpGet:
              path: /health
              port: http
            initialDelaySeconds: 5
            periodSeconds: 15
          livenessProbe:
            tcpSocket:
              port: http
            initialDelaySeconds: 5
            periodSeconds: 15
            timeoutSeconds: 5
          volumeMounts:
            - name: tmpdata
              mountPath: /tmpData
            - name: config
              mountPath: /config
            - mountPath: /example
              name: example
          resources:
            {}
      volumes:
        - name: tmpdata
          emptyDir: {}
        - name: config
          configMap:
            name: RELEASE-NAME-victoria-metrics-agent-config
        - configMap:
            name: example
          name: example

```