### PR TITLE
victoria-metrics-k8s-stack: add conditions for kube-apiserver-burnrate.rules

### DIFF
--- a/charts/victoria-metrics-k8s-stack/hack/sync_rules.py
+++ b/charts/victoria-metrics-k8s-stack/hack/sync_rules.py
@@ -65,6 +65,7 @@ condition_map = {
     'etcd': '.Values.kubeEtcd.enabled .Values.defaultRules.rules.etcd',
     'general.rules': '.Values.defaultRules.rules.general',
     'k8s.rules': '.Values.defaultRules.rules.k8s',
+    'kube-apiserver-burnrate.rules': '.Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserverBurnrate',
     'kube-apiserver-availability.rules': '.Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserverAvailability',
     'kube-apiserver-slos': '.Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserverSlos',
     'kube-apiserver.rules': '.Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserver',

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kube-apiserver-burnrate.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kube-apiserver-burnrate.rules.yaml
@@ -3,7 +3,7 @@ Generated from 'kube-apiserver-burnrate.rules' group from https://raw.githubuser
 Do not change in-place! In order to change this file first read following link:
 https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack/hack
 */ -}}
-{{- if and .Values.defaultRules.create  }}
+{{- if and .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserverBurnrate }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/_rules.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/_rules.tpl
@@ -7,6 +7,7 @@ rules:
   - "etcd"
   - "general.rules"
   - "k8s.rules"
+  - "kube-apiserver-burnrate.rules"
   - "kube-apiserver-availability.rules"
   - "kube-apiserver-slos"
   - "kube-apiserver.rules"

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -37,6 +37,7 @@ defaultRules:
     k8s: true
     kubeApiserver: true
     kubeApiserverAvailability: true
+    kubeApiserverBurnrate: true
     kubeApiserverSlos: true
     kubelet: true
     kubePrometheusGeneral: true


### PR DESCRIPTION
Title says all :) This PR allows it to disable the generation of the kinda resource intensive kube-apiserver-burnrate rules.