### PR TITLE
add securityContext in alertmanager-deployment.yaml

### DIFF
--- a/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
@@ -35,6 +35,8 @@ spec:
     {{- end }}
       serviceAccountName: {{ template "vmalert.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+      securityContext:
+        {{- toYaml .Values.alertmanager.securityContext | nindent 8 }}
       containers:
         - name: {{ template "vmalert.name" . }}-alertmanager
           securityContext:


### PR DESCRIPTION
I am using [charts/victoria-metrics-alert](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts) to configure the alertmanager, but I found the following errors in the alertmanager pod logs:
```
level=info ts=2022-02-09T08:56:36.032Z caller=silence.go:379 component=silences msg="Running maintenance failed" err="open /alertmanager/silences.7153164ab75d6846: permission denied"
level=error ts=2022-02-09T08:56:36.032Z caller=nflog.go:365 component=nflog msg="Running maintenance failed" err="open /alertmanager/nflog.5d365deceefa53d9: permission denied"
```
Inside the pod, it also shows the permission denied error
```
/data $ touch example
touch: example: Permission denied
/data $ id
uid=65534(nobody) gid=65534(nogroup)
```
even if I have defined the fsGroup in the values.yaml like following:
```
alertmanager:
  enabled: true
  persistentVolume:
    enabled: true
  securityContext:
    fsGroup: 2000
```
This pull request is related to the [issue280](https://github.com/VictoriaMetrics/helm-charts/issues/280).