### PR TITLE
deploy `podSecurityPolicy` resources only if Kubernetes (<1.25) supports the resource

### DIFF
--- a/charts/victoria-metrics-agent/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrole.yaml
@@ -36,7 +36,7 @@ rules:
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']

--- a/charts/victoria-metrics-agent/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-agent/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -40,6 +40,7 @@ containerWorkingDir: "/"
 
 rbac:
   create: true
+  # Note: The PSP will only be deployed, if Kubernetes (<1.25) supports the resource.
   pspEnabled: true
   annotations: {}
   extraLabels: {}

--- a/charts/victoria-metrics-alert/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-alert/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-alert/templates/role.yaml
+++ b/charts/victoria-metrics-alert/templates/role.yaml
@@ -14,7 +14,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 rules:
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -17,6 +17,7 @@ imagePullSecrets: []
 
 rbac:
   create: true
+  # Note: The PSP will only be deployed, if Kubernetes (<1.25) supports the resource.
   pspEnabled: true
   namespaced: false
   extraLabels: {}

--- a/charts/victoria-metrics-auth/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-auth/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -20,6 +20,7 @@ fullnameOverride: ""
 containerWorkingDir: "/"
 
 rbac:
+  # Note: The PSP will only be deployed, if Kubernetes (<1.25) supports the resource.
   pspEnabled: true
   annotations: {}
   extraLabels: {}

--- a/charts/victoria-metrics-cluster/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrole.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 rules:
   - apiGroups:      ['extensions']
     resources:      ['podsecuritypolicies']

--- a/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-cluster/templates/role.yaml
+++ b/charts/victoria-metrics-cluster/templates/role.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 rules:
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -8,6 +8,7 @@ printNotes: true
 
 rbac:
   create: true
+  # Note: The PSP will only be deployed, if Kubernetes (<1.25) supports the resource.
   pspEnabled: true
   namespaced: false
   extraLabels: {}

--- a/charts/victoria-metrics-operator/templates/psp.yaml
+++ b/charts/victoria-metrics-operator/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -34,6 +34,7 @@ logLevel: "info"
 rbac:
   # -- Specifies whether the RBAC resources should be created
   create: true
+  # Note: The PSP will only be deployed, if Kubernetes (<1.25) supports the resource.
   pspEnabled: true
 
 # -- Labels to be added to the all resources

--- a/charts/victoria-metrics-single/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-single/templates/clusterrole.yaml
@@ -34,7 +34,7 @@ rules:
   - nonResourceURLs: [ "/metrics" ]
     verbs: [ "get" ]
   {{- end }}
-  {{- if .Values.rbac.pspEnabled  }}
+  {{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
   - apiGroups:      ['extensions']
     resources:      ['podsecuritypolicies']
     verbs:          ['use']

--- a/charts/victoria-metrics-single/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-single/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-single/templates/role.yaml
+++ b/charts/victoria-metrics-single/templates/role.yaml
@@ -14,7 +14,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 rules:
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -4,6 +4,7 @@
 
 rbac:
   create: true
+  # Note: The PSP will only be deployed, if Kubernetes (<1.25) supports the resource.
   pspEnabled: true
   namespaced: false
   extraLabels: {}


### PR DESCRIPTION
This change will make Helm check for the presence of the `policy/v1beta1` API, before it deploys `podSecurityPolicy` resources, which are no longer supported with Kubernetes 1.25.

Fixes #390.