### PR TITLE
[victoria-metrics-single] Fix ClusterRole to include networking.k8s.io

### DIFF
--- a/charts/victoria-metrics-single/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-single/templates/clusterrole.yaml
@@ -27,6 +27,7 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses
     verbs: [ "get", "list", "watch" ]


### PR DESCRIPTION
Fix victoria-metrics-single ClusteRole to include missing `networking.k8s.io` causing permission error when using `role: ingress` in `kubernetes_sd_configs`.

In victoria-metrics-agent chart the same fix is applied at [this commit](https://github.com/VictoriaMetrics/helm-charts/commit/5f41ebda18caab18d6a88ad43502da91411d0852).