### PR TITLE
Include datasource.yaml for any datasource

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
@@ -13,10 +13,11 @@ metadata:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
 {{- include "victoria-metrics-k8s-stack.labels" . | nindent 4 }}
 data:
-{{- if or .Values.vmsingle.enabled  .Values.vmcluster.enabled }}
+{{- if or .Values.vmsingle.enabled  .Values.vmcluster.enabled .Values.grafana.additionalDataSources }}
   datasource.yaml: |-
     apiVersion: 1
     datasources:
+{{- if or .Values.vmsingle.enabled  .Values.vmcluster.enabled }}
     - name: VictoriaMetrics
       type: prometheus
       url: {{ include "victoria-metrics-k8s-stack.vmSelectEndpoint" . }}
@@ -34,5 +35,6 @@ data:
 {{- end }}
 {{- if .Values.grafana.additionalDataSources }}
 {{ tpl (toYaml .Values.grafana.additionalDataSources | indent 4) . }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The datasource.yaml-boilerplate needs to be present if *any* datasource is enabled; including `.Values.grafana.additionalDataSources`.

Before this change the chart would fail if both `.Values.vmsingle.enabled` & `.Values.vmcluster.enabled` was set to `false`, but `.Values.grafana.additionalDataSources` was containing dashboard configuration.

I've only tested this with the above mentioned circumstances.