### PR TITLE
add scheme + tlsConfig endpoint option for servicemonitor

### DIFF
--- a/charts/victoria-metrics-agent/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-agent/templates/service-monitor.yaml
@@ -24,10 +24,17 @@ spec:
        {{- include "chart.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: http
+      {{- if .Values.serviceMonitor.scheme }}
+      scheme: {{ .Values.serviceMonitor.scheme }}
+      {{- end }}
       {{- if .Values.serviceMonitor.interval }}
       interval: {{ .Values.serviceMonitor.interval }}
       {{- end }}
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.tlsConfig }}
+      tlsConfig:
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -205,6 +205,11 @@ serviceMonitor:
   annotations: {}
 #    interval: 15s
 #    scrapeTimeout: 5s
+  # -- Commented. HTTP scheme to use for scraping.
+#    scheme: https
+  # -- Commented. TLS configuration to use when scraping the endpoint
+#    tlsConfig:
+#      insecureSkipVerify: true
 
 persistence:
   enabled: false

--- a/charts/victoria-metrics-alert/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-alert/templates/service-monitor.yaml
@@ -24,10 +24,17 @@ spec:
 {{- include "vmalert.server.matchLabels" . | nindent 6 }}
   endpoints:
     - port: http
+      {{- if .Values.serviceMonitor.scheme }}
+      scheme: {{ .Values.serviceMonitor.scheme }}
+      {{- end }}
       {{- if .Values.serviceMonitor.interval }}
       interval: {{ .Values.serviceMonitor.interval }}
       {{- end }}
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.tlsConfig }}
+      tlsConfig:
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -203,6 +203,11 @@ serviceMonitor:
   annotations: {}
 #    interval: 15s
 #    scrapeTimeout: 5s
+  # -- Commented. HTTP scheme to use for scraping.
+#    scheme: https
+  # -- Commented. TLS configuration to use when scraping the endpoint
+#    tlsConfig:
+#      insecureSkipVerify: true
 
 alertmanager:
   enabled: false

--- a/charts/victoria-metrics-auth/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-auth/templates/service-monitor.yaml
@@ -24,10 +24,17 @@ spec:
       {{- include "chart.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: http
+      {{- if .Values.serviceMonitor.scheme }}
+      scheme: {{ .Values.serviceMonitor.scheme }}
+      {{- end }}
       {{- if .Values.serviceMonitor.interval }}
       interval: {{ .Values.serviceMonitor.interval }}
       {{- end }}
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.tlsConfig }}
+      tlsConfig:
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -168,11 +168,16 @@ tolerations: []
 affinity: {}
 
 serviceMonitor:
-  enabled: false
+  enabled: false 
   extraLabels: {}
   annotations: {}
 #    interval: 15s
 #    scrapeTimeout: 5s
+  # -- Commented. HTTP scheme to use for scraping.
+#    scheme: https
+  # -- Commented. TLS configuration to use when scraping the endpoint
+#    tlsConfig:
+#      insecureSkipVerify: true
 
 # -- Use existing configmap if specified otherwise .config values will be used. Ref: https://victoriametrics.github.io/vmauth.html
 configMap: ""

--- a/charts/victoria-metrics-cluster/templates/vminsert-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-service-monitor.yaml
@@ -24,10 +24,17 @@ spec:
       {{- include "victoria-metrics.vminsert.matchLabels" . | nindent 6 }} 
   endpoints:
     - port: http
+      {{- if .Values.vminsert.serviceMonitor.scheme }}
+      scheme: {{ .Values.vminsert.serviceMonitor.scheme }}
+      {{- end }}
       {{- if .Values.vminsert.serviceMonitor.interval }}
       interval: {{ .Values.vminsert.serviceMonitor.interval }}
       {{- end }}
       {{- if .Values.vminsert.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.vminsert.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.vminsert.serviceMonitor.tlsConfig }}
+      tlsConfig:
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service-monitor.yaml
@@ -24,10 +24,17 @@ spec:
       {{- include "victoria-metrics.vmselect.matchLabels" . | nindent 6 }} 
   endpoints:
     - port: http
