### PR TITLE
Update kube-controller-manager.yaml

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-controller-manager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-controller-manager.yaml
@@ -30,7 +30,7 @@ metadata:
   namespace: kube-system
   labels:
     app: {{ include "victoria-metrics-k8s-stack.fullname" . }}-kube-controller-manager
-    jobLabel: kube-controller
+    jobLabel: kube-controller-manager
 {{ include "victoria-metrics-k8s-stack.labels" . | indent 4 }}
 spec:
   clusterIP: None


### PR DESCRIPTION
incorrect job label generate alert "kubecontroller manager is down" into vmalert