### PR TITLE
Produce valid Role rules when rbac.pspEnabled=false

### DIFF
--- a/charts/victoria-metrics-cluster/templates/role.yaml
+++ b/charts/victoria-metrics-cluster/templates/role.yaml
@@ -13,8 +13,8 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-rules:
 {{- if .Values.rbac.pspEnabled }}
+rules:
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']


### PR DESCRIPTION
In victoria-metrics-cluster version 0.8.17, setting `rbac.pspEnabled=false` produces an invalid Role - the `rules` key is listed twice.

`helm template vm vm/victoria-metrics-cluster --version 0.8.17 --set rbac.pspEnabled=false | grep -A 11 -F 'Source: victoria-metrics-cluster/templates/role.yaml'`

```
# Source: victoria-metrics-cluster/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: vm-victoria-metrics-cluster
  namespace: default
  labels:
    helm.sh/chart: victoria-metrics-cluster-0.8.17
    app.kubernetes.io/managed-by: Helm
rules:
rules: []
---
```

Compare `victoria-metrics-cluster/templates/role.yaml` with `victoria-metrics-cluster/templates/clusterole.yaml`; latter works.

Move the rules key into conditional block.