### PR TITLE
 Fix 'persistence.matchLabels' option

### DIFF
--- a/charts/victoria-metrics-agent/templates/pvc.yaml
+++ b/charts/victoria-metrics-agent/templates/pvc.yaml
@@ -24,9 +24,9 @@ spec:
   {{- if .Values.persistence.storageClassName }}
   storageClassName: {{ .Values.persistence.storageClassName }}
   {{- end -}}
-  {{- if .Values.persistence.matchLabels }}
+  {{- with .Values.persistence.matchLabels }}
   selector:
     matchLabels:
-      {{ toYaml .Values.persistence.matchLabels | indent 6 }}
+      {{- toYaml . | nindent 6 }}
   {{- end }}
 {{- end -}}

--- a/charts/victoria-metrics-agent/templates/statefulset.yaml
+++ b/charts/victoria-metrics-agent/templates/statefulset.yaml
@@ -180,10 +180,10 @@ spec:
       {{- if .Values.persistence.storageClassName }}
       storageClassName: {{ .Values.persistence.storageClassName }}
       {{- end }}
-      {{- if .Values.persistence.matchLabels }}
+      {{- with .Values.persistence.matchLabels }}
       selector:
         matchLabels:
-          {{ toYaml .Values.persistence.matchLabels | indent 10 }}
+          {{- toYaml . | nindent 10 }}
       {{- end }}
       resources:
         requests:

--- a/charts/victoria-metrics-single/templates/server-pvc.yaml
+++ b/charts/victoria-metrics-single/templates/server-pvc.yaml
@@ -23,10 +23,10 @@ spec:
 {{- if .Values.server.persistentVolume.storageClass }}
   storageClassName: {{ .Values.server.persistentVolume.storageClass | quote }}
 {{- end }}
-{{- if .Values.server.persistentVolume.matchLabels }}
+{{- with .Values.server.persistentVolume.matchLabels }}
   selector:
     matchLabels:
-      {{ toYaml .Values.server.persistentVolume.matchLabels | indent 6 }}
+      {{- toYaml . | nindent 6 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -245,10 +245,10 @@ spec:
         storageClassName: "{{ .Values.server.persistentVolume.storageClass }}"
       {{- end }}
       {{- end }}
-      {{- if .Values.server.persistentVolume.matchLabels }}
+      {{- with .Values.server.persistentVolume.matchLabels }}
         selector:
           matchLabels:
-            {{ toYaml .Values.server.persistentVolume.matchLabels | indent 12 }}
+            {{- toYaml . | nindent 12 }}
       {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
@tenmozes this fixes #245 

While replacing 'if' with 'with' https://github.com/VictoriaMetrics/helm-charts/pull/245#discussion_r732125291 I discovered a bug with incorrect indentation when using multiple labels in 'matchLabels'. Sorry.