### PR TITLE
fix: agent statefulset clusterMode values misspell

### DIFF
--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -19,7 +19,7 @@ statefulset:
   enabled: false
   # -- create cluster of vmagents. See https://docs.victoriametrics.com/vmagent.html#scraping-big-number-of-targets
   # available since 1.77.1 version https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.77.1
-  cluserMode: false
+  clusterMode: false
   # -- replication factor for vmagent in cluster mode
   replicationFactor: 1
   # ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies


### PR DESCRIPTION
fix: victoria-metrics-agent  `statefulset.clusterMode` values misspell, should be **clusterMode**.  @valyala 