### PR TITLE
expose "nodePort" in service configuration

### DIFF
--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: victoria-metrics-agent
 description: Victoria Metrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
-version: 0.8.1
+version: 0.8.2
 appVersion: v1.76.1

--- a/charts/victoria-metrics-agent/README.md
+++ b/charts/victoria-metrics-agent/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Agent.
 
- ![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square)
+ ![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square)
 
 Victoria Metrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
 

--- a/charts/victoria-metrics-agent/templates/service.yaml
+++ b/charts/victoria-metrics-agent/templates/service.yaml
@@ -35,6 +35,9 @@ spec:
       port: {{ .Values.service.servicePort }}
       protocol: TCP
       targetPort: http
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
 {{- if .Values.extraArgs.graphiteListenAddr }}
     - name: graphite-tcp
       protocol: TCP

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -150,6 +150,7 @@ service:
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
   servicePort: 8429
+  # nodePort: 30000
   type: ClusterIP
   # Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   # externalTrafficPolicy: "local"

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: victoria-metrics-alert
 description: Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.4.27
+version: 0.4.28
 appVersion: v1.76.1

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Alert.
 
- ![Version: 0.4.27](https://img.shields.io/badge/Version-0.4.27-informational?style=flat-square)
+ ![Version: 0.4.28](https://img.shields.io/badge/Version-0.4.28-informational?style=flat-square)
 
 Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
 

--- a/charts/victoria-metrics-alert/templates/server-service.yaml
+++ b/charts/victoria-metrics-alert/templates/server-service.yaml
@@ -35,6 +35,9 @@ spec:
       port: {{ .Values.server.service.servicePort }}
       targetPort: http
       protocol: TCP
+      {{- with .Values.server.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "vmalert.server.matchLabels" . | nindent 4 }}
   type: "{{ .Values.server.service.type }}"

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -122,6 +122,7 @@ server:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     servicePort: 8880
+    # nodePort: 30000
     type: ClusterIP
     # Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     # externalTrafficPolicy: "local"

--- a/charts/victoria-metrics-auth/Chart.yaml
+++ b/charts/victoria-metrics-auth/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.76.1
 description: Victoria Metrics Auth - is a simple auth proxy and router for VictoriaMetrics.
 name: victoria-metrics-auth
-version: 0.2.45
+version: 0.2.46

--- a/charts/victoria-metrics-auth/README.md
+++ b/charts/victoria-metrics-auth/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Auth.
 
- ![Version: 0.2.45](https://img.shields.io/badge/Version-0.2.45-informational?style=flat-square)
+ ![Version: 0.2.46](https://img.shields.io/badge/Version-0.2.46-informational?style=flat-square)
 
 Victoria Metrics Auth - is a simple auth proxy and router for VictoriaMetrics.
 

--- a/charts/victoria-metrics-auth/templates/service.yaml
+++ b/charts/victoria-metrics-auth/templates/service.yaml
@@ -35,6 +35,9 @@ spec:
       port: {{ .Values.service.servicePort }}
       protocol: TCP
       targetPort: http
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.service.type }}"

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -95,6 +95,7 @@ service:
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
   servicePort: 8427
+  # nodePort: 30000
   type: ClusterIP
   # Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   # externalTrafficPolicy: "local"

--- a/charts/victoria-metrics-gateway/Chart.yaml
+++ b/charts/victoria-metrics-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Victoria Metrics Gateway - Auth & Rate-Limitting proxy for Victoria Metrics
 name: victoria-metrics-gateway
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.76.1

--- a/charts/victoria-metrics-gateway/README.md
+++ b/charts/victoria-metrics-gateway/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for vmgateway
 
- ![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)
+ ![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square)
 
 Victoria Metrics Gateway - Auth & Rate-Limitting proxy for Victoria Metrics
 

--- a/charts/victoria-metrics-gateway/templates/service.yaml
+++ b/charts/victoria-metrics-gateway/templates/service.yaml
@@ -35,6 +35,9 @@ spec:
       port: {{ .Values.service.servicePort }}
       protocol: TCP
       targetPort: http
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.service.type }}"

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -86,6 +86,7 @@ service:
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
   servicePort: 8431
+  # nodePort: 30000
   type: ClusterIP
   # Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   # externalTrafficPolicy: "local"

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.76.1
 description: Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.8.25
+version: 0.8.26

--- a/charts/victoria-metrics-single/README.md
+++ b/charts/victoria-metrics-single/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for Single Version
 
- ![Version: 0.8.25](https://img.shields.io/badge/Version-0.8.25-informational?style=flat-square)
+ ![Version: 0.8.26](https://img.shields.io/badge/Version-0.8.26-informational?style=flat-square)
 
 Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 

--- a/charts/victoria-metrics-single/templates/server-service.yaml
+++ b/charts/victoria-metrics-single/templates/server-service.yaml
@@ -35,6 +35,9 @@ spec:
       port: {{ .Values.server.service.servicePort }}
       protocol: TCP
       targetPort: http
+      {{- with .Values.server.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
 {{- if .Values.server.extraArgs.graphiteListenAddr }}
     - name: graphite-tcp
       protocol: TCP

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -296,6 +296,8 @@ server:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: 8428
+    # -- Node port
+    # nodePort: 30000
     # -- Service type
     type: ClusterIP
     # Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip


### PR DESCRIPTION
Hi, this PR is exposing nodePort config where it might be useful (related to #98):

- victoria-metrics-agent
- victoria-metrics-alert
- victoria-metrics-auth
- victoria-metrics-gateway
- victoria-metrics-single