### PR TITLE
Correct comment on persistentVolume size: option

### DIFF
--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -144,7 +144,7 @@ server:
     mountPath: /storage
     # -- Mount subpath
     subPath: ""
-    # -- Size of the volume. Better to set the same as resource limit memory property.
+    # -- Size of the volume. Should be calculated based on the metrics you send and retention policy you set.
     size: 16Gi
 
   # -- Sts/Deploy additional labels


### PR DESCRIPTION
victoria-metrics-single.

Pardon me if I'm missing something, but it looks like the volume size here does not correspond to memory itself, rather a storage for the metrics persisting.