### PR TITLE
fix(victoria-metrics-k8s-stack/_helpers): fix datatype of vmsingle/vm…

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -85,17 +85,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "victoria-metrics-k8s-stack.vmSelectEndpoint" -}}
 {{- if .Values.vmsingle.enabled -}}
-{{ printf "http://%s.%s.svc:%d" (include "victoria-metrics-k8s-stack.vmsingleName" .) .Release.Namespace (.Values.vmsingle.spec.port | default 8429) }}
+{{ printf "http://%s.%s.svc:%s" (include "victoria-metrics-k8s-stack.vmsingleName" .) .Release.Namespace (.Values.vmsingle.spec.port | default "8429") }}
 {{- else if .Values.vmcluster.enabled -}}
-{{ printf "http://%s-%s.%s.svc:%d/select/0/prometheus" "vmselect" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vmselect.port | default 8481) }}
+{{ printf "http://%s-%s.%s.svc:%s/select/0/prometheus" "vmselect" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vmselect.port | default "8481") }}
 {{- end }}
 {{- end }}
 
 {{- define "victoria-metrics-k8s-stack.vmSingleInsertEndpoint" -}}
-{{ printf "http://%s.%s.svc:%d" (include "victoria-metrics-k8s-stack.vmsingleName" .) .Release.Namespace (.Values.vmsingle.spec.port | default 8429) }}
+{{ printf "http://%s.%s.svc:%s" (include "victoria-metrics-k8s-stack.vmsingleName" .) .Release.Namespace (.Values.vmsingle.spec.port | default "8429") }}
 {{- end }}
 {{- define "victoria-metrics-k8s-stack.vmClusterInsertEndpoint" -}}
-{{ printf "http://%s-%s.%s.svc:%d/insert/0/prometheus" "vminsert" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vminsert.port | default 8480) }}
+{{ printf "http://%s-%s.%s.svc:%s/insert/0/prometheus" "vminsert" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vminsert.port | default "8480") }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Hello, I found a data type mismatch for vmsingle.spec.port, vmcluster.spec.vminsert.port, and vmcluster.spec.vmselect.port in templates for variables such as:
- "victoria-metrics-k8s-stack.vmSelectEndpoint"
- "victoria-metrics-k8s-stack.vmSingleInsertEndpoint"
- "victoria-metrics-k8s-stack.vmClusterInsertEndpoint"

Example for vmsinglespec:
https://docs.victoriametrics.com/operator/api.html#vmsinglespec

Field port has Scheme as string

Reproduce the issue

```
cat <<EOF | helm template vm ./ -n monitoring-system -s templates/victoria-metrics-operator/vmagent.yaml -f -
---
vmsingle:
    enabled: true
    spec:
      port: "12345"
EOF

```

Reponse:

```
---
# Source: victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmagent.yaml
...
spec:
...
  remoteWrite:
  - url: http://vmsingle-vm-victoria-metrics-k8s-stack.monitoring-system.svc:%!d(string=12345)/api/v1/write
...

```
I propose to correct the inconsistency or discuss a workaround