### PR TITLE
[victoria-metrics-operator] Do not specify default resources

### DIFF
--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -65,13 +65,13 @@ serviceAccount:
   name: ""
 
 # -- Resource object
-resources: 
-  limits:
-    cpu: 120m
-    memory: 320Mi
-  requests:
-    cpu: 80m
-    memory: 120Mi
+resources: {}
+  # limits:
+  #   cpu: 120m
+  #   memory: 320Mi
+  # requests:
+  #   cpu: 80m
+  #   memory: 120Mi
 
 # -- Pod's node selector. Ref: [https://kubernetes.io/docs/user-guide/node-selection/](https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}


### PR DESCRIPTION
Hi,

This is a tiny change to prevent setting default resources for the Operator. Helm recommends not to specify default resources and to leave this as a conscious choice for the user.

We currently have two issues with default resources:
1. Using CPU limits leads to unnecessary throttling - https://github.com/kubernetes/kubernetes/issues/67577
2. We can not unset the cpu limit key in a sub-chart due to a bug in Helm - https://github.com/helm/helm/issues/9027

Most community helm charts do not set resources but provide guidance with some commented values instead. 

Thanks!



