### PR TITLE
charts/victoria-metrics-gateway/README.md: fix wrong command

### DIFF
--- a/charts/victoria-metrics-gateway/README.md
+++ b/charts/victoria-metrics-gateway/README.md
@@ -61,7 +61,7 @@ helm install vmgateway vm/victoria-metrics-gateway -f values.yaml -n NAMESPACE
 Get the pods lists by running this commands:
 
 ```console
-kubectl get pods -A | grep 'vminsert\|vmselect\|vmstorage'
+kubectl get pods -A | grep 'vmgateway'
 ```
 
 Get the application by running this command:

--- a/charts/victoria-metrics-gateway/README.md.gotmpl
+++ b/charts/victoria-metrics-gateway/README.md.gotmpl
@@ -61,7 +61,7 @@ helm install vmgateway vm/victoria-metrics-gateway -f values.yaml -n NAMESPACE
 Get the pods lists by running this commands:
 
 ```console
-kubectl get pods -A | grep 'vminsert\|vmselect\|vmstorage'
+kubectl get pods -A | grep 'vmgateway'
 ```
 
 Get the application by running this command:


### PR DESCRIPTION
Fix wrong grep pattern in README.md for vmgateway

**Get the pods lists by running this commands** section contain:
```console
kubectl get pods -A | grep 'vminsert\|vmselect\|vmstorage'
```

when it should be:
```console
kubectl get pods -A | grep 'vmgateway'
```

