### PR TITLE
Bugfix for retention period smaller than one month (vmstorage/single)

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
           securityContext:
             {{- toYaml .Values.vmstorage.podSecurityContext | nindent 12 }}
           args:
-            - {{ printf "%s=%d" "--retentionPeriod" (int .Values.vmstorage.retentionPeriod) | quote}}
+            - {{ printf "%s=%s" "--retentionPeriod" (toString .Values.vmstorage.retentionPeriod) | quote}}
             - {{ printf "%s=%s" "--storageDataPath" .Values.vmstorage.persistentVolume.mountPath | quote}}
           {{- range $key, $value := .Values.vmstorage.extraArgs }}
             - --{{ $key }}={{ $value }}

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -38,7 +38,7 @@ spec:
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           args:
-            - {{ printf "%s=%d" "--retentionPeriod" (int .Values.server.retentionPeriod) | quote}}
+            - {{ printf "%s=%s" "--retentionPeriod" (toString .Values.server.retentionPeriod) | quote}}
             - {{ printf "%s=%s" "--storageDataPath" .Values.server.persistentVolume.mountPath | quote}}
           {{- range $key, $value := .Values.server.extraArgs }}
             - --{{ $key }}={{ $value }}


### PR DESCRIPTION
**Description**
Starting from v1.45.0, VM allows to have retention periods smaller than one month (https://github.com/VictoriaMetrics/VictoriaMetrics/issues/173).

The issue is that the current template fails to render non-numerical values like `5d`, `1w` - they produce  `--retentionPeriod=0`

**Bugfix**
The proposed bugfix changes the respective templates to let them treat `.Values.vmstorage.retentionPeriod` and `.Values.server.retentionPeriod` as strings instead of numbers. So, values in any format become possible.