### PR TITLE
[cluster] disable udp port for service type LoadBalancer by default

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vminsert-service.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-service.yaml
@@ -70,7 +70,7 @@ spec:
       port: {{ include "split-host-port" .Values.vminsert.extraArgs.opentsdbHTTPListenAddr }}
       targetPort: opentsdbhttp
 {{- end }}
-{{- if .Values.vminsert.extraArgs.opentsdbListenAddr }}
+{{- if and .Values.vminsert.extraArgs.opentsdbListenAddr ( or .Values.vminsert.service.udp ( ne .Values.vminsert.service.type  "LoadBalancer" ) )}}
     - name: opentsdb-udp
       protocol: UDP
       port: {{ include "split-host-port" .Values.vminsert.extraArgs.opentsdbListenAddr }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -370,6 +370,9 @@ vminsert:
     servicePort: 8480
     # -- Service type
     type: ClusterIP
+    # -- Enable UDP port. used if you have "spec.opentsdbListenAddr" specified
+    # -- Make sure that service is not type "LoadBalancer", as it requires "MixedProtocolLBService" feature gate. ref: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+    udp: false
   ingress:
     # -- Enable deployment of ingress for vminsert component
     enabled: false


### PR DESCRIPTION
with this change, if service type `LoadBalancer` and `extraArgs.opentsdbListenAddr` specified for VMinsert, by default UDP port will not be created in service spec. Because out of the box LoadBalancer service type doesn't support TCP and UDP in one service. 

However if needed, `udp: true` may be specified. this is to cover cases when feature gate `MixedProtocolLBService` enabled

addresses #319 