### PR TITLE
Fix scrape config for kubernetes-service-enpoints (victoria-metrics-single)

### DIFF
--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -463,7 +463,7 @@ server:
               source_labels: [ __meta_kubernetes_pod_container_init ]
               regex: true
             - action: keep_if_equal
-              source_labels: [ __meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_container_port_number ]
+              source_labels: [ __meta_kubernetes_service_annotation_prometheus_io_port, __meta_kubernetes_pod_container_port_number ]
             - source_labels:
                 [ __meta_kubernetes_service_annotation_prometheus_io_scrape ]
               action: keep
@@ -520,7 +520,7 @@ server:
               source_labels: [ __meta_kubernetes_pod_container_init ]
               regex: true
             - action: keep_if_equal
-              source_labels: [ __meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_container_port_number ]
+              source_labels: [ __meta_kubernetes_service_annotation_prometheus_io_port, __meta_kubernetes_pod_container_port_number ]
             - source_labels:
                 [ __meta_kubernetes_service_annotation_prometheus_io_scrape_slow ]
               action: keep


### PR DESCRIPTION
Identical to #146 but for victoria-metrics-single chart.