### PR TITLE
Schedule operator cleanup hook onto operator nodes/affinity/tolerations

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/uninstall_hook.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/uninstall_hook.yaml
@@ -31,6 +31,18 @@ spec:
               kubectl delete vmalertmanagers --all --ignore-not-found=true;
               kubectl delete vmclusters --all --ignore-not-found=true;
       restartPolicy: OnFailure
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 ---
 {{- if .Values.operator.cleanupSA.create }}
 apiVersion: v1


### PR DESCRIPTION
This fixes a bug whereby running clusters with tainted nodes (e.g. Spot nodes in AKS are tainted out the box) means you cannot run the cleanup helm hook and you cannot remove the helm release from your cluster without first removing the finalizer