### PR TITLE
Specify custom service account

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.66.2
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.9.5
+version: 0.9.6

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -131,9 +131,7 @@ spec:
       securityContext:
 {{ toYaml .Values.vminsert.securityContext | indent 8 }}
     {{- end }}
-    {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
-    {{- end }}
     {{- if .Values.vminsert.tolerations }}
       tolerations:
 {{ toYaml .Values.vminsert.tolerations | indent 8 }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -109,9 +109,7 @@ spec:
       securityContext:
 {{ toYaml .Values.vmselect.securityContext | indent 8 }}
     {{- end }}
-    {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
-    {{- end }}
     {{- if .Values.vmselect.tolerations }}
       tolerations:
 {{ toYaml .Values.vmselect.tolerations | indent 8 }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -107,9 +107,7 @@ spec:
       securityContext:
 {{ toYaml .Values.vmselect.securityContext | indent 8 }}
     {{- end }}
-    {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
-    {{- end }}
     {{- if .Values.vmselect.tolerations }}
       tolerations:
 {{ toYaml .Values.vmselect.tolerations | indent 8 }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -165,9 +165,7 @@ spec:
       securityContext:
 {{ toYaml .Values.vmstorage.securityContext | indent 8 }}
     {{- end }}
-    {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
-    {{- end }}
     {{- if .Values.vmstorage.tolerations }}
       tolerations:
 {{ toYaml .Values.vmstorage.tolerations | indent 8 }}

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.66.2
 description: Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.8.6
+version: 0.8.7

--- a/charts/victoria-metrics-single/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-single/templates/server-deployment.yaml
@@ -201,9 +201,7 @@ spec:
       securityContext:
 {{ toYaml .Values.server.securityContext | indent 8 }}
     {{- end }}
-    {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
-    {{- end }}
     {{- if .Values.server.tolerations }}
       tolerations:
 {{ toYaml .Values.server.tolerations | indent 8 }}

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -196,9 +196,7 @@ spec:
       securityContext:
 {{ toYaml .Values.server.securityContext | indent 8 }}
     {{- end }}
-    {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
-    {{- end }}
     {{- if .Values.server.tolerations }}
       tolerations:
 {{ toYaml .Values.server.tolerations | indent 8 }}


### PR DESCRIPTION
This MR fixes a bug when it's not possible to specify already existing service account for single/cluster VM versions