### PR TITLE
[vmalert] allow empty config if rule file specified

### DIFF
--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: victoria-metrics-alert
 description: Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.3.20
+version: 0.3.21
 appVersion: v1.55.1

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Alert.
 
- ![Version: 0.3.18](https://img.shields.io/badge/Version-0.3.18-informational?style=flat-square)
+ ![Version: 0.3.21](https://img.shields.io/badge/Version-0.3.21-informational?style=flat-square)
 
 Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
 

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -1,6 +1,8 @@
 {{- if and .Values.server.enabled -}}
+{{- if not .Values.server.extraArgs.rule }}
 {{- if and (eq .Values.server.configMap "") (eq (len .Values.server.config.alerts.groups) 0) -}}
-{{- fail "at least one item in `.server.config.alerts.groups` must be set " -}}
+{{- fail "at least one item in `.server.config.alerts.groups` or `.server.extraArgs.rule` must be set " -}}
+{{- end -}}
 {{- end -}}
 {{- if and (.Values.alertmanager.enabled) (eq .Values.server.notifier.alertmanager.url "") -}}
 {{- fail "alert manager URL must be specified" -}}


### PR DESCRIPTION
When deploying the vmalert chart, templating will fail if neither a config nor an existing configmap are provided in the values. There is another way to provide rules to vmalert though, through the `rule` argument. This PR allows a deployment with no config or configmap as long as an additional rule parameter is provided.