### PR TITLE
Add HPA Support to vmselect component

### DIFF
--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -184,6 +184,10 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmselect.extraVolumeMounts | list | `[]` |  |
 | vmselect.extraVolumes | list | `[]` |  |
 | vmselect.fullnameOverride | string | `""` | Overrides the full name of vmselect component |
+| vmselect.horizontalPodAutoscaler.enabled | bool | `false` | Use HPA for vmselect component |
+| vmselect.horizontalPodAutoscaler.maxReplicas | int | `10` | Maximum replicas for HPA to use to to scale the vmselect component |
+| vmselect.horizontalPodAutoscaler.minReplicas | int | `1` | Minimum replicas for HPA to use to scale the vmselect component |
+| vmselect.horizontalPodAutoscaler.targetCPUUtilizationPercentage | int | `70` | CPU Utilization to scale upon for vmselect component |
 | vmselect.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | vmselect.image.repository | string | `"victoriametrics/vmselect"` | Image repository |
 | vmselect.image.tag | string | `"v1.62.0-cluster"` | Image tag |

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -187,7 +187,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmselect.horizontalPodAutoscaler.enabled | bool | `false` | Use HPA for vmselect component |
 | vmselect.horizontalPodAutoscaler.maxReplicas | int | `10` | Maximum replicas for HPA to use to to scale the vmselect component |
 | vmselect.horizontalPodAutoscaler.minReplicas | int | `1` | Minimum replicas for HPA to use to scale the vmselect component |
-| vmselect.horizontalPodAutoscaler.targetCPUUtilizationPercentage | int | `70` | CPU Utilization to scale upon for vmselect component |
+| vmselect.horizontalPodAutoscaler.metrics | object | `` | Metric for HPA to use to scale the vmselect component |
 | vmselect.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | vmselect.image.repository | string | `"victoriametrics/vmselect"` | Image repository |
 | vmselect.image.tag | string | `"v1.62.0-cluster"` | Image tag |

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -17,7 +17,9 @@ spec:
   selector:
     matchLabels:
       {{- include "victoria-metrics.vmselect.matchLabels" . | nindent 6 }}
+{{- if not .Values.vmselect.horizontalPodAutoscaler.enabled }}
   replicas: {{ .Values.vmselect.replicaCount }}
+{{- end }}
   template:
     metadata:
     {{- if .Values.vmselect.podAnnotations }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-hpa.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-hpa.yaml
@@ -16,5 +16,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ template "victoria-metrics.vmselect.fullname" . }}
-  targetCPUUtilizationPercentage: {{ .Values.vmselect.horizontalPodAutoscaler.targetCPUUtilizationPercentage }}
+  metrics:
+  {{ toYaml .Values.vmselect.horizontalPodAutoscaler.metrics | indent 4 }}
 {{- end -}}

--- a/charts/victoria-metrics-cluster/templates/vmselect-hpa.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-hpa.yaml
@@ -17,5 +17,5 @@ spec:
     kind: Deployment
     name: {{ template "victoria-metrics.vmselect.fullname" . }}
   metrics:
-  {{ toYaml .Values.vmselect.horizontalPodAutoscaler.metrics | indent 4 }}
+{{ toYaml .Values.vmselect.horizontalPodAutoscaler.metrics | indent 4 }}
 {{- end -}}

--- a/charts/victoria-metrics-cluster/templates/vmselect-hpa.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-hpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.vmselect.horizontalPodAutoscaler.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    {{- include "victoria-metrics.vmselect.labels" . | nindent 4 }}
+{{- with .Values.vmselect.extraLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ template "victoria-metrics.vmselect.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  maxReplicas: {{ .Values.vmselect.horizontalPodAutoscaler.maxReplicas }}
+  minReplicas: {{ .Values.vmselect.horizontalPodAutoscaler.minReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "victoria-metrics.vmselect.fullname" . }}
+  targetCPUUtilizationPercentage: {{ .Values.vmselect.horizontalPodAutoscaler.targetCPUUtilizationPercentage }}
+{{- end -}}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -70,6 +70,13 @@ vmselect:
       timeoutSeconds: 5
       failureThreshold: 3
 
+# Horizontal Pod Autoscaling
+  horizontalPodAutoscaler:
+    enabled: false
+    maxReplicas: 10
+    minReplicas: 1
+    targetCPUUtilizationPercentage: 70
+
   # Additional hostPath mounts
   extraHostPathMounts:
    []

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -75,7 +75,7 @@ vmselect:
     enabled: false
     maxReplicas: 10
     minReplicas: 1
-    targetCPUUtilizationPercentage: 70
+    metrics: []
 
   # Additional hostPath mounts
   extraHostPathMounts:


### PR DESCRIPTION
Configuration to allow the vmselect component to be scaled based on its CPU Utilization. 
We are already using this in our production vm-clusters. 