### PR TITLE
add additional VMRules in template/rules folder and change corresponding values.yaml

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/rules/additionalVictoriaMetricsRules.yml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/additionalVictoriaMetricsRules.yml
@@ -1,0 +1,24 @@
+{{- if .Values.additionalVictoriaMetricsMap}}
+apiVersion: v1
+kind: List
+metadata:
+  name: {{ include "victoria-metrics-k8s-stack.fullname" $ }}-additional-victoria-metrics-rules
+  namespace: {{ .Release.Namespace }}
+items:
+{{- range $VMRuleName, $VMRule := .Values.additionalVictoriaMetricsMap }}
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    kind: VMRule
+    metadata:
+      name: {{ template "victoria-metrics-k8s-stack.name" $ }}-{{ $VMRuleName }}
+      namespace: {{ $.Release.Namespace }}
+      labels:
+        app: {{ template "victoria-metrics-k8s-stack.name" $ }}
+{{ include "victoria-metrics-k8s-stack.labels" $ | indent 8 }}
+    {{- if $VMRule.additionalLabels }}
+{{ toYaml $VMRule.additionalLabels | indent 8 }}
+    {{- end }}
+    spec:
+      groups:
+{{ toYaml $VMRule.groups| indent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -63,6 +63,15 @@ defaultRules:
   # -- Additional labels for PrometheusRule alerts
   additionalRuleLabels: {}
 
+# Provide custom recording or alerting rules to be deployed into the cluster.
+additionalVictoriaMetricsMap:
+  rule-name:
+    groups:
+    - name: my_group
+      rules:
+      - record: my_record
+        expr: 100 * my_record
+
 ##############
 
 # -- victoria-metrics-operator dependency chart configuration.


### PR DESCRIPTION
Dear maintainers of VictoriaMetrics community,

thanks a lot for the nice helm chart! As mentioned by this [issue](https://github.com/VictoriaMetrics/helm-charts/issues/289), someone has the same problem as me when adding new VMrules to VMAlert using k8s-stack helm chart. I tried a lot with args from [VMAlertSpec](https://docs.victoriametrics.com/operator/api.html#vmalertspec) but didn't succeed to add additional rules with this helm chart. I compared it with the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/09534e674f1fc2015a84e1ca268e09214a8bc347/charts/kube-prometheus-stack) chart from prometheus-community and found that they add [additionalPrometheusRules.yaml](https://github.com/prometheus-community/helm-charts/blob/09534e674f1fc2015a84e1ca268e09214a8bc347/charts/kube-prometheus-stack/templates/prometheus/additionalPrometheusRules.yaml) into the helm templates in order to add custom-defined rules. The corresponding parameters can be found [here](https://github.com/prometheus-community/helm-charts/blob/09534e674f1fc2015a84e1ca268e09214a8bc347/charts/kube-prometheus-stack/values.yaml#L84-L92) in values.yaml.

As a result, I have add the similar configuration for victoria-metrics-k8s-stack chart and hope that it can help other users get an easier way to deploy their rules. Please check my pull request and I am happy to hear your comments. 

Thanks a lot for your contributions.

Best regards,
Weibo