### PR TITLE
Add alertmanager templates ability

### DIFF
--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: victoria-metrics-alert
 description: Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.3.31
+version: 0.3.32
 appVersion: v1.61.1

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Alert.
 
- ![Version: 0.3.31](https://img.shields.io/badge/Version-0.3.31-informational?style=flat-square)
+ ![Version: 0.3.32](https://img.shields.io/badge/Version-0.3.32-informational?style=flat-square)
 
 Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
 
@@ -123,6 +123,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | alertmanager.resources | object | `{}` |  |
 | alertmanager.retention | string | `"120h"` |  |
 | alertmanager.tag | string | `"v0.20.0"` |  |
+| alertmanager.templates | object | `{}` |  |
 | alertmanager.tolerations | list | `[]` |  |
 | imagePullSecrets | list | `[]` |  |
 | rbac.annotations | object | `{}` |  |

--- a/charts/victoria-metrics-alert/templates/alertmanager-configmap.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-configmap.yaml
@@ -8,4 +8,9 @@ metadata:
 data:
   alertmanager.yaml: |
     {{ toYaml .Values.alertmanager.config | nindent 4 }}
+
+    {{- range $key, $value := .Values.alertmanager.templates }}
+      {{ $key }}: |-
+        {{- $value | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -211,6 +211,8 @@ alertmanager:
       repeat_interval: 24h
     receivers:
       - name: devnull
+  templates: {}
+  #  alertmanager.tmpl: |-
   ingress:
     enabled: false
     annotations: {}


### PR DESCRIPTION
Added the ability to fill in templates for the alertmanager.
Based on https://github.com/prometheus-community/helm-charts/tree/main/charts/alertmanager

Signed-off-by: Igor Churmeev <ichurmeev@makezbs.com>