### PR TITLE
Expose podSecurityContext also for StatefulSet

### DIFF
--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -45,6 +45,8 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "victoria-metrics.name" . }}-{{ .Values.server.name }}
+          securityContext:
+            {{- toYaml .Values.server.podSecurityContext | nindent 12 }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           {{- if .Values.server.containerWorkingDir }}


### PR DESCRIPTION
When deploying with a StatefulSet, podSecurityContext was not exposed as it was with the Deployment template, making it impossible to use the Helm chart with our secured cluster.

This exposes it.