### PR TITLE
feat: allow to set custom vmInsertEndpoint for own remoteWrite URL

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -99,6 +99,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.vmcluster.enabled -}}
 {{ printf "http://%s-%s.%s.svc:%d/insert/0/prometheus" "vminsert" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vminsert.port | default 8480) }}
 {{- end }}
+{{- if .Values.vmInsertEndpoint -}}
+{{ .Values.vmInsertEndpoint }}
+{{- end }}
 {{- end }}
 
 

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -63,6 +63,9 @@ defaultRules:
   # -- Additional labels for PrometheusRule alerts
   additionalRuleLabels: {}
 
+## - Override vmInsertEndpoint for a custom remoteWrite endpoint
+vmInsertEndpoint: ""
+
 ##############
 
 # -- victoria-metrics-operator dependency chart configuration.


### PR DESCRIPTION
We needed to deploy a custom vmInsertEndpoint. Right now we use the following to override it manually:
```
vmagent:
  spec:
    containers:
    - name: vmagent
      args:
      - -httpListenAddr=:8429
      - -promscrape.config=/etc/vmagent/config_out/vmagent.env.yaml
      - -promscrape.streamParse=true
      - -remoteWrite.maxDiskUsagePerURL=1073741824
      - -remoteWrite.tmpDataPath=/tmp/vmagent-remotewrite-data
      - -remoteWrite.url=x/api/v1/write
```

But this required us to manually override all args of the vmagent. We'd love to keep this automated and this PR makes that possible.

In that case we just have to define it as follows:
```
vmInsertEndpoint: x
```