### PR TITLE
Add 'persistence.matchLabels' option to vmsingle and vmagent

### DIFF
--- a/charts/victoria-metrics-agent/README.md
+++ b/charts/victoria-metrics-agent/README.md
@@ -295,6 +295,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | persistence.enabled | bool | `false` |  |
 | persistence.existingClaim | string | `""` |  |
 | persistence.extraLabels | object | `{}` |  |
+| persistence.matchLabels | object | `{}` | Bind Persistent Volume by labels. Must match all labels of targeted PV. |
 | persistence.size | string | `"10Gi"` |  |
 | podAnnotations | object | `{}` |  |
 | podDisruptionBudget.enabled | bool | `false` |  |

--- a/charts/victoria-metrics-agent/templates/pvc.yaml
+++ b/charts/victoria-metrics-agent/templates/pvc.yaml
@@ -24,4 +24,9 @@ spec:
   {{- if .Values.persistence.storageClassName }}
   storageClassName: {{ .Values.persistence.storageClassName }}
   {{- end -}}
+  {{- if .Values.persistence.matchLabels }}
+  selector:
+    matchLabels:
+      {{ toYaml .Values.persistence.matchLabels | indent 6 }}
+  {{- end }}
 {{- end -}}

--- a/charts/victoria-metrics-agent/templates/statefulset.yaml
+++ b/charts/victoria-metrics-agent/templates/statefulset.yaml
@@ -180,6 +180,11 @@ spec:
       {{- if .Values.persistence.storageClassName }}
       storageClassName: {{ .Values.persistence.storageClassName }}
       {{- end }}
+      {{- if .Values.persistence.matchLabels }}
+      selector:
+        matchLabels:
+          {{ toYaml .Values.persistence.matchLabels | indent 10 }}
+      {{- end }}
       resources:
         requests:
           storage: {{ .Values.persistence.size | quote }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -209,6 +209,8 @@ persistence:
   annotations: {}
   extraLabels: {}
   existingClaim: ""
+  # -- Bind Persistent Volume by labels. Must match all labels of targeted PV.
+  matchLabels: {}
 
 config:
   global:

--- a/charts/victoria-metrics-single/README.md
+++ b/charts/victoria-metrics-single/README.md
@@ -147,6 +147,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | server.persistentVolume.annotations | object | `{}` | Persistant volume annotations |
 | server.persistentVolume.enabled | bool | `true` | Create/use Persistent Volume Claim for server component. Empty dir if false |
 | server.persistentVolume.existingClaim | string | `""` | Existing Claim name. If defined, PVC must be created manually before volume will be bound |
+| server.persistentVolume.matchLabels | object | `{}` | Bind Persistent Volume by labels. Must match all labels of targeted PV. |
 | server.persistentVolume.mountPath | string | `"/storage"` | Mount path. Server data Persistent Volume mount root path. |
 | server.persistentVolume.size | string | `"16Gi"` | Size of the volume. Better to set the same as resource limit memory property. |
 | server.persistentVolume.storageClass | string | `""` | StorageClass to use for persistent volume. Requires server.persistentVolume.enabled: true. If defined, PVC created automatically |

--- a/charts/victoria-metrics-single/templates/server-pvc.yaml
+++ b/charts/victoria-metrics-single/templates/server-pvc.yaml
@@ -23,6 +23,11 @@ spec:
 {{- if .Values.server.persistentVolume.storageClass }}
   storageClassName: {{ .Values.server.persistentVolume.storageClass | quote }}
 {{- end }}
+{{- if .Values.server.persistentVolume.matchLabels }}
+  selector:
+    matchLabels:
+      {{ toYaml .Values.server.persistentVolume.matchLabels | indent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -245,5 +245,10 @@ spec:
         storageClassName: "{{ .Values.server.persistentVolume.storageClass }}"
       {{- end }}
       {{- end }}
+      {{- if .Values.server.persistentVolume.matchLabels }}
+        selector:
+          matchLabels:
+            {{ toYaml .Values.server.persistentVolume.matchLabels | indent 12 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -137,6 +137,9 @@ server:
     # -- Existing Claim name. If defined, PVC must be created manually before volume will be bound
     existingClaim: ""
 
+    # -- Bind Persistent Volume by labels. Must match all labels of targeted PV.
+    matchLabels: {}
+
     # -- Mount path. Server data Persistent Volume mount root path.
     mountPath: /storage
     # -- Mount subpath


### PR DESCRIPTION
This is important when Persistent Volumes are provisioned in advance.

This is similar to [Prometheus chart `prometheus-community/helm-charts`][1].

[1]: https://github.com/prometheus-community/helm-charts/blob/prometheus-14.11.0/charts/prometheus/values.yaml#L919