### PR TITLE
Add clusternativeListenAddr port support in vmselect chart

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -67,6 +67,11 @@ spec:
           ports:
             - name: http
               containerPort: 8481
+          {{- if .Values.vmselect.extraArgs.clusternativeListenAddr }}
+            - name: cluster-tcp
+              protocol: TCP
+              containerPort: {{ include "split-host-port" .Values.vmselect.extraArgs.clusternativeListenAddr }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /health

--- a/charts/victoria-metrics-cluster/templates/vmselect-service-headless.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service-headless.yaml
@@ -20,6 +20,12 @@ spec:
       port: {{ .Values.vmselect.statefulSet.service.servicePort }}
       protocol: TCP
       targetPort: http
+  {{- if .Values.vmselect.extraArgs.clusternativeListenAddr }}
+    - name: cluster-tcp
+      protocol: TCP
+      port: {{ include "split-host-port" .Values.vmselect.extraArgs.clusternativeListenAddr }}
+      targetPort: cluster-tcp
+  {{- end }}
   selector:
     {{- include "victoria-metrics.vmselect.matchLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/victoria-metrics-cluster/templates/vmselect-service.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service.yaml
@@ -35,6 +35,12 @@ spec:
       port: {{ .Values.vmselect.service.servicePort }}
       protocol: TCP
       targetPort: http
+  {{- if .Values.vmselect.extraArgs.clusternativeListenAddr }}
+    - name: cluster-tcp
+      protocol: TCP
+      port: {{ include "split-host-port" .Values.vmselect.extraArgs.clusternativeListenAddr }}
+      targetPort: cluster-tcp
+  {{- end }}
   selector:
     {{- include "victoria-metrics.vmselect.matchLabels" . | nindent 4 }}
   type: "{{ .Values.vmselect.service.type }}"

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -64,6 +64,11 @@ spec:
           ports:
             - name: http
               containerPort: 8481
+          {{- if .Values.vmselect.extraArgs.clusternativeListenAddr }}
+            - name: cluster-tcp
+              protocol: TCP
+              containerPort: {{ include "split-host-port" .Values.vmselect.extraArgs.clusternativeListenAddr }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
vmselect already supported multi-level cluster setup by setting clusternativeListenAddr. 