### PR TITLE
BugFix: change int to toString for the retentionPeriod in VMSingle deployment

### DIFF
--- a/charts/victoria-metrics-single/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-single/templates/server-deployment.yaml
@@ -56,7 +56,7 @@ spec:
           workingDir: {{ .Values.server.containerWorkingDir }}
           {{- end }}
           args:
-            - {{ printf "%s=%d" "--retentionPeriod" (int .Values.server.retentionPeriod) | quote}}
+            - {{ printf "%s=%s" "--retentionPeriod" (toString .Values.server.retentionPeriod) | quote}}
             - {{ printf "%s=%s" "--storageDataPath" .Values.server.persistentVolume.mountPath | quote}}
           {{- if .Values.server.scrape.enabled }}
             - -promscrape.config=/scrapeconfig/scrape.yml


### PR DESCRIPTION
Hello VictoriaMetrics team,

we are currently use the victoria-metrics-single helm chart and found that our settings of retentionPeriod of vmsingle deployment is set to zero because of the int function. I notice that there is similar [pull request](https://github.com/VictoriaMetrics/helm-charts/pull/87) for the statefulset but the deployment is not changed. 

Best regards,
Weibo