### PR TITLE
Mixed helm chart values

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/cadvisor.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/cadvisor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.kubelet.enabled .Values.kubelet.probes }}
+{{- if and .Values.kubelet.enabled .Values.kubelet.cadvisor }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMNodeScrape
 metadata:

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kubelet-probes.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kubelet-probes.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.kubelet.enabled .Values.kubelet.cadvisor }}
+{{- if and .Values.kubelet.enabled .Values.kubelet.probes }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMNodeScrape
 metadata:


### PR DESCRIPTION
`.Values.kubelet.cadvisor` / `.Values.kubelet.probes` wrong way around.

Noticed this when reading around how to use the helm chart.  Pretty sure this is just a copy/paste error.