### PR TITLE
Add optional relabelings for serviceMonitors

### DIFF
--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: victoria-metrics-agent
 description: Victoria Metrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
-version: 0.7.45
+version: 0.7.46
 appVersion: v1.76.1

--- a/charts/victoria-metrics-agent/README.md
+++ b/charts/victoria-metrics-agent/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Agent.
 
- ![Version: 0.7.44](https://img.shields.io/badge/Version-0.7.44-informational?style=flat-square)
+ ![Version: 0.7.46](https://img.shields.io/badge/Version-0.7.46-informational?style=flat-square)
 
 Victoria Metrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
 
@@ -328,6 +328,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | serviceMonitor.annotations | object | `{}` |  |
 | serviceMonitor.enabled | bool | `false` |  |
 | serviceMonitor.extraLabels | object | `{}` |  |
+| serviceMonitor.relabelings | list | `[]` |  |
 | statefulset.enabled | bool | `false` |  |
 | statefulset.updateStrategy | object | `{}` |  |
 | tolerations | list | `[]` |  |

--- a/charts/victoria-metrics-agent/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-agent/templates/service-monitor.yaml
@@ -37,4 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-agent/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-agent/templates/service-monitor.yaml
@@ -37,8 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceMonitor.relabelings }}
+      {{- with .Values.serviceMonitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -209,6 +209,7 @@ serviceMonitor:
   enabled: false
   extraLabels: {}
   annotations: {}
+  relabelings: []
 #    interval: 15s
 #    scrapeTimeout: 5s
   # -- Commented. HTTP scheme to use for scraping.

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: victoria-metrics-alert
 description: Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.4.26
+version: 0.4.27
 appVersion: v1.76.1

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Alert.
 
- ![Version: 0.4.25](https://img.shields.io/badge/Version-0.4.25-informational?style=flat-square)
+ ![Version: 0.4.27](https://img.shields.io/badge/Version-0.4.27-informational?style=flat-square)
 
 Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
 
@@ -207,3 +207,4 @@ Change the values according to the need of the environment in ``victoria-metrics
 | serviceMonitor.annotations | object | `{}` |  |
 | serviceMonitor.enabled | bool | `false` |  |
 | serviceMonitor.extraLabels | object | `{}` |  |
+| serviceMonitor.relabelings | list | `[]` |  |

--- a/charts/victoria-metrics-alert/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-alert/templates/service-monitor.yaml
@@ -37,4 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-alert/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-alert/templates/service-monitor.yaml
@@ -37,8 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceMonitor.relabelings }}
+      {{- with .Values.serviceMonitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -205,6 +205,7 @@ serviceMonitor:
   enabled: false
   extraLabels: {}
   annotations: {}
+  relabelings: []
 #    interval: 15s
 #    scrapeTimeout: 5s
   # -- Commented. HTTP scheme to use for scraping.

--- a/charts/victoria-metrics-auth/Chart.yaml
+++ b/charts/victoria-metrics-auth/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.76.1
 description: Victoria Metrics Auth - is a simple auth proxy and router for VictoriaMetrics.
 name: victoria-metrics-auth
-version: 0.2.44
+version: 0.2.45

--- a/charts/victoria-metrics-auth/README.md
+++ b/charts/victoria-metrics-auth/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Auth.
 
- ![Version: 0.2.43](https://img.shields.io/badge/Version-0.2.43-informational?style=flat-square)
+ ![Version: 0.2.45](https://img.shields.io/badge/Version-0.2.45-informational?style=flat-square)
 
 Victoria Metrics Auth - is a simple auth proxy and router for VictoriaMetrics.
 
@@ -154,4 +154,5 @@ Change the values according to the need of the environment in ``victoria-metrics
 | serviceMonitor.annotations | object | `{}` |  |
 | serviceMonitor.enabled | bool | `false` |  |
 | serviceMonitor.extraLabels | object | `{}` |  |
+| serviceMonitor.relabelings | list | `[]` |  |
 | tolerations | list | `[]` | Tolerations configurations. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |

--- a/charts/victoria-metrics-auth/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-auth/templates/service-monitor.yaml
@@ -37,4 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-auth/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-auth/templates/service-monitor.yaml
@@ -37,8 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceMonitor.relabelings }}
+      {{- with .Values.serviceMonitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -174,6 +174,7 @@ serviceMonitor:
   enabled: false 
   extraLabels: {}
   annotations: {}
+  relabelings: []
 #    interval: 15s
 #    scrapeTimeout: 5s
   # -- Commented. HTTP scheme to use for scraping.

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.76.1
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.9.21
+version: 0.9.22

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for Cluster Version
 
- ![Version: 0.9.20](https://img.shields.io/badge/Version-0.9.20-informational?style=flat-square)
+ ![Version: 0.9.22](https://img.shields.io/badge/Version-0.9.22-informational?style=flat-square)
 
 Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 
@@ -171,6 +171,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vminsert.serviceMonitor.enabled | bool | `false` | Enable deployment of Service Monitor for vminsert component. This is Prometheus operator object |
 | vminsert.serviceMonitor.extraLabels | object | `{}` | Service Monitor labels |
 | vminsert.serviceMonitor.namespace | string | `""` | Target namespace of ServiceMonitor manifest |
+| vminsert.serviceMonitor.relabelings | list | `[]` | Service Monitor annotations |
 | vminsert.suppresStorageFQDNsRender | bool | `false` | Suppress rendering `--storageNode` FQDNs based on `vmstorage.replicaCount` value. If true suppress rendering `--stroageNodes`, they can be re-defined in exrtaArgs |
 | vminsert.tolerations | list | `[]` | Array of tolerations object. Ref: [https://kubernetes.io/docs/concepts/configuration/assign-pod-node/](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) |
 | vmselect.affinity | object | `{}` | Pod affinity |
@@ -239,6 +240,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmselect.serviceMonitor.enabled | bool | `false` | Enable deployment of Service Monitor for vmselect component. This is Prometheus operator object |
 | vmselect.serviceMonitor.extraLabels | object | `{}` | Service Monitor labels |
 | vmselect.serviceMonitor.namespace | string | `""` | Target namespace of ServiceMonitor manifest |
+| vmselect.serviceMonitor.relabelings | list | `[]` | Service Monitor annotations |
 | vmselect.statefulSet.enabled | bool | `false` | Deploy StatefulSet instead of Deployment for vmselect. Useful if you want to keep cache data. Creates statefulset instead of deployment, useful when you want to keep the cache |
 | vmselect.statefulSet.podManagementPolicy | string | `"OrderedReady"` | Deploy order policy for StatefulSet pods |
 | vmselect.statefulSet.service.annotations | object | `{}` | Headless service annotations |
@@ -305,6 +307,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmstorage.serviceMonitor.enabled | bool | `false` | Enable deployment of Service Monitor for vmstorage component. This is Prometheus operator object |
 | vmstorage.serviceMonitor.extraLabels | object | `{}` | Service Monitor labels |
 | vmstorage.serviceMonitor.namespace | string | `""` | Target namespace of ServiceMonitor manifest |
+| vmstorage.serviceMonitor.relabelings | list | `[]` | Service Monitor relabelings |
 | vmstorage.terminationGracePeriodSeconds | int | `60` | Pod's termination grace period in seconds |
 | vmstorage.tolerations | list | `[]` | Array of tolerations object. Node tolerations for server scheduling to nodes with taints. Ref: [https://kubernetes.io/docs/concepts/configuration/assign-pod-node/](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) |
 | vmstorage.vmbackupmanager.destination | string | `""` | backup destination at S3, GCS or local filesystem. Pod name will be included to path! |

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -171,7 +171,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vminsert.serviceMonitor.enabled | bool | `false` | Enable deployment of Service Monitor for vminsert component. This is Prometheus operator object |
 | vminsert.serviceMonitor.extraLabels | object | `{}` | Service Monitor labels |
 | vminsert.serviceMonitor.namespace | string | `""` | Target namespace of ServiceMonitor manifest |
-| vminsert.serviceMonitor.relabelings | list | `[]` | Service Monitor annotations |
+| vminsert.serviceMonitor.relabelings | list | `[]` | Service Monitor relabelings |
 | vminsert.suppresStorageFQDNsRender | bool | `false` | Suppress rendering `--storageNode` FQDNs based on `vmstorage.replicaCount` value. If true suppress rendering `--stroageNodes`, they can be re-defined in exrtaArgs |
 | vminsert.tolerations | list | `[]` | Array of tolerations object. Ref: [https://kubernetes.io/docs/concepts/configuration/assign-pod-node/](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) |
 | vmselect.affinity | object | `{}` | Pod affinity |
@@ -240,7 +240,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmselect.serviceMonitor.enabled | bool | `false` | Enable deployment of Service Monitor for vmselect component. This is Prometheus operator object |
 | vmselect.serviceMonitor.extraLabels | object | `{}` | Service Monitor labels |
 | vmselect.serviceMonitor.namespace | string | `""` | Target namespace of ServiceMonitor manifest |
-| vmselect.serviceMonitor.relabelings | list | `[]` | Service Monitor annotations |
+| vmselect.serviceMonitor.relabelings | list | `[]` | Service Monitor relabelings |
 | vmselect.statefulSet.enabled | bool | `false` | Deploy StatefulSet instead of Deployment for vmselect. Useful if you want to keep cache data. Creates statefulset instead of deployment, useful when you want to keep the cache |
 | vmselect.statefulSet.podManagementPolicy | string | `"OrderedReady"` | Deploy order policy for StatefulSet pods |
 | vmselect.statefulSet.service.annotations | object | `{}` | Headless service annotations |

--- a/charts/victoria-metrics-cluster/templates/vminsert-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-service-monitor.yaml
@@ -37,8 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.vminsert.serviceMonitor.relabelings }}
+      {{- with .Values.vminsert.serviceMonitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.vminsert.serviceMonitor.relabelings | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vminsert-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-service-monitor.yaml
@@ -37,4 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.vminsert.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.vminsert.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service-monitor.yaml
@@ -37,4 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.vmselect.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.vmselect.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service-monitor.yaml
@@ -37,8 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.vmselect.serviceMonitor.relabelings }}
+      {{- with .Values.vmselect.serviceMonitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.vmselect.serviceMonitor.relabelings | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-service-monitor.yaml
@@ -37,4 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.vmstorage.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.vmstorage.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-service-monitor.yaml
@@ -37,8 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.vmstorage.serviceMonitor.relabelings }}
+      {{- with .Values.vmstorage.serviceMonitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.vmstorage.serviceMonitor.relabelings | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -244,7 +244,7 @@ vmselect:
     # -- Commented. TLS configuration to use when scraping the endpoint
 #    tlsConfig:
 #      insecureSkipVerify: true
-    # -- Service Monitor annotations
+    # -- Service Monitor relabelings
     relabelings: []
 
 vminsert:
@@ -398,7 +398,7 @@ vminsert:
     # -- Commented. TLS configuration to use when scraping the endpoint
 #    tlsConfig:
 #      insecureSkipVerify: true
-    # -- Service Monitor annotations
+    # -- Service Monitor relabelings
     relabelings: []
 
 vmstorage:

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -244,6 +244,8 @@ vmselect:
     # -- Commented. TLS configuration to use when scraping the endpoint
 #    tlsConfig:
 #      insecureSkipVerify: true
+    # -- Service Monitor annotations
+    relabelings: []
 
 vminsert:
   # -- Enable deployment of vminsert component. Deployment is used
@@ -396,6 +398,8 @@ vminsert:
     # -- Commented. TLS configuration to use when scraping the endpoint
 #    tlsConfig:
 #      insecureSkipVerify: true
+    # -- Service Monitor annotations
+    relabelings: []
 
 vmstorage:
   # -- Enable deployment of vmstorage component. StatefulSet is used
@@ -638,3 +642,5 @@ vmstorage:
     # -- Commented. TLS configuration to use when scraping the endpoint
 #    tlsConfig:
 #      insecureSkipVerify: true
+    # -- Service Monitor relabelings
+    relabelings: []

--- a/charts/victoria-metrics-gateway/Chart.yaml
+++ b/charts/victoria-metrics-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Victoria Metrics Gateway - Auth & Rate-Limitting proxy for Victoria Metrics
 name: victoria-metrics-gateway
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.76.1

--- a/charts/victoria-metrics-gateway/README.md
+++ b/charts/victoria-metrics-gateway/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for vmgateway
 
- ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+ ![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)
 
 Victoria Metrics Gateway - Auth & Rate-Limitting proxy for Victoria Metrics
 
@@ -162,5 +162,6 @@ Change the values according to the need of the environment in ``victoria-metrics
 | serviceMonitor.annotations | object | `{}` |  |
 | serviceMonitor.enabled | bool | `false` |  |
 | serviceMonitor.extraLabels | object | `{}` |  |
+| serviceMonitor.relabelings | list | `[]` |  |
 | tolerations | list | `[]` | Tolerations configurations. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | write.url | string | `""` | Write endpoint without suffixes, victoriametrics or vminsert. Example http://victoroametrics:8428 or http://vminsert:8480 |

--- a/charts/victoria-metrics-gateway/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-gateway/templates/service-monitor.yaml
@@ -37,4 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-gateway/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-gateway/templates/service-monitor.yaml
@@ -37,8 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceMonitor.relabelings }}
+      {{- with .Values.serviceMonitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -144,6 +144,7 @@ serviceMonitor:
   enabled: false
   extraLabels: {}
   annotations: {}
+  relabelings: []
   #    interval: 15s
   #    scrapeTimeout: 5s
   # -- Commented. HTTP scheme to use for scraping.

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics kubernetes monitoring stack.
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square)
 
 Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 
@@ -396,6 +396,13 @@ Change the values according to the need of the environment in ``victoria-metrics
 | kubelet.spec.bearerTokenFile | string | `"/var/run/secrets/kubernetes.io/serviceaccount/token"` |  |
 | kubelet.spec.honorLabels | bool | `true` |  |
 | kubelet.spec.interval | string | `"30s"` |  |
+| kubelet.spec.metricRelabelConfigs[0].action | string | `"labeldrop"` |  |
+| kubelet.spec.metricRelabelConfigs[0].regex | string | `"(uid)"` |  |
+| kubelet.spec.metricRelabelConfigs[1].action | string | `"labeldrop"` |  |
+| kubelet.spec.metricRelabelConfigs[1].regex | string | `"(id|name|image)"` |  |
+| kubelet.spec.metricRelabelConfigs[2].action | string | `"drop"` |  |
+| kubelet.spec.metricRelabelConfigs[2].regex | string | `"(rest_client_request_duration_seconds_bucket|rest_client_request_duration_seconds_sum|rest_client_request_duration_seconds_count)"` |  |
+| kubelet.spec.metricRelabelConfigs[2].source_labels[0] | string | `"__name__"` |  |
 | kubelet.spec.relabelConfigs[0].action | string | `"labelmap"` |  |
 | kubelet.spec.relabelConfigs[0].regex | string | `"__meta_kubernetes_node_label_(.+)"` |  |
 | kubelet.spec.relabelConfigs[1].sourceLabels[0] | string | `"__metrics_path__"` |  |

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.76.1
 description: Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.8.23
+version: 0.8.24

--- a/charts/victoria-metrics-single/README.md
+++ b/charts/victoria-metrics-single/README.md
@@ -191,7 +191,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | server.serviceMonitor.annotations | object | `{}` | Service Monitor annotations |
 | server.serviceMonitor.enabled | bool | `false` | Enable deployment of Service Monitor for server component. This is Prometheus operator object |
 | server.serviceMonitor.extraLabels | object | `{}` | Service Monitor labels |
-| server.serviceMonitor.relabelings | list | `[]` | Service Monitor annotations |
+| server.serviceMonitor.relabelings | list | `[]` | Service Monitor relabelings |
 | server.startupProbe | object | `{}` |  |
 | server.statefulSet.enabled | bool | `true` | Creates statefulset instead of deployment, useful when you want to keep the cache |
 | server.statefulSet.podManagementPolicy | string | `"OrderedReady"` | Deploy order policy for StatefulSet pods |

--- a/charts/victoria-metrics-single/README.md
+++ b/charts/victoria-metrics-single/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for Single Version
 
- ![Version: 0.8.22](https://img.shields.io/badge/Version-0.8.22-informational?style=flat-square)
+ ![Version: 0.8.24](https://img.shields.io/badge/Version-0.8.24-informational?style=flat-square)
 
 Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 
@@ -191,6 +191,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | server.serviceMonitor.annotations | object | `{}` | Service Monitor annotations |
 | server.serviceMonitor.enabled | bool | `false` | Enable deployment of Service Monitor for server component. This is Prometheus operator object |
 | server.serviceMonitor.extraLabels | object | `{}` | Service Monitor labels |
+| server.serviceMonitor.relabelings | list | `[]` | Service Monitor annotations |
 | server.startupProbe | object | `{}` |  |
 | server.statefulSet.enabled | bool | `true` | Creates statefulset instead of deployment, useful when you want to keep the cache |
 | server.statefulSet.podManagementPolicy | string | `"OrderedReady"` | Deploy order policy for StatefulSet pods |

--- a/charts/victoria-metrics-single/templates/server-service-monitor.yaml
+++ b/charts/victoria-metrics-single/templates/server-service-monitor.yaml
@@ -37,8 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.server.serviceMonitor.relabelings }}
+      {{- with .Values.server.serviceMonitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.server.serviceMonitor.relabelings | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-single/templates/server-service-monitor.yaml
+++ b/charts/victoria-metrics-single/templates/server-service-monitor.yaml
@@ -37,4 +37,8 @@ spec:
       tlsConfig:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.server.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.server.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -336,6 +336,8 @@ server:
     # -- Commented. TLS configuration to use when scraping the endpoint
 #    tlsConfig:
 #      insecureSkipVerify: true
+    # -- Service Monitor annotations
+    relabelings: []
 
   # -- Scrape configuration for victoriametrics
   scrape:

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -336,7 +336,7 @@ server:
     # -- Commented. TLS configuration to use when scraping the endpoint
 #    tlsConfig:
 #      insecureSkipVerify: true
-    # -- Service Monitor annotations
+    # -- Service Monitor relabelings
     relabelings: []
 
   # -- Scrape configuration for victoriametrics


### PR DESCRIPTION
Hi,

This is a small change to allow defining relabelings for serviceMonitors. Looks like nobody run `helm-docs` for a while and it updated a few readme files not related to this PR.

Thanks,
Arcadie