### PR TITLE
addded deploymet stratagy for vm-agent

### DIFF
--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: victoria-metrics-agent
 description: Victoria Metrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
-version: 0.6.10
+version: 0.6.11
 appVersion: v1.50.2

--- a/charts/victoria-metrics-agent/README.md
+++ b/charts/victoria-metrics-agent/README.md
@@ -248,6 +248,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | config.scrape_configs[7].relabel_configs[5].target_label | string | `"kubernetes_pod_name"` |  |
 | configMap | string | `""` |  |
 | containerWorkingDir | string | `"/"` |  |
+| deploymentStrategy | object | `{}` |  |
 | env | list | `[]` |  |
 | extraArgs."envflag.enable" | string | `"true"` |  |
 | extraArgs."envflag.prefix" | string | `"VM_"` |  |

--- a/charts/victoria-metrics-agent/templates/deployment.yaml
+++ b/charts/victoria-metrics-agent/templates/deployment.yaml
@@ -11,6 +11,8 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    {{- toYaml .Values.deploymentStrategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "chart.selectorLabels" . | nindent 6 }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -3,6 +3,11 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
+deploymentStrategy: {}
+  # rollingUpdate:
+  #  maxSurge: 25%
+  #  maxUnavailable: 25%
+  # type: RollingUpdate
 
 image:
   repository: victoriametrics/vmagent


### PR DESCRIPTION
The victoriam metrics agent doesn't have the deployment strategy
I faced with the issue when you use PVC and re-create the deployment, it can't re-create POD because the previous POD is using PVC volume, to resolve such issue, deployment strategy should be defined `recreate`
I've just added this parameter `deploymentStratagy`