### PR TITLE
Add AlertManager External URL Prefix

### DIFF
--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -1,4 +1,4 @@
-# Helm Chart For Victoria Metrics Alert.
+# Helm Chart For Victoria Metrics Alert
 
  ![Version: 0.4.36](https://img.shields.io/badge/Version-0.4.36-informational?style=flat-square)
 
@@ -99,6 +99,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | alertmanager.baseURL | string | `""` |  |
+| alertmanager.baseURLPrefix | string | `""` |  |
 | alertmanager.config.global.resolve_timeout | string | `"5m"` |  |
 | alertmanager.config.receivers[0].name | string | `"devnull"` |  |
 | alertmanager.config.route.group_by[0] | string | `"alertname"` |  |
@@ -153,7 +154,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | server.datasource.basicAuth.username | string | `""` |  |
 | server.datasource.url | string | `""` |  |
 | server.enabled | bool | `true` |  |
-| server.env | list | `[]` | Additional environment variables (ex.: secret tokens, flags) https://github.com/VictoriaMetrics/VictoriaMetrics#environment-variables |
+| server.env | list | `[]` | Additional environment variables (ex.: secret tokens, flags) <https://github.com/VictoriaMetrics/VictoriaMetrics#environment-variables> |
 | server.extraArgs."envflag.enable" | string | `"true"` |  |
 | server.extraArgs."envflag.prefix" | string | `"VM_"` |  |
 | server.extraArgs.loggerFormat | string | `"json"` |  |

--- a/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
@@ -57,6 +57,9 @@ spec:
             {{ if .Values.alertmanager.baseURL }}
             - --web.external-url={{ .Values.alertmanager.baseURL }}
             {{- end }}
+            {{ if .Values.alertmanager.baseURLPrefix }}
+            - --web.route-prefix={{ .Values.alertmanager.baseURLPrefix }}
+            {{- end }}
             {{- range $key, $value := .Values.alertmanager.extraArgs }}
             - --{{ $key }}={{ $value }}
             {{- end }}
@@ -71,11 +74,19 @@ spec:
                   fieldPath: status.podIP
           readinessProbe:
             httpGet:
+              {{ if .Values.alertmanager.baseURLPrefix }}
+              path: {{ .Values.alertmanager.baseURLPrefix }}/-/ready
+              {{- else}}
               path: /-/ready
+              {{- end }}
               port: web
           livenessProbe:
             httpGet:
+              {{ if .Values.alertmanager.baseURLPrefix }}
+              path: {{ .Values.alertmanager.baseURLPrefix }}/-/healthy
+              {{- else}}
               path: /-/healthy
+              {{- end }}
               port: web
           volumeMounts:
             - name: storage

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -97,9 +97,9 @@ server:
   # Extra Volumes for the pod
   extraVolumes:
     []
-     #- name: example
-     #  configMap:
-     #    name: example
+    #- name: example
+    #  configMap:
+    #    name: example
 
   # Extra Volume Mounts for the container
   extraVolumeMounts:
@@ -209,9 +209,9 @@ serviceMonitor:
   relabelings: []
 #    interval: 15s
 #    scrapeTimeout: 5s
-  # -- Commented. HTTP scheme to use for scraping.
+# -- Commented. HTTP scheme to use for scraping.
 #    scheme: https
-  # -- Commented. TLS configuration to use when scraping the endpoint
+# -- Commented. TLS configuration to use when scraping the endpoint
 #    tlsConfig:
 #      insecureSkipVerify: true
 
@@ -235,6 +235,8 @@ alertmanager:
 
   # external URL, that alertmanager will expose to receivers
   baseURL: ""
+  # external URL Prefix, Prefix for the internal routes of web endpoints
+  baseURLPrefix: ""
   # use existing configmap if specified
   # otherwise .config values will be used
   configMap: ""


### PR DESCRIPTION
This adds an additional support to the existing `alertmanager.baseURL` that allows the customization of the prefix `alertmanager.baseURLPrefix`