### PR TITLE
Fix typo in telegram_configs.parse_mode

### DIFF
--- a/charts/victoria-metrics-k8s-stack/crds/crd.yaml
+++ b/charts/victoria-metrics-k8s-stack/crds/crd.yaml
@@ -3372,12 +3372,12 @@ spec:
                             type: string
                           parse_mode:
                             description: ParseMode for telegram message, supported
-                              values are MarkdownV2, Markdown, Markdown and empty
+                              values are MarkdownV2, Markdown, HTML and empty
                               string for plain text.
                             enum:
                             - MarkdownV2
                             - Markdown
-                            - Markdown
+                            - HTML
                             type: string
                           send_resolved:
                             description: SendResolved controls notify about resolved

--- a/charts/victoria-metrics-operator/templates/crd.yaml
+++ b/charts/victoria-metrics-operator/templates/crd.yaml
@@ -3373,12 +3373,12 @@ spec:
                             type: string
                           parse_mode:
                             description: ParseMode for telegram message, supported
-                              values are MarkdownV2, Markdown, Markdown and empty
+                              values are MarkdownV2, Markdown, HTML and empty
                               string for plain text.
                             enum:
                             - MarkdownV2
                             - Markdown
-                            - Markdown
+                            - HTML
                             type: string
                           send_resolved:
                             description: SendResolved controls notify about resolved

--- a/charts/victoria-metrics-operator/templates/crd_legacy.yaml
+++ b/charts/victoria-metrics-operator/templates/crd_legacy.yaml
@@ -3320,12 +3320,12 @@ spec:
                           type: string
                         parse_mode:
                           description: ParseMode for telegram message, supported values
-                            are MarkdownV2, Markdown, Markdown and empty string for
+                            are MarkdownV2, Markdown, HTML and empty string for
                             plain text.
                           enum:
                           - MarkdownV2
                           - Markdown
-                          - Markdown
+                          - HTML
                           type: string
                         send_resolved:
                           description: SendResolved controls notify about resolved


### PR DESCRIPTION
Hi! 
I found a typo in the CRD manifests.
There was duplicated "markdown" and no "HTML" option.

Link to the official docs: https://prometheus.io/docs/alerting/latest/configuration/#telegram_config