### PR TITLE
Fix victoria-metrics-agent clusterrole

### DIFF
--- a/charts/victoria-metrics-agent/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrole.yaml
@@ -14,6 +14,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs: ["get", "list", "watch"]=
 - apiGroups: [""]
   resources:
   - nodes
@@ -21,7 +26,6 @@ rules:
   - nodes/metrics
   - services
   - endpoints
-  - endpointslices
   - pods
   verbs: ["get", "list", "watch"]
 - apiGroups:

--- a/charts/victoria-metrics-agent/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrole.yaml
@@ -18,7 +18,7 @@ rules:
   - discovery.k8s.io
   resources:
   - endpointslices
-  verbs: ["get", "list", "watch"]=
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources:
   - nodes


### PR DESCRIPTION
Endpointslices are not in base api groups. They are from discovery.k8s.io api group.
Need to be defined explicitly in clusterrole manifest.