### PR TITLE
comment external labels in default values

### DIFF
--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -258,8 +258,8 @@ vmalert:
   # https://github.com/VictoriaMetrics/operator/blob/master/docs/api.MD#vmalertspec
   spec:
     evaluationInterval: 15s
-    externalLabels:
-      cluster: cluster-name
+#    externalLabels:
+#      cluster: cluster-name
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
@@ -302,8 +302,8 @@ vmagent:
   # https://github.com/VictoriaMetrics/operator/blob/master/docs/api.MD#vmagentspec
   spec:
     scrapeInterval: 25s
-    externalLabels:
-      cluster: cluster-name
+#    externalLabels:
+#      cluster: cluster-name
     extraArgs:
       promscrape.streamParse: "true"
   ingress:


### PR DESCRIPTION
by default external label "cluster: cluster-name" merged with overwrite by custom values
as result - excess label:
```
spec:
   externalLabels:
     cluster: cluster-name
     k8s_cluster: k8s-test
```