### PR TITLE
quote var value to avoid string-to-bool conversion

### DIFF
--- a/charts/victoria-metrics-operator/templates/deployment.yaml
+++ b/charts/victoria-metrics-operator/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           env:
           {{- range .Values.env }}
             - name: {{ .name }}
-              value: {{ quote .value }}
+              value: {{ .value | quote }}
           {{- end }}
             - name: WATCH_NAMESPACE
               value: ""

--- a/charts/victoria-metrics-operator/templates/deployment.yaml
+++ b/charts/victoria-metrics-operator/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           env:
           {{- range .Values.env }}
             - name: {{ .name }}
-              value: {{ .value }}
+              value: {{ quote .value }}
           {{- end }}
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
Kubernetes's Pod specification requires environment variable values to be strings. I run into an issue trying to set environment variables to "false" or "true" as those get converted to boolean.

The example bellow results in a templating error.
```
env:
  - name: TEST123
    value: "false"
```

```
v1.EnvVar.Value: ReadString: expects " or n, but found f, error found in #10 byte of ...|,"value":false},{"na|..., bigger context ...|nd":["manager"],"env":[{"name":"TEST123","value":false},{"name":"WATCH_NAMESPACE","value":""},{"name|...
```

