### PR TITLE
Added check for extraVolumes

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -150,8 +150,10 @@ spec:
       affinity:
 {{ toYaml .Values.vminsert.affinity | indent 8 }}
     {{- end }}
-{{- end }}
+    {{- if .Values.vminsert.extraVolumes }}
       volumes:
         {{- with .Values.vminsert.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- end }}
+{{- end }}


### PR DESCRIPTION
Fixes issue #348 

Since `vminsert` is stateless, there is no need to add any default volumes unlike other components like `vmagent`, `vmselect` or `vmstorage`.

Only add `volumes` and `volumeMounts` when they are defined in `values.yml`