### PR TITLE
victoria-metrics-k8s-stack: add feature for select nonzero default tenant 

### DIFF
--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -425,6 +425,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |
+| tenant | string | `"0"` | Default tenant for vmagent (remoteWrite), vmalert (remoteWrite,remoteRead,datasource) and grafana(default datasource) |
 | victoria-metrics-operator | object | `{"createCRD":false,"operator":{"disable_prometheus_converter":true}}` | For possible values refer to https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-operator#parameters |
 | victoria-metrics-operator.createCRD | bool | `false` | all values for victoria-metrics-operator helm chart can be specified here |
 | victoria-metrics-operator.operator.disable_prometheus_converter | bool | `true` | By default, operator converts prometheus-operator objects. |

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -87,7 +87,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.vmsingle.enabled -}}
 {{ printf "http://%s.%s.svc:%s" (include "victoria-metrics-k8s-stack.vmsingleName" .) .Release.Namespace (.Values.vmsingle.spec.port | default "8429") }}
 {{- else if .Values.vmcluster.enabled -}}
-{{ printf "http://%s-%s.%s.svc:%s/select/0/prometheus" "vmselect" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vmselect.port | default "8481") }}
+{{ printf "http://%s-%s.%s.svc:%s/select/%s/prometheus" "vmselect" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vmselect.port | default "8481") (.Values.tenant | default "0") }}
 {{- end }}
 {{- end }}
 
@@ -95,7 +95,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ printf "http://%s.%s.svc:%s" (include "victoria-metrics-k8s-stack.vmsingleName" .) .Release.Namespace (.Values.vmsingle.spec.port | default "8429") }}
 {{- end }}
 {{- define "victoria-metrics-k8s-stack.vmClusterInsertEndpoint" -}}
-{{ printf "http://%s-%s.%s.svc:%s/insert/0/prometheus" "vminsert" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vminsert.port | default "8480") }}
+{{ printf "http://%s-%s.%s.svc:%s/insert/%s/prometheus" "vminsert" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vminsert.port | default "8480") (.Values.tenant | default "0") }}
 {{- end }}
 
 {{/*

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -1,5 +1,6 @@
 nameOverride: ""
 fullnameOverride: ""
+tenant: "0"
 
 # -- Configures operator CRD
 operator:


### PR DESCRIPTION
When working with an external storage, I would like to specify a non-zero default tenant so that the correct tenant is immediately specified for all endpoints (for vmagent (remoteWrite), vmalert (remoteWrite,remoteRead,datasource) and grafana(default datasource)