### PR TITLE
Extra alertmanagerTemplates and argocd releaseName issue

### DIFF
--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 3.4.2
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 2.0.3
+  version: 2.0.4
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.14.2
-digest: sha256:b63108d685ec438b9e32800a332000914726b14461d8229ad9b2e713a3a1cabf
-generated: "2021-08-17T22:21:50.110721+08:00"
+digest: sha256:57001639a9999eae25d974dd2282004aba3889611305a1ae46f21364774f25fe
+generated: "2021-08-19T14:55:16.645677+03:00"

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -152,7 +152,7 @@ configSecret: {{ .Values.alertmanager.spec.configSecret | default (printf "%s-al
 {{- $list = append $list (printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-monzo-tpl" | trunc 63 | trimSuffix "-") }}
 {{- end }}
 {{- if .Values.alertmanager.templateFiles }}
-{{- $list = append $list (printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-custom-tpl" | trunc 63 | trimSuffix "-") }}
+{{- $list = append $list (printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-extra-tpl" | trunc 63 | trimSuffix "-") }}
 {{- end }}
 configMaps:
 {{- range compact $list }}

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -151,6 +151,9 @@ configSecret: {{ .Values.alertmanager.spec.configSecret | default (printf "%s-al
 {{- if .Values.alertmanager.monzoTemplate.enabled }}
 {{- $list = append $list (printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-monzo-tpl" | trunc 63 | trimSuffix "-") }}
 {{- end }}
+{{- if .Values.alertmanager.templateFiles }}
+{{- $list = append $list (printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-custom-tpl" | trunc 63 | trimSuffix "-") }}
+{{- end }}
 configMaps:
 {{- range compact $list }}
 - {{ . }}

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/coredns.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/coredns.yaml
@@ -37,7 +37,7 @@ spec:
   selector:
     matchLabels:
       app: {{ include "victoria-metrics-k8s-stack.fullname" . }}-coredns
-      app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+      app.kubernetes.io/instance: {{ default $.Release.Name $.Values.argocdReleaseOverride | quote }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/grafana.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/grafana.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: grafana
-      app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+      app.kubernetes.io/instance: {{ default $.Release.Name $.Values.argocdReleaseOverride | quote }}
 {{- if empty .Values.grafana.vmServiceScrape.spec }}
   endpoints:
   - port: {{ .Values.grafana.service.portName }}

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-controller-manager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-controller-manager.yaml
@@ -61,7 +61,7 @@ spec:
   selector:
     matchLabels:
       app: {{ include "victoria-metrics-k8s-stack.fullname" . }}-kube-controller-manager
-      app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+      app.kubernetes.io/instance: {{ default $.Release.Name $.Values.argocdReleaseOverride | quote }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-etcd.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-etcd.yaml
@@ -61,7 +61,7 @@ spec:
   selector:
     matchLabels:
       app: {{ include "victoria-metrics-k8s-stack.fullname" . }}-kube-etcd
-      app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+      app.kubernetes.io/instance: {{ default $.Release.Name $.Values.argocdReleaseOverride | quote }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-proxy.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-proxy.yaml
@@ -61,7 +61,7 @@ spec:
   selector:
     matchLabels:
       app: {{ include "victoria-metrics-k8s-stack.fullname" . }}-kube-proxy
-      app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+      app.kubernetes.io/instance: {{ default $.Release.Name $.Values.argocdReleaseOverride | quote }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-scheduler.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
   selector:
     matchLabels:
       app: {{ include "victoria-metrics-k8s-stack.fullname" . }}-kube-scheduler
-      app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+      app.kubernetes.io/instance: {{ default $.Release.Name $.Values.argocdReleaseOverride | quote }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-state-metrics.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-state-metrics.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kube-state-metrics
-      app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+      app.kubernetes.io/instance: {{ default $.Release.Name $.Values.argocdReleaseOverride | quote }}
 {{- if empty (index .Values "kube-state-metrics" "vmServiceScrape" "spec") }}
   endpoints:
   - port: http

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/nodeexporter.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/nodeexporter.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: prometheus-node-exporter
-      release: {{ $.Release.Name | quote }}
+      release: {{ default $.Release.Name $.Values.argocdReleaseOverride | quote }}
 {{- if empty (index .Values "prometheus-node-exporter" "vmServiceScrape" "spec") }}
   endpoints:
   - port: metrics

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/custom-templates.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/custom-templates.yaml
@@ -2,7 +2,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-custom-tpl" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-extra-tpl" | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
   labels: 
     app.kubernetes.io/component: {{ include "victoria-metrics-k8s-stack.name" $ }}-alertmanager

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/custom-templates.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/custom-templates.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.templateFiles }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-custom-tpl" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels: 
+    app.kubernetes.io/component: {{ include "victoria-metrics-k8s-stack.name" $ }}-alertmanager
+{{ include "victoria-metrics-k8s-stack.labels" . | indent 4 }}
+data:
+{{- range $file, $template := .Values.alertmanager.templateFiles }}
+  {{ $file }}: |-
+     {{- $template | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -374,6 +374,7 @@ alertmanager:
   monzoTemplate:
     enabled: true
 
+  # extra alert templates
   templateFiles: {}
     # template_1.tmpl: |-
     #   {{ define "hello" -}}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -12,6 +12,11 @@ operator:
     tag: v1.16.0
     pullPolicy: IfNotPresent
 
+# If this chart is used in "Agrocd" with "releaseName" field then  
+# VMServiceScrapes couldn't select the proper services.
+# For correct working need set value 'argocdReleaseOverride=$ARGOCD_APP_NAME'
+argocdReleaseOverride: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -374,6 +374,13 @@ alertmanager:
   monzoTemplate:
     enabled: true
 
+  templateFiles: {}
+    # template_1.tmpl: |-
+    #   {{ define "hello" -}}
+    #   hello, Victoria!
+    #   {{- end }}
+    # template_2.tmpl: ""
+
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName


### PR DESCRIPTION
1. allow set custom alertmanager templates as in prometheus-operator
```
alertmanager:
  templateFiles:
    template_1.tmpl: |-
      {{ define "hello" -}}
      hello, Victoria!
      {{- end }}
    template_2.tmpl:  |-
      {{ define "bye" -}}
      arrivederci!
      {{- end }}
```
2. We use it with argocd, and it uses label app.kubernetes.io/instance to define release and always overrides it.
And if set releaseName in argocd, then VMServiceScrape select incorrect labels.
I've set the "argocdReleaseOverride" value and can manage with it.