### PR TITLE
add topologySpreadConstraints to select deployment to make it possible to spread them between az

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.66.2
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.9.5
+version: 0.9.6

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -120,6 +120,10 @@ spec:
       affinity:
 {{ toYaml .Values.vmselect.affinity | indent 8 }}
     {{- end }}
+    {{- if .Values.vmselect.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.vmselect.topologySpreadConstraints | indent 8 }}
+    {{- end }}
       volumes:
         {{- with .Values.vmselect.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -130,6 +130,8 @@ vmselect:
   nodeSelector: {}
   # -- Pod affinity
   affinity: {}
+  # -- Pod topologySpreadConstraints
+  topologySpreadConstraints: []
   # -- Pod's annotations
   podAnnotations: {}
   # -- Count of vmselect pods


### PR DESCRIPTION
This Pr will allow to use `topologySpreadConstraints` to spread pods between zones in case you have a cluster per zone architecture.