### PR TITLE
adds selectNode param for vmselect,

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.50.2
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.8.7
+version: 0.8.8

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for Cluster Version
 
- ![Version: 0.8.5](https://img.shields.io/badge/Version-0.8.5-informational?style=flat-square)
+ ![Version: 0.8.8](https://img.shields.io/badge/Version-0.8.8-informational?style=flat-square)
 
 Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -156,6 +156,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{- define "victoria-metrics.vmselect.vmselect-pod-fqdn" -}}
+{{- $pod := include "victoria-metrics.vmselect.fullname" . -}}
+{{- $svc := include "victoria-metrics.vmselect.fullname" . -}}
+{{- $namespace := .Release.Namespace -}}
+{{- $dnsSuffix := .Values.clusterDomainSuffix -}}
+{{- range $i := until (.Values.vmselect.replicaCount | int) -}}
+{{- printf "- --selectNode=%s-%d.%s.%s.svc.%s:8481\n" $pod $i $svc $namespace $dnsSuffix -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "split-host-port" -}}
 {{- $hp := split ":" . -}}
 {{- printf "%s" $hp._1 -}}

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -47,6 +47,7 @@ spec:
           {{- if not .Values.vmselect.suppresStorageFQDNsRender }}
           {{- include "victoria-metrics.vmselect.vmstorage-pod-fqdn" . | nindent 12 }}
           {{- end }}
+          {{- include "victoria-metrics.vmselect.vmselect-pod-fqdn" . | nindent 12 -}}
           {{- range $key, $value := .Values.vmselect.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}


### PR DESCRIPTION
fixes issue https://github.com/VictoriaMetrics/helm-charts/issues/89

It possible to use --selectNode flag only with statefulset version of vmselect. 