### PR TITLE
#109 custom labels for victoria-metrics-single

### DIFF
--- a/charts/victoria-metrics-single/README.md
+++ b/charts/victoria-metrics-single/README.md
@@ -147,6 +147,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | server.persistentVolume.storageClass | string | `""` | StorageClass to use for persistent volume. Requires server.persistentVolume.enabled: true. If defined, PVC created automatically |
 | server.persistentVolume.subPath | string | `""` | Mount subpath |
 | server.podAnnotations | object | `{}` | Pod's annotations |
+| server.podLabels | object | `{}` | Pod's additional labels |
 | server.podManagementPolicy | string | `"OrderedReady"` | Pod's management policy  |
 | server.podSecurityContext | object | `{}` | Pod's security context. Ref: [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | server.priorityClassName | string | `""` | Name of Priority Class |

--- a/charts/victoria-metrics-single/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-single/templates/server-deployment.yaml
@@ -28,6 +28,9 @@ spec:
     {{- end }}
       labels:
         {{- include "victoria-metrics.server.labels" . | nindent 8 }}
+        {{- range $key, $value := .Values.server.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
 {{- if .Values.server.affinity }}
       affinity:

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -25,6 +25,9 @@ spec:
     {{- end }}
       labels:
         {{- include "victoria-metrics.server.labels" . | nindent 8 }}
+        {{- range $key, $value := .Values.server.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
 {{- if .Values.server.priorityClassName }}
       priorityClassName: "{{ .Values.server.priorityClassName }}"

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -122,6 +122,8 @@ server:
     # -- Size of the volume. Better to set the same as resource limit memory property.
     size: 16Gi
 
+  # -- Pod's additional labels
+  podLabels: {}
   # -- Pod's annotations
   podAnnotations: {}
   # -- Pod's management policy 


### PR DESCRIPTION
Did the same as https://github.com/VictoriaMetrics/helm-charts/pull/108
@f41gh7 

What do you think, would it be better to add custom labels to `{{- define "victoria-metrics.server.labels" -}}`?

https://github.com/VictoriaMetrics/helm-charts/issues/109