### PR TITLE
removed external label

### DIFF
--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -522,8 +522,6 @@ vmagent:
     image:
       tag: v1.83.1
     scrapeInterval: 25s
-    externalLabels:
-      cluster: cluster-name
     extraArgs:
       promscrape.streamParse: "true"
   ingress:


### PR DESCRIPTION
Remove external label 'cluster' as it breaks cassandra jobs as it also has this label in its metrics. Anyway this label`s default value 'cluster-name' is useless and should be set only if needed. 