### PR TITLE
Fix scrape config for kubernetes-service-endpoints

### DIFF
--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -334,7 +334,7 @@ config:
           source_labels: [__meta_kubernetes_pod_container_init]
           regex: true
         - action: keep_if_equal
-          source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_container_port_number]
+          source_labels: [__meta_kubernetes_service_annotation_prometheus_io_port, __meta_kubernetes_pod_container_port_number]
         - source_labels:
             [__meta_kubernetes_service_annotation_prometheus_io_scrape]
           action: keep
@@ -391,7 +391,7 @@ config:
           source_labels: [__meta_kubernetes_pod_container_init]
           regex: true
         - action: keep_if_equal
-          source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_container_port_number]
+          source_labels: [__meta_kubernetes_service_annotation_prometheus_io_port, __meta_kubernetes_pod_container_port_number]
         - source_labels:
             [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
           action: keep


### PR DESCRIPTION
I noticed that the example config was referring to a pod label in the service configs, hence all the service metrics were dropped.