### PR TITLE
moved templates outside alertmanager.yaml

### DIFF
--- a/charts/victoria-metrics-alert/templates/alertmanager-configmap.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-configmap.yaml
@@ -9,8 +9,8 @@ data:
   alertmanager.yaml: |
     {{ toYaml .Values.alertmanager.config | nindent 4 }}
 
-    {{- range $key, $value := .Values.alertmanager.templates }}
-      {{ $key }}: |-
-        {{- $value | nindent 4 }}
-    {{- end }}
+{{- range $key, $value := .Values.alertmanager.templates }}
+  {{ $key }}: |-
+    {{- $value | nindent 4 }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Templates should be stored in a separate files outside alertmanager.yaml 
