### PR TITLE
Allow setting jsonData for Grafana datasource(s)

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
@@ -22,6 +22,7 @@ data:
       url: {{ include "victoria-metrics-k8s-stack.vmSelectEndpoint" . }}
       access: proxy
       isDefault: true
+      jsonData: {{ toYaml .Values.grafana.sidecar.datasources.jsonData | nindent 8 }}
 {{- end }}
 {{- if .Values.grafana.sidecar.datasources.createVMReplicasDatasources }}
 {{- range until (int .Values.vmsingle.spec.replicaCount) }}
@@ -30,6 +31,7 @@ data:
       url: "http://{{ include "victoria-metrics-k8s-stack.vmsingleName" $ }}-{{ . }}.{{ $.Release.Namespace }}.svc:{{ $.Values.vmsingle.spec.port | default 8428 }}"
       access: proxy
       isDefault: false
+      jsonData: {{ toYaml .Values.grafana.sidecar.datasources.jsonData | nindent 8 }}
 {{- end }}
 {{- end }}
 {{- if .Values.grafana.additionalDataSources }}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -530,6 +530,10 @@ grafana:
     datasources:
       enabled: true
       createVMReplicasDatasources: false
+      # JSON options for VM datasources
+      # See https://grafana.com/docs/grafana/latest/administration/provisioning/#json-data
+      jsonData: {}
+      #  timeInterval: "1m"
     dashboards:
       enabled: true
       multicluster: false


### PR DESCRIPTION
We are using a polling interval of 1m (for snmp-exporter) and would like to change the default interval on the provisioned VM datasources in Grafana (see [docs](https://grafana.com/docs/grafana/latest/administration/provisioning/#json-data)). With this PR, we can change it as follows:

```yaml
grafana:
  sidecar:
    datasources:
      jsonData:
        timeInterval: "1m"
```