+      {{- if .Values.vmselect.serviceMonitor.scheme }}
+      scheme: {{ .Values.vmselect.serviceMonitor.scheme }}
+      {{- end }}
       {{- if .Values.vmselect.serviceMonitor.interval }}
       interval: {{ .Values.vmselect.serviceMonitor.interval }}
       {{- end }}
       {{- if .Values.vmselect.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.vmselect.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.vmselect.serviceMonitor.tlsConfig }}
+      tlsConfig:
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-service-monitor.yaml
@@ -24,10 +24,17 @@ spec:
       {{- include "victoria-metrics.vmstorage.matchLabels" . | nindent 6 }} 
   endpoints:
     - port: http
+      {{- if .Values.vmstorage.serviceMonitor.scheme }}
+      scheme: {{ .Values.vmstorage.serviceMonitor.scheme }}
+      {{- end }}
       {{- if .Values.vmstorage.serviceMonitor.interval }}
       interval: {{ .Values.vmstorage.serviceMonitor.interval }}
       {{- end }}
       {{- if .Values.vmstorage.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.vmstorage.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.vmstorage.serviceMonitor.tlsConfig }}
+      tlsConfig:
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -239,6 +239,11 @@ vmselect:
 #    interval: 15s
     # Commented. Prometheus pre-scrape timeout for vmselect component
 #    scrapeTimeout: 5s
+    # -- Commented. HTTP scheme to use for scraping.
+#    scheme: https
+    # -- Commented. TLS configuration to use when scraping the endpoint
+#    tlsConfig:
+#      insecureSkipVerify: true
 
 vminsert:
   # -- Enable deployment of vminsert component. Deployment is used
@@ -386,6 +391,11 @@ vminsert:
 #    interval: 15s
     # Commented. Prometheus pre-scrape timeout for vminsert component
 #    scrapeTimeout: 5s
+    # -- Commented. HTTP scheme to use for scraping.
+#    scheme: https
+    # -- Commented. TLS configuration to use when scraping the endpoint
+#    tlsConfig:
+#      insecureSkipVerify: true
 
 vmstorage:
   # -- Enable deployment of vmstorage component. StatefulSet is used
@@ -623,3 +633,8 @@ vmstorage:
 #    interval: 15s
     # Commented. Prometheus pre-scrape timeout for vmstorage component
 #    scrapeTimeout: 5s
+    # -- Commented. HTTP scheme to use for scraping.
+#    scheme: https
+    # -- Commented. TLS configuration to use when scraping the endpoint
+#    tlsConfig:
+#      insecureSkipVerify: true

--- a/charts/victoria-metrics-single/templates/server-service-monitor.yaml
+++ b/charts/victoria-metrics-single/templates/server-service-monitor.yaml
@@ -24,10 +24,17 @@ spec:
       {{- include "victoria-metrics.server.matchLabels" . | nindent 6 }} 
   endpoints:
     - port: http
+      {{- if .Values.server.serviceMonitor.scheme }}
+      scheme: {{ .Values.server.serviceMonitor.scheme }}
+      {{- end }}
       {{- if .Values.server.serviceMonitor.interval }}
       interval: {{ .Values.server.serviceMonitor.interval }}
       {{- end }}
       {{- if .Values.server.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.server.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.server.serviceMonitor.tlsConfig }}
+      tlsConfig:
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -318,10 +318,15 @@ server:
     extraLabels: {}
     # -- Service Monitor annotations
     annotations: {}
-    # -- Commented. Prometheus scare interval for server component
+    # -- Commented. Prometheus scrape interval for server component
 #    interval: 15s
     # -- Commented. Prometheus pre-scrape timeout for server component
 #    scrapeTimeout: 5s
+    # -- Commented. HTTP scheme to use for scraping.
+#    scheme: https
+    # -- Commented. TLS configuration to use when scraping the endpoint
+#    tlsConfig:
+#      insecureSkipVerify: true
 
   # -- Scrape configuration for victoriametrics
   scrape:


### PR DESCRIPTION
Adding on all existing VictoriaMetrics charts the possibility to tune :

-  [ServiceMonitorSpec](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitorspec).[Endpoint](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint).scheme
- [ServiceMonitorSpec](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitorspec).[Endpoint](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint).[TLSConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#tlsconfig)

Making this PR after [discussion](https://victoriametrics.slack.com/archives/CGZF1H6L9/p1643646902896069) on #general Slack channel with @tenmozes 