### PR TITLE
Fix victoria-metrics-cluster  wrong end of template

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -150,8 +150,8 @@ spec:
       affinity:
 {{ toYaml .Values.vminsert.affinity | indent 8 }}
     {{- end }}
-{{- end }}
       volumes:
         {{- with .Values.vminsert.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+{{- end }}


### PR DESCRIPTION
- When you disabled vminsert,  empty manifest shown up
```
---
# Source: victoria-metrics-cluster/templates/vminsert-deployment.yaml
volumes:
```
- fixed PR https://github.com/VictoriaMetrics/helm-charts/pull/308
