### PR TITLE
Added go_template for readiness & liveness probes (initialDelaySeconds)

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -92,14 +92,17 @@ spec:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 15
+            initialDelaySeconds: {{ .Values.vminsert.probe.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.vminsert.probe.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.vminsert.probe.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.vminsert.probe.readiness.failureThreshold }}
           livenessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 15
-            timeoutSeconds: 5
+            initialDelaySeconds: {{ .Values.vminsert.probe.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.vminsert.probe.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.vminsert.probe.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.vminsert.probe.liveness.failureThreshold }}
           resources:
 {{ toYaml .Values.vminsert.resources | indent 12 }}
     {{- if .Values.imagePullSecrets }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -58,12 +58,12 @@ spec:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 5
+            initialDelaySeconds: {{ .Values.vmselect.probe.readiness.initialDelaySeconds }}
             periodSeconds: 15
           livenessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 5
+            initialDelaySeconds: {{ .Values.vmselect.probe.liveness.initialDelaySeconds }}
             periodSeconds: 15
             timeoutSeconds: 5
           volumeMounts:

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -59,13 +59,16 @@ spec:
               path: /health
               port: http
             initialDelaySeconds: {{ .Values.vmselect.probe.readiness.initialDelaySeconds }}
-            periodSeconds: 15
+            periodSeconds: {{ .Values.vmselect.probe.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.vmselect.probe.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.vmselect.probe.readiness.failureThreshold }}
           livenessProbe:
             tcpSocket:
               port: http
             initialDelaySeconds: {{ .Values.vmselect.probe.liveness.initialDelaySeconds }}
-            periodSeconds: 15
-            timeoutSeconds: 5
+            periodSeconds: {{ .Values.vmselect.probe.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.vmselect.probe.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.vmselect.probe.liveness.failureThreshold }}
           volumeMounts:
             - mountPath: {{ .Values.vmselect.cacheMountPath }}
               name: cache-volume

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -49,6 +49,19 @@ vmselect:
   extraLabels: {}
   env: []
 
+  # Readiness & Liveness probes
+  probe:
+    readiness:
+      initialDelaySeconds: 5
+      periodSeconds: 15
+      timeoutSeconds: 5
+      failureThreshold: 3
+    liveness:
+      initialDelaySeconds: 5
+      periodSeconds: 15
+      timeoutSeconds: 5
+      failureThreshold: 3
+
   # Additional hostPath mounts
   extraHostPathMounts:
    []

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -236,6 +236,19 @@ vminsert:
   suppresStorageFQDNsRender: false
   automountServiceAccountToken: true
 
+  # Readiness & Liveness probes
+  probe:
+    readiness:
+      initialDelaySeconds: 5
+      periodSeconds: 15
+      timeoutSeconds: 5
+      failureThreshold: 3
+    liveness:
+      initialDelaySeconds: 5
+      periodSeconds: 15
+      timeoutSeconds: 5
+      failureThreshold: 3
+
   podDisruptionBudget:
     # -- See `kubectl explain poddisruptionbudget.spec` for more. Ref: [https://kubernetes.io/docs/tasks/run-application/configure-pdb/](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
     enabled: false


### PR DESCRIPTION
we have had an issue with an 'initialDelaySeconds' on readiness probe - and predefined 5 seconds wasn't enough. So, we need this change to increase the value for this option. Kindly hope you'll find it useful ;) thanks