### PR TITLE
fix: add missing clusterrole rule for serviceendpoint discovery

### DIFF
--- a/charts/victoria-metrics-agent/README.md
+++ b/charts/victoria-metrics-agent/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Agent.
 
- ![Version: 0.8.16](https://img.shields.io/badge/Version-0.8.16-informational?style=flat-square)
+ ![Version: 0.8.18](https://img.shields.io/badge/Version-0.8.18-informational?style=flat-square)
 
 Victoria Metrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
 

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Alert.
 
- ![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)
+ ![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square)
 
 Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
 

--- a/charts/victoria-metrics-auth/README.md
+++ b/charts/victoria-metrics-auth/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Auth.
 
- ![Version: 0.2.57](https://img.shields.io/badge/Version-0.2.57-informational?style=flat-square)
+ ![Version: 0.2.59](https://img.shields.io/badge/Version-0.2.59-informational?style=flat-square)
 
 Victoria Metrics Auth - is a simple auth proxy and router for VictoriaMetrics.
 

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for Cluster Version
 
- ![Version: 0.9.37](https://img.shields.io/badge/Version-0.9.37-informational?style=flat-square)
+ ![Version: 0.9.39](https://img.shields.io/badge/Version-0.9.39-informational?style=flat-square)
 
 Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 

--- a/charts/victoria-metrics-gateway/README.md
+++ b/charts/victoria-metrics-gateway/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for vmgateway
 
- ![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square)
+ ![Version: 0.1.17](https://img.shields.io/badge/Version-0.1.17-informational?style=flat-square)
 
 Victoria Metrics Gateway - Auth & Rate-Limitting proxy for Victoria Metrics
 

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics kubernetes monitoring stack.
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![Version: 0.12.4](https://img.shields.io/badge/Version-0.12.4-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![Version: 0.12.6](https://img.shields.io/badge/Version-0.12.6-informational?style=flat-square)
 
 Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 
@@ -292,6 +292,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | defaultRules.rules.k8s | bool | `true` |  |
 | defaultRules.rules.kubeApiserver | bool | `true` |  |
 | defaultRules.rules.kubeApiserverAvailability | bool | `true` |  |
+| defaultRules.rules.kubeApiserverBurnrate | bool | `true` |  |
 | defaultRules.rules.kubeApiserverSlos | bool | `true` |  |
 | defaultRules.rules.kubePrometheusGeneral | bool | `true` |  |
 | defaultRules.rules.kubePrometheusNodeRecording | bool | `true` |  |
@@ -487,10 +488,12 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmcluster.ingress.storage.tls | list | `[]` |  |
 | vmcluster.spec.replicationFactor | int | `2` |  |
 | vmcluster.spec.retentionPeriod | string | `"14"` |  |
+| vmcluster.spec.vminsert.extraArgs | object | `{}` |  |
 | vmcluster.spec.vminsert.image.tag | string | `"v1.82.1-cluster"` |  |
 | vmcluster.spec.vminsert.replicaCount | int | `2` |  |
 | vmcluster.spec.vminsert.resources | object | `{}` |  |
 | vmcluster.spec.vmselect.cacheMountPath | string | `"/select-cache"` |  |
+| vmcluster.spec.vmselect.extraArgs | object | `{}` |  |
 | vmcluster.spec.vmselect.image.tag | string | `"v1.82.1-cluster"` |  |
 | vmcluster.spec.vmselect.replicaCount | int | `2` |  |
 | vmcluster.spec.vmselect.resources | object | `{}` |  |
@@ -500,4 +503,4 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmcluster.spec.vmstorage.resources | object | `{}` |  |
 | vmcluster.spec.vmstorage.storage.volumeClaimTemplate.spec.resources.requests.storage | string | `"10Gi"` |  |
 | vmcluster.spec.vmstorage.storageDataPath | string | `"/vm-data"` |  |
-| vmsingle | object | `{"annotations":{},"enabled":true,"ingress":{"annotations":{},"enabled":false,"extraPaths":[],"hosts":["vmsingle.domain.com"],"labels":{},"path":"/","pathType":"Prefix","tls":[]},"spec":{"image":{"tag":"v1.82.1"},"replicaCount":1,"retentionPeriod":"14","storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"20Gi"}}}}}` | Configures vmsingle params |
+| vmsingle | object | `{"annotations":{},"enabled":true,"ingress":{"annotations":{},"enabled":false,"extraPaths":[],"hosts":["vmsingle.domain.com"],"labels":{},"path":"/","pathType":"Prefix","tls":[]},"spec":{"extraArgs":{},"image":{"tag":"v1.82.1"},"replicaCount":1,"retentionPeriod":"14","storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"20Gi"}}}}}` | Configures vmsingle params |

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: 1.82.1
 description: Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.8.39
+version: 0.8.40
 sources:
 - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-single/README.md
+++ b/charts/victoria-metrics-single/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for Single Version
 
- ![Version: 0.8.37](https://img.shields.io/badge/Version-0.8.37-informational?style=flat-square)
+ ![Version: 0.8.40](https://img.shields.io/badge/Version-0.8.40-informational?style=flat-square)
 
 Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 

--- a/charts/victoria-metrics-single/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-single/templates/clusterrole.yaml
@@ -16,6 +16,11 @@ metadata:
 {{- if or .Values.rbac.pspEnabled .Values.server.scrape.enabled }}
 rules:
   {{- if .Values.server.scrape.enabled }}
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs: ["get", "list", "watch"]
   - apiGroups: [ "" ]
     resources:
       - nodes


### PR DESCRIPTION
VictoriaMetrics Single Server is unable to discover Kubernetes Service Endpoints with its current Cluster role rules. This PR addresses this problem by adding the necessary rule to the Cluster role.