### PR TITLE
fix livenessProbe for TLS configured VM-single 

### DIFF
--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -178,8 +178,10 @@ server:
 
   # Indicates whether the Container is running. If the liveness probe fails, the kubelet kills the Container, and the Container is subjected to its restart policy. If a Container does not provide a liveness probe, the default state is Success.
   livenessProbe:
-    tcpSocket:
-      port: http
+    httpGet:
+      scheme: HTTP
+      path: /health
+      port: 8428
     initialDelaySeconds: 30
     periodSeconds: 30
     timeoutSeconds: 5


### PR DESCRIPTION
Actually, the way helm chart victoriametrics-single is templatized does not allow me to use `httpGet` instead of `TcpSocket`. Which is mandatory if I want to avoid error logs like that force us to remove the `TooManyLogs` alert :vomiting_face: 
```
{"ts":"2022-02-01T17:33:09.490Z","level":"error","caller":"net/http/server.go:3158","msg":"http: TLS handshake error from X.X.X.X:58276: EOF"}
```
Those logs are triggered with the `tcpSocket` livenessProbe

-----------------------
Using actual victoriametrics-single helm chart, if I try to tune the helm chart to use `httpGet` using follow values : 
```
server:
  livenessProbe:
    httpGet:
      scheme: HTTPS
      path: /health
      port: 8428
```
Because of default livenessProbe values, my livenessprobe deployment will look like this :
```
livenessProbe:
  failureThreshold: 10
  httpGet:
    path: /health
    port: 8428
    scheme: HTTPS
  initialDelaySeconds: 5
  periodSeconds: 15
  tcpSocket:
    port: http
  timeoutSeconds: 5
```
And this will throw this error

`failed to create resource: Deployment.apps "victoriametrics-victoria-metrics-single-server" is invalid: spec.template.spec.containers[0].livenessProbe.tcpSocket: Forbidden: may not specify more than 1 handler type`

**So, i'm asking to change the way the livenessProble works, switching from `TcpSocket` :arrow_forward: `httpGet` using `/health` endpoint and allow people to set the `scheme` if they works with a TLS enabled victoriametrics. Because right now this chart does not allow a clean TLS configured victoriametrics.**

If you are ok with my point and want me to propagate this change to all VM helm charts i'll be happy to do it.

Thank you.
