### PR TITLE
Add endpointslices permissions to ClusterRole manifest

### DIFF
--- a/charts/victoria-metrics-agent/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrole.yaml
@@ -21,6 +21,7 @@ rules:
   - nodes/metrics
   - services
   - endpoints
+  - endpointslices
   - pods
   verbs: ["get", "list", "watch"]
 - apiGroups:


### PR DESCRIPTION
Need to add endpointslices to list of allowed resources to ClusterRole definition in victoria-metrics-agent chart.