### PR TITLE
Add startup probe support

### DIFF
--- a/charts/victoria-metrics-single/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-single/templates/server-deployment.yaml
@@ -114,6 +114,10 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with $.Values.server.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.server.resources | indent 12 }}
           volumeMounts:

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -105,6 +105,10 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with $.Values.server.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
           volumeMounts:

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -179,6 +179,15 @@ server:
     timeoutSeconds: 5
     failureThreshold: 10
 
+  # Indicates whether the Container is done with potentially costly initialization. If set it is executed first. If it fails Container is restarted. If it succeeds liveness and readiness probes takes over.
+  startupProbe: {}
+    #tcpSocket:
+    #  port: http
+    #failureThreshold: 30
+    #periodSeconds: 15
+    #successThreshold: 1
+    #timeoutSeconds: 5
+
   # -- Security context to be added to server pods
   securityContext: {}
   # -- Pod's security context. Ref: [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)


### PR DESCRIPTION
Startup of application is often more demanding on cpu/memory then rest of the runtime. Sometimes it is hard to tune readiness/liveness probes so that they allow application to start but are responsive enough for issues during normal operation. Startup probe can save the day here.

VictoriaMetrics is no difference. Full disk for example can cause compactification to be halted. After volume is enlarged startup of Victoria takes longer since it needs to catch up in maintenance backlog.

Thus I propose adding support for startup probes into official Helm chart.