### PR TITLE
[victoria-metrics-k8s-stack]: Fix vm-cluster dashboard

### DIFF
--- a/charts/victoria-metrics-k8s-stack/hack/sync_grafana_dashboards.py
+++ b/charts/victoria-metrics-k8s-stack/hack/sync_grafana_dashboards.py
@@ -41,13 +41,13 @@ charts = [
         'type': 'json'
     },
     {
-        'source': 'https://raw.githubusercontent.com/VictoriaMetrics/VictoriaMetrics/master/dashboards/vmagent.json',
+        'name': 'victoriametrics-cluster',
+        'source': 'https://raw.githubusercontent.com/VictoriaMetrics/VictoriaMetrics/cluster/dashboards/victoriametrics-cluster.json',
         'destination': '../templates/grafana/dashboards',
         'type': 'json'
     },
     {
-        'name': 'victoriametrics-cluster',
-        'source': 'https://raw.githubusercontent.com/VictoriaMetrics/VictoriaMetrics/cluster/dashboards/victoriametrics.json',
+        'source': 'https://raw.githubusercontent.com/VictoriaMetrics/VictoriaMetrics/master/dashboards/vmagent.json',
         'destination': '../templates/grafana/dashboards',
         'type': 'json'
     },

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'victoriametrics-cluster' from https://raw.githubusercontent.com/VictoriaMetrics/VictoriaMetrics/cluster/dashboards/victoriametrics.json
+Generated from 'victoriametrics-cluster' from https://raw.githubusercontent.com/VictoriaMetrics/VictoriaMetrics/cluster/dashboards/victoriametrics-cluster.json
 Do not change in-place! In order to change this file first read following link:
 https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack/hack
 */ -}}
@@ -58,8 +58,8 @@ data:
             },
             {
                 "type": "panel",
-                "id": "text",
-                "name": "Text",
+                "id": "table",
+                "name": "Table",
                 "version": ""
             }
         ],
@@ -85,21 +85,20 @@ data:
                 }
             ]
         },
-        "description": "Overview for single node VictoriaMetrics v1.79.0 or higher",
+        "description": "Overview for cluster VictoriaMetrics v1.79.0 or higher",
         "editable": true,
         "fiscalYearStartMonth": 0,
-        "gnetId": 10229,
-        "graphTooltip": 0,
+        "graphTooltip": 1,
         "id": null,
-        "iteration": 1663928777219,
+        "iteration": 1663928613745,
         "links": [
             {
                 "icon": "doc",
                 "tags": [],
                 "targetBlank": true,
-                "title": "Single server Wiki",
+                "title": "Cluster Wiki",
                 "type": "link",
-                "url": "https://docs.victoriametrics.com/"
+                "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/wiki/Cluster-VictoriaMetrics"
             },
             {
                 "icon": "external link",
@@ -114,7 +113,6 @@ data:
                 "tags": [],
                 "targetBlank": true,
                 "title": "New releases",
-                "tooltip": "",
                 "type": "link",
                 "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/releases"
             }
@@ -122,8 +120,9 @@ data:
         "liveNow": false,
         "panels": [
             {
-                "collapsed": false,
+                "collapsed": true,
                 "datasource": {
+                    "type": "prometheus",
                     "uid": "$ds"
                 },
                 "gridPos": {
@@ -132,655 +131,754 @@ data:
                     "x": 0,
                     "y": 0
                 },
-                "id": 6,
-                "panels": [],
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Stats",
-                "type": "row"
-            },
-            {
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "description": "",
-                "gridPos": {
-                    "h": 2,
-                    "w": 4,
-                    "x": 0,
-                    "y": 1
-                },
-                "id": 85,
-                "options": {
-                    "content": "<div style=\"text-align: center;\">$version</div>",
-                    "mode": "markdown"
-                },
-                "pluginVersion": "9.0.3",
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Version",
-                "type": "text"
-            },
-            {
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "description": "How many datapoints are in storage",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [],
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                }
-                            ]
-                        },
-                        "unit": "short"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 2,
-                    "w": 5,
-                    "x": 4,
-                    "y": 1
-                },
-                "id": 26,
-                "links": [],
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "text": {},
-                    "textMode": "auto"
-                },
-                "pluginVersion": "9.0.3",
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!=\"indexdb\"})",
-                        "format": "time_series",
-                        "instant": true,
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "",
-                        "refId": "A"
-                    }
-                ],
-                "title": "Total datapoints",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "$ds"
-                },
-                "description": "Total amount of used disk space",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [],
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                }
-                            ]
-                        },
-                        "unit": "bytes"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 2,
-                    "w": 5,
-                    "x": 9,
-                    "y": 1
-                },
-                "id": 81,
-                "links": [],
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "text": {},
-                    "textMode": "auto"
-                },
-                "pluginVersion": "9.0.3",
-                "targets": [
+                "id": 137,
+                "panels": [
                     {
                         "datasource": {
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "exemplar": false,
-                        "expr": "sum(vm_data_size_bytes{job=~\"$job\"})",
-                        "format": "time_series",
-                        "instant": true,
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "",
-                        "refId": "A"
-                    }
-                ],
-                "title": "Disk space usage",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "$ds"
-                },
-                "description": "Average disk usage per datapoint.",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
+                        "description": "How many datapoints are in storage",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "thresholds"
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
                         },
-                        "mappings": [],
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                }
-                            ]
+                        "gridPos": {
+                            "h": 2,
+                            "w": 6,
+                            "x": 0,
+                            "y": 1
                         },
-                        "unit": "bytes"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 2,
-                    "w": 5,
-                    "x": 14,
-                    "y": 1
-                },
-                "id": 82,
-                "links": [],
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
+                        "id": 131,
+                        "links": [],
+                        "maxDataPoints": 100,
+                        "options": {
+                            "colorMode": "value",
+                            "graphMode": "area",
+                            "justifyMode": "auto",
+                            "orientation": "horizontal",
+                            "reduceOptions": {
+                                "calcs": [
+                                    "lastNotNull"
+                                ],
+                                "fields": "",
+                                "values": false
+                            },
+                            "text": {},
+                            "textMode": "auto"
+                        },
+                        "pluginVersion": "9.0.3",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(vm_rows{job=~\"$job_storage\", type!=\"indexdb\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A"
+                            }
                         ],
-                        "fields": "",
-                        "values": false
+                        "title": "Total datapoints",
+                        "type": "stat"
                     },
-                    "text": {},
-                    "textMode": "auto"
-                },
-                "pluginVersion": "9.0.3",
-                "targets": [
                     {
                         "datasource": {
                             "uid": "$ds"
                         },
-                        "exemplar": true,
-                        "expr": "sum(vm_data_size_bytes{job=~\"$job\"}) / sum(vm_rows{job=~\"$job\"})",
-                        "format": "time_series",
-                        "instant": true,
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "",
-                        "refId": "A"
-                    }
-                ],
-                "title": "Bytes per point",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "description": "Total size of allowed memory via flag `-memory.allowedPercent`",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
+                        "description": "The minimum free disk space left among all storage nodes.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "thresholds"
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        }
+                                    ]
+                                },
+                                "unit": "bytes"
+                            },
+                            "overrides": []
                         },
-                        "mappings": [],
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                }
-                            ]
+                        "gridPos": {
+                            "h": 2,
+                            "w": 6,
+                            "x": 6,
+                            "y": 1
                         },
-                        "unit": "bytes"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 2,
-                    "w": 5,
-                    "x": 19,
-                    "y": 1
-                },
-                "id": 79,
-                "links": [],
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
+                        "id": 124,
+                        "links": [],
+                        "maxDataPoints": 100,
+                        "options": {
+                            "colorMode": "value",
+                            "graphMode": "area",
+                            "justifyMode": "auto",
+                            "orientation": "horizontal",
+                            "reduceOptions": {
+                                "calcs": [
+                                    "lastNotNull"
+                                ],
+                                "fields": "",
+                                "values": false
+                            },
+                            "text": {},
+                            "textMode": "auto"
+                        },
+                        "pluginVersion": "9.0.3",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "min(vm_free_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A"
+                            }
                         ],
-                        "fields": "",
-                        "values": false
+                        "title": "Min free disk space",
+                        "type": "stat"
                     },
-                    "text": {},
-                    "textMode": "auto"
-                },
-                "pluginVersion": "9.0.3",
-                "targets": [
                     {
                         "datasource": {
                             "uid": "$ds"
                         },
-                        "exemplar": true,
-                        "expr": "sum(vm_allowed_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
-                        "format": "time_series",
-                        "instant": true,
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "",
-                        "refId": "A"
-                    }
-                ],
-                "title": "Allowed memory",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
+                        "description": "Average disk usage per datapoint.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "thresholds"
+                                },
+                                "decimals": 2,
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        }
+                                    ]
+                                },
+                                "unit": "bytes"
+                            },
+                            "overrides": []
                         },
-                        "mappings": [],
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
+                        "gridPos": {
+                            "h": 2,
+                            "w": 6,
+                            "x": 12,
+                            "y": 1
+                        },
+                        "id": 112,
+                        "links": [],
+                        "maxDataPoints": 100,
+                        "options": {
+                            "colorMode": "value",
+                            "graphMode": "area",
+                            "justifyMode": "auto",
+                            "orientation": "horizontal",
+                            "reduceOptions": {
+                                "calcs": [
+                                    "lastNotNull"
+                                ],
+                                "fields": "",
+                                "values": false
+                            },
+                            "text": {},
+                            "textMode": "auto"
+                        },
+                        "pluginVersion": "9.0.3",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job_storage\", type!=\"indexdb\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Bytes per point",
+                        "type": "stat"
+                    },
+                    {
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Total size of allowed memory via flag `-memory.allowedPercent` for all VM components",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "thresholds"
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        }
+                                    ]
+                                },
+                                "unit": "bytes"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 2,
+                            "w": 6,
+                            "x": 18,
+                            "y": 1
+                        },
+                        "id": 130,
+                        "links": [],
+                        "maxDataPoints": 100,
+                        "options": {
+                            "colorMode": "value",
+                            "graphMode": "area",
+                            "justifyMode": "auto",
+                            "orientation": "horizontal",
+                            "reduceOptions": {
+                                "calcs": [
+                                    "lastNotNull"
+                                ],
+                                "fields": "",
+                                "values": false
+                            },
+                            "text": {},
+                            "textMode": "auto"
+                        },
+                        "pluginVersion": "9.0.3",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(vm_allowed_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Allowed memory",
+                        "type": "stat"
+                    },
+                    {
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the number of active time series with new data points inserted during the last hour. High value may result in ingestion slowdown. \n\nSee more details here https://docs.victoriametrics.com/FAQ.html#what-is-an-active-time-series",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "thresholds"
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 2,
+                            "w": 6,
+                            "x": 0,
+                            "y": 3
+                        },
+                        "id": 34,
+                        "links": [],
+                        "maxDataPoints": 100,
+                        "options": {
+                            "colorMode": "value",
+                            "graphMode": "area",
+                            "justifyMode": "auto",
+                            "orientation": "horizontal",
+                            "reduceOptions": {
+                                "calcs": [
+                                    "lastNotNull"
+                                ],
+                                "fields": "",
+                                "values": false
+                            },
+                            "text": {},
+                            "textMode": "auto"
+                        },
+                        "pluginVersion": "9.0.3",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(vm_cache_entries{job=~\"$job\", instance=~\"$instance.*\", type=\"storage/hour_metric_ids\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Active series",
+                        "type": "stat"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Total amount of used disk space",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "thresholds"
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        }
+                                    ]
+                                },
+                                "unit": "bytes"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 2,
+                            "w": 6,
+                            "x": 6,
+                            "y": 3
+                        },
+                        "id": 35,
+                        "links": [],
+                        "maxDataPoints": 100,
+                        "options": {
+                            "colorMode": "value",
+                            "graphMode": "area",
+                            "justifyMode": "auto",
+                            "orientation": "horizontal",
+                            "reduceOptions": {
+                                "calcs": [
+                                    "lastNotNull"
+                                ],
+                                "fields": "",
+                                "values": false
+                            },
+                            "text": {},
+                            "textMode": "auto"
+                        },
+                        "pluginVersion": "9.0.3",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": false,
+                                "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Disk space usage",
+                        "type": "stat"
+                    },
+                    {
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Total number of available CPUs for all VM components. ",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "thresholds"
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 2,
+                            "w": 6,
+                            "x": 12,
+                            "y": 3
+                        },
+                        "id": 126,
+                        "links": [],
+                        "maxDataPoints": 100,
+                        "options": {
+                            "colorMode": "value",
+                            "graphMode": "area",
+                            "justifyMode": "auto",
+                            "orientation": "horizontal",
+                            "reduceOptions": {
+                                "calcs": [
+                                    "lastNotNull"
+                                ],
+                                "fields": "",
+                                "values": false
+                            },
+                            "text": {},
+                            "textMode": "auto"
+                        },
+                        "pluginVersion": "9.0.3",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(vm_available_cpu_cores{job=~\"$job\", instance=~\"$instance\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Available CPU",
+                        "type": "stat"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Total size of available memory for all VM components.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "thresholds"
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        }
+                                    ]
+                                },
+                                "unit": "bytes"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 2,
+                            "w": 6,
+                            "x": 18,
+                            "y": 3
+                        },
+                        "id": 128,
+                        "links": [],
+                        "maxDataPoints": 100,
+                        "options": {
+                            "colorMode": "value",
+                            "graphMode": "area",
+                            "justifyMode": "auto",
+                            "orientation": "horizontal",
+                            "reduceOptions": {
+                                "calcs": [
+                                    "lastNotNull"
+                                ],
+                                "fields": "",
+                                "values": false
+                            },
+                            "text": {},
+                            "textMode": "auto"
+                        },
+                        "pluginVersion": "9.0.3",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(vm_available_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Available memory",
+                        "type": "stat"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "thresholds"
+                                },
+                                "custom": {
+                                    "align": "auto",
+                                    "displayMode": "auto",
+                                    "inspect": false,
+                                    "minWidth": 50
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                }
+                            },
+                            "overrides": [
                                 {
-                                    "color": "red",
-                                    "value": null
+                                    "matcher": {
+                                        "id": "byName",
+                                        "options": "Time"
+                                    },
+                                    "properties": [
+                                        {
+                                            "id": "custom.hidden",
+                                            "value": true
+                                        }
+                                    ]
                                 },
                                 {
-                                    "color": "green",
-                                    "value": 1800
+                                    "matcher": {
+                                        "id": "byName",
+                                        "options": "Value"
+                                    },
+                                    "properties": [
+                                        {
+                                            "id": "displayName",
+                                            "value": "Count"
+                                        }
+                                    ]
                                 }
                             ]
                         },
-                        "unit": "s"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 2,
-                    "w": 4,
-                    "x": 0,
-                    "y": 3
-                },
-                "id": 87,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "auto",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "text": {},
-                    "textMode": "auto"
-                },
-                "pluginVersion": "9.0.3",
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
+                        "gridPos": {
+                            "h": 5,
+                            "w": 8,
+                            "x": 0,
+                            "y": 5
                         },
-                        "exemplar": true,
-                        "expr": "vm_app_uptime_seconds{job=~\"$job\", instance=~\"$instance\"}",
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "A"
-                    }
-                ],
-                "title": "Uptime",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "description": "Shows the number of active time series with new data points inserted during the last hour. High value may result in ingestion slowdown. \n\nSee more details here https://docs.victoriametrics.com/FAQ.html#what-is-an-active-time-series",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
+                        "id": 149,
+                        "options": {
+                            "footer": {
+                                "fields": "",
+                                "reducer": [
+                                    "sum"
+                                ],
+                                "show": false
+                            },
+                            "showHeader": true
                         },
-                        "mappings": [],
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                }
-                            ]
-                        },
-                        "unit": "short"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 2,
-                    "w": 5,
-                    "x": 4,
-                    "y": 3
-                },
-                "id": 38,
-                "links": [],
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "text": {},
-                    "textMode": "auto"
-                },
-                "pluginVersion": "9.0.3",
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "exemplar": true,
-                        "expr": "vm_cache_entries{job=~\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"}",
-                        "format": "time_series",
-                        "instant": true,
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "",
-                        "refId": "A"
-                    }
-                ],
-                "title": "Active series",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "description": "The minimum free disk space left",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [],
-                        "thresholds": {
-                            "mode": "percentage",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                }
-                            ]
-                        },
-                        "unit": "bytes"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 2,
-                    "w": 5,
-                    "x": 9,
-                    "y": 3
-                },
-                "id": 80,
-                "links": [],
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "text": {},
-                    "textMode": "auto"
-                },
-                "pluginVersion": "9.0.3",
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "exemplar": true,
-                        "expr": "min(vm_free_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"})",
-                        "format": "time_series",
-                        "instant": true,
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "",
-                        "refId": "A"
-                    }
-                ],
-                "title": "Min free disk space",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "description": "Total number of available CPUs for VM process",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "mappings": [],
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
+                        "pluginVersion": "9.0.3",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
                                 },
-                                {
-                                    "color": "red",
-                                    "value": 80
-                                }
-                            ]
-                        },
-                        "unit": "short"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 2,
-                    "w": 5,
-                    "x": 14,
-                    "y": 3
-                },
-                "id": 77,
-                "links": [],
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
+                                "editorMode": "code",
+                                "exemplar": false,
+                                "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(job, short_version)",
+                                "format": "table",
+                                "instant": true,
+                                "range": false,
+                                "refId": "A"
+                            }
                         ],
-                        "fields": "",
-                        "values": false
+                        "type": "table"
                     },
-                    "text": {},
-                    "textMode": "auto"
-                },
-                "pluginVersion": "9.0.3",
-                "targets": [
                     {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
                         "datasource": {
                             "uid": "$ds"
                         },
-                        "exemplar": true,
-                        "expr": "sum(vm_available_cpu_cores{job=~\"$job\", instance=~\"$instance\"})",
-                        "format": "time_series",
-                        "instant": true,
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "",
-                        "refId": "A"
-                    }
-                ],
-                "title": "Available CPU",
-                "type": "stat"
-            },
-            {
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "description": "Total size of available memory for VM process",
-                "fieldConfig": {
-                    "defaults": {
-                        "color": {
-                            "mode": "thresholds"
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
                         },
-                        "mappings": [],
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "green",
-                                    "value": null
-                                }
-                            ]
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 5,
+                            "w": 16,
+                            "x": 8,
+                            "y": 5
                         },
-                        "unit": "bytes"
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 2,
-                    "w": 5,
-                    "x": 19,
-                    "y": 3
-                },
-                "id": 78,
-                "links": [],
-                "maxDataPoints": 100,
-                "options": {
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "orientation": "horizontal",
-                    "reduceOptions": {
-                        "calcs": [
-                            "lastNotNull"
+                        "hiddenSeries": false,
+                        "id": 62,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": false,
+                            "current": true,
+                            "hideEmpty": false,
+                            "hideZero": false,
+                            "max": false,
+                            "min": false,
+                            "rightSide": true,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": false,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": true,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sort(sum(up{job=~\"$job\", instance=~\"$instance\"}) by (job, instance))",
+                                "format": "time_series",
+                                "instant": false,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}({{`{{`}}job{{`}}`}})",
+                                "refId": "A"
+                            }
                         ],
-                        "fields": "",
-                        "values": false
-                    },
-                    "text": {},
-                    "textMode": "auto"
-                },
-                "pluginVersion": "9.0.3",
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Uptime",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 1,
+                            "value_type": "individual"
                         },
-                        "exemplar": true,
-                        "expr": "sum(vm_available_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
-                        "format": "time_series",
-                        "instant": true,
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "",
-                        "refId": "A"
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:1177",
+                                "decimals": 0,
+                                "format": "none",
+                                "logBase": 1,
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:1178",
+                                "format": "short",
+                                "label": "",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false,
+                            "alignLevel": 2
+                        }
                     }
                 ],
-                "title": "Available memory",
-                "type": "stat"
+                "title": "Stats",
+                "type": "row"
             },
             {
                 "collapsed": false,
@@ -791,19 +889,11 @@ data:
                     "h": 1,
                     "w": 24,
                     "x": 0,
-                    "y": 5
+                    "y": 1
                 },
-                "id": 24,
+                "id": 10,
                 "panels": [],
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Performance",
+                "title": "Overview",
                 "type": "row"
             },
             {
@@ -814,204 +904,7 @@ data:
                 "datasource": {
                     "uid": "$ds"
                 },
-                "description": "* `*` - unsupported query path\n* `/write` - insert into VM\n* `/metrics` - query VM system metrics\n* `/query` - query instant values\n* `/query_range` - query over a range of time\n* `/series` - match a certain label set\n* `/label/{}/values` - query a list of label values (variables mostly)",
-                "fieldConfig": {
-                    "defaults": {
-                        "links": []
-                    },
-                    "overrides": []
-                },
-                "fill": 0,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 8,
-                    "w": 12,
-                    "x": 0,
-                    "y": 6
-                },
-                "hiddenSeries": false,
-                "id": 12,
-                "legend": {
-                    "alignAsTable": true,
-                    "avg": true,
-                    "current": true,
-                    "max": true,
-                    "min": false,
-                    "show": true,
-                    "sort": "current",
-                    "sortDesc": true,
-                    "total": false,
-                    "values": true
-                },
-                "lines": true,
-                "linewidth": 1,
-                "links": [],
-                "nullPointMode": "null as zero",
-                "options": {
-                    "alertThreshold": true
-                },
-                "percentage": false,
-                "pluginVersion": "9.0.3",
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance\", path!~\"/favicon.ico\"}[$__interval])) by (path) > 0",
-                        "format": "time_series",
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "{{`{{`}}path{{`}}`}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeRegions": [],
-                "title": "Requests rate ($instance)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 2,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "mode": "time",
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "$$hashKey": "object:758",
-                        "format": "short",
-                        "logBase": 1,
-                        "min": "0",
-                        "show": true
-                    },
-                    {
-                        "$$hashKey": "object:759",
-                        "format": "short",
-                        "logBase": 1,
-                        "min": "0",
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "description": "The less time it takes is better.\n* `*` - unsupported query path\n* `/write` - insert into VM\n* `/metrics` - query VM system metrics\n* `/query` - query instant values\n* `/query_range` - query over a range of time\n* `/series` - match a certain label set\n* `/label/{}/values` - query a list of label values (variables mostly)",
-                "fieldConfig": {
-                    "defaults": {
-                        "links": []
-                    },
-                    "overrides": []
-                },
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 8,
-                    "w": 12,
-                    "x": 12,
-                    "y": 6
-                },
-                "hiddenSeries": false,
-                "id": 22,
-                "legend": {
-                    "alignAsTable": true,
-                    "avg": true,
-                    "current": true,
-                    "max": true,
-                    "min": false,
-                    "show": true,
-                    "sort": "current",
-                    "sortDesc": true,
-                    "total": false,
-                    "values": true
-                },
-                "lines": true,
-                "linewidth": 1,
-                "links": [],
-                "nullPointMode": "null as zero",
-                "options": {
-                    "alertThreshold": true
-                },
-                "percentage": false,
-                "pluginVersion": "9.0.3",
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "expr": "max(vm_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=~\"(0.5|0.99)\"}) by (path, quantile) > 0",
-                        "format": "time_series",
-                        "intervalFactor": 1,
-                        "legendFormat": "{{`{{`}}quantile{{`}}`}} ({{`{{`}}path{{`}}`}})",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeRegions": [],
-                "title": "Query duration ($instance)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 2,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "mode": "time",
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "format": "s",
-                        "logBase": 1,
-                        "min": "0",
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "logBase": 1,
-                        "min": "0",
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "description": "Shows the number of active time series with new data points inserted during the last hour. High value may result in ingestion slowdown. \n\nSee following link for details:",
+                "description": "How many datapoints are inserted into storage per second by protocol and accountID",
                 "fieldConfig": {
                     "defaults": {
                         "links": []
@@ -1024,10 +917,10 @@ data:
                     "h": 8,
                     "w": 12,
                     "x": 0,
-                    "y": 14
+                    "y": 2
                 },
                 "hiddenSeries": false,
-                "id": 51,
+                "id": 2,
                 "legend": {
                     "alignAsTable": true,
                     "avg": true,
@@ -1042,13 +935,6 @@ data:
                 },
                 "lines": true,
                 "linewidth": 1,
-                "links": [
-                    {
-                        "targetBlank": true,
-                        "title": "troubleshooting",
-                        "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/README.md#troubleshooting"
-                    }
-                ],
                 "nullPointMode": "null",
                 "options": {
                     "alertThreshold": true
@@ -1060,23 +946,24 @@ data:
                 "renderer": "flot",
                 "seriesOverrides": [],
                 "spaceLength": 10,
-                "stack": false,
+                "stack": true,
                 "steppedLine": false,
                 "targets": [
                     {
                         "datasource": {
+                            "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "expr": "vm_cache_entries{job=~\"$job\", instance=~\"$instance\", type=\"storage/hour_metric_ids\"}",
-                        "format": "time_series",
-                        "intervalFactor": 1,
-                        "legendFormat": "Active time series",
+                        "exemplar": true,
+                        "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type,accountID) > 0 ",
+                        "interval": "",
+                        "legendFormat": "{{`{{`}}type{{`}}`}}",
                         "refId": "A"
                     }
                 ],
                 "thresholds": [],
                 "timeRegions": [],
-                "title": "Active time series ($instance)",
+                "title": "Datapoints ingestion rate ($instance)",
                 "tooltip": {
                     "shared": true,
                     "sort": 0,
@@ -1121,21 +1008,21 @@ data:
                     },
                     "overrides": []
                 },
-                "fill": 1,
+                "fill": 0,
                 "fillGradient": 0,
                 "gridPos": {
                     "h": 8,
                     "w": 12,
                     "x": 12,
-                    "y": 14
+                    "y": 2
                 },
                 "hiddenSeries": false,
-                "id": 35,
+                "id": 6,
                 "legend": {
                     "alignAsTable": true,
                     "avg": true,
                     "current": true,
-                    "max": false,
+                    "max": true,
                     "min": false,
                     "show": true,
                     "sort": "current",
@@ -1162,12 +1049,111 @@ data:
                 "targets": [
                     {
                         "datasource": {
+                            "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "exemplar": false,
-                        "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by (path) > 0",
+                        "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance.*\", path!~\"/favicon.ico\"}[$__rate_interval])) by (path) > 0",
                         "format": "time_series",
-                        "interval": "",
+                        "intervalFactor": 1,
+                        "legendFormat": "{{`{{`}}path{{`}}`}}",
+                        "refId": "A"
+                    }
+                ],
+                "thresholds": [],
+                "timeRegions": [],
+                "title": "Requests rate ($instance)",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 2,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "mode": "time",
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [
+                    {
+                        "$$hashKey": "object:3307",
+                        "format": "short",
+                        "logBase": 1,
+                        "min": "0",
+                        "show": true
+                    },
+                    {
+                        "$$hashKey": "object:3308",
+                        "format": "short",
+                        "logBase": 1,
+                        "min": "0",
+                        "show": true
+                    }
+                ],
+                "yaxis": {
+                    "align": false
+                }
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                    "uid": "$ds"
+                },
+                "description": "* `*` - unsupported query path\n* `/write` - insert into VM\n* `/metrics` - query VM system metrics\n* `/query` - query instant values\n* `/query_range` - query over a range of time\n* `/series` - match a certain label set\n* `/label/{}/values` - query a list of label values (variables mostly)",
+                "fieldConfig": {
+                    "defaults": {
+                        "links": []
+                    },
+                    "overrides": []
+                },
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": {
+                    "h": 8,
+                    "w": 12,
+                    "x": 0,
+                    "y": 10
+                },
+                "hiddenSeries": false,
+                "id": 52,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": true,
+                    "current": true,
+                    "max": true,
+                    "min": false,
+                    "show": true,
+                    "sort": "current",
+                    "sortDesc": true,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null as zero",
+                "options": {
+                    "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "9.0.3",
+                "pointradius": 2,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance.*\"}[$__rate_interval])) by (path) > 0",
+                        "format": "time_series",
                         "intervalFactor": 1,
                         "legendFormat": "{{`{{`}}path{{`}}`}}",
                         "refId": "A"
@@ -1213,30 +1199,128 @@ data:
                 "datasource": {
                     "uid": "$ds"
                 },
-                "description": "Shows how many ongoing insertions (not API /write calls) on disk are taking place, where:\n* `max` - equal to number of CPUs;\n* `current` - current number of goroutines busy with inserting rows into underlying storage.\n\nEvery successful API /write call results into flush on disk. However, these two actions are separated and controlled via different concurrency limiters. The `max` on this panel can't be changed and always equal to number of CPUs. \n\nWhen `current` hits `max` constantly, it means storage is overloaded and requires more CPU.\n\n",
+                "description": "The less time it takes is better.\n* `*` - unsupported query path\n* `/write` - insert into VM\n* `/metrics` - query VM system metrics\n* `/query` - query instant values\n* `/query_range` - query over a range of time\n* `/series` - match a certain label set\n* `/label/{}/values` - query a list of label values (variables mostly)",
                 "fieldConfig": {
                     "defaults": {
                         "links": []
                     },
                     "overrides": []
                 },
-                "fill": 0,
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": {
+                    "h": 8,
+                    "w": 12,
+                    "x": 12,
+                    "y": 10
+                },
+                "hiddenSeries": false,
+                "id": 8,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": true,
+                    "current": true,
+                    "max": true,
+                    "min": false,
+                    "show": true,
+                    "sort": "current",
+                    "sortDesc": true,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null as zero",
+                "options": {
+                    "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "9.0.3",
+                "pointradius": 2,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "expr": "max(vm_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=~\"(0.5|0.99)\"}) by (path, quantile) > 0",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "{{`{{`}}quantile{{`}}`}} ({{`{{`}}path{{`}}`}})",
+                        "refId": "A"
+                    }
+                ],
+                "thresholds": [],
+                "timeRegions": [],
+                "title": "Query duration ($instance)",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 2,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "mode": "time",
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [
+                    {
+                        "$$hashKey": "object:423",
+                        "format": "s",
+                        "logBase": 1,
+                        "min": "0",
+                        "show": true
+                    },
+                    {
+                        "$$hashKey": "object:424",
+                        "format": "short",
+                        "logBase": 1,
+                        "min": "0",
+                        "show": true
+                    }
+                ],
+                "yaxis": {
+                    "align": false
+                }
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                    "uid": "$ds"
+                },
+                "description": "RPC errors are interconnection errors between cluster components. Errors rate should be 0 if network connection is stable and all components are up and operational.",
+                "fieldConfig": {
+                    "defaults": {
+                        "links": []
+                    },
+                    "overrides": []
+                },
+                "fill": 1,
                 "fillGradient": 0,
                 "gridPos": {
                     "h": 8,
                     "w": 12,
                     "x": 0,
-                    "y": 22
+                    "y": 18
                 },
                 "hiddenSeries": false,
-                "id": 59,
+                "id": 44,
                 "legend": {
                     "alignAsTable": true,
                     "avg": true,
                     "current": true,
-                    "hideEmpty": false,
-                    "hideZero": false,
-                    "max": false,
+                    "max": true,
                     "min": false,
                     "show": true,
                     "sort": "current",
@@ -1253,48 +1337,54 @@ data:
                 },
                 "percentage": false,
                 "pluginVersion": "9.0.3",
-                "pointradius": 2,
+                "pointradius": 1,
                 "points": false,
                 "renderer": "flot",
-                "seriesOverrides": [
-                    {
-                        "$$hashKey": "object:840",
-                        "alias": "max",
-                        "color": "#C4162A"
-                    }
-                ],
+                "seriesOverrides": [],
                 "spaceLength": 10,
                 "stack": false,
                 "steppedLine": false,
                 "targets": [
                     {
                         "datasource": {
+                            "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "expr": "sum(vm_concurrent_addrows_capacity{job=~\"$job\", instance=~\"$instance\"})",
+                        "expr": "sum(rate(vm_rpc_connection_errors_total{job=~\"$job\",instance=~\"$instance.*\"}[$__rate_interval]))",
                         "format": "time_series",
-                        "interval": "",
                         "intervalFactor": 1,
-                        "legendFormat": "max",
+                        "legendFormat": "Connection",
                         "refId": "A"
                     },
                     {
                         "datasource": {
+                            "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "expr": "sum(vm_concurrent_addrows_current{job=~\"$job\", instance=~\"$instance\"})",
+                        "expr": "sum(rate(vm_rpc_dial_errors_total{job=~\"$job\",instance=~\"$instance.*\"}[$__rate_interval]))",
                         "format": "time_series",
                         "intervalFactor": 1,
-                        "legendFormat": "current",
+                        "legendFormat": "Dial",
                         "refId": "B"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "expr": "sum(rate(vm_rpc_handshake_errors_total{job=~\"$job\",instance=~\"$instance.*\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "Handshake",
+                        "refId": "E"
                     }
                 ],
                 "thresholds": [],
                 "timeRegions": [],
-                "title": "Concurrent flushes on disk ($instance)",
+                "title": "RPC errors ($instance)",
                 "tooltip": {
                     "shared": true,
-                    "sort": 2,
+                    "sort": 0,
                     "value_type": "individual"
                 },
                 "type": "graph",
@@ -1305,16 +1395,12 @@ data:
                 },
                 "yaxes": [
                     {
-                        "$$hashKey": "object:425",
-                        "decimals": 0,
-                        "format": "short",
+                        "format": "rps",
                         "logBase": 1,
                         "min": "0",
                         "show": true
                     },
                     {
-                        "$$hashKey": "object:426",
-                        "decimals": 0,
                         "format": "short",
                         "logBase": 1,
                         "min": "0",
@@ -1327,30 +1413,30 @@ data:
             },
             {
                 "aliasColors": {},
-                "bars": false,
+                "bars": true,
                 "dashLength": 10,
                 "dashes": false,
                 "datasource": {
                     "type": "prometheus",
                     "uid": "$ds"
                 },
-                "description": "99th percentile of number of raw samples read per query.",
+                "description": "Shows the rate of logging the messages by their level. Unexpected spike in rate is a good reason to check logs.",
                 "fieldConfig": {
                     "defaults": {
                         "links": []
                     },
                     "overrides": []
                 },
-                "fill": 0,
+                "fill": 1,
                 "fillGradient": 0,
                 "gridPos": {
                     "h": 8,
                     "w": 12,
                     "x": 12,
-                    "y": 22
+                    "y": 18
                 },
                 "hiddenSeries": false,
-                "id": 101,
+                "id": 104,
                 "legend": {
                     "alignAsTable": true,
                     "avg": true,
@@ -1363,319 +1449,10 @@ data:
                     "total": false,
                     "values": true
                 },
-                "lines": true,
+                "lines": false,
                 "linewidth": 1,
                 "links": [],
-                "nullPointMode": "null as zero",
-                "options": {
-                    "alertThreshold": true
-                },
-                "percentage": false,
-                "pluginVersion": "9.0.3",
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "$ds"
-                        },
-                        "expr": "histogram_quantile(0.99, sum(rate(vm_rows_read_per_query_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (vmrange))",
-                        "format": "time_series",
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "{{`{{`}}instance{{`}}`}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeRegions": [],
-                "title": "Rows read per query ($instance)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 2,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "mode": "time",
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "$$hashKey": "object:2848",
-                        "decimals": 2,
-                        "format": "short",
-                        "logBase": 1,
-                        "min": "0",
-                        "show": true
-                    },
-                    {
-                        "$$hashKey": "object:2849",
-                        "format": "short",
-                        "logBase": 1,
-                        "min": "0",
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "$ds"
-                },
-                "description": "99th percentile of number of series read per query.",
-                "fieldConfig": {
-                    "defaults": {
-                        "links": []
-                    },
-                    "overrides": []
-                },
-                "fill": 0,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 8,
-                    "w": 12,
-                    "x": 0,
-                    "y": 30
-                },
-                "hiddenSeries": false,
-                "id": 99,
-                "legend": {
-                    "alignAsTable": true,
-                    "avg": true,
-                    "current": true,
-                    "max": true,
-                    "min": false,
-                    "show": true,
-                    "sort": "current",
-                    "sortDesc": true,
-                    "total": false,
-                    "values": true
-                },
-                "lines": true,
-                "linewidth": 1,
-                "links": [],
-                "nullPointMode": "null as zero",
-                "options": {
-                    "alertThreshold": true
-                },
-                "percentage": false,
-                "pluginVersion": "9.0.3",
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "$ds"
-                        },
-                        "expr": "histogram_quantile(0.99, sum(rate(vm_series_read_per_query_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (vmrange))",
-                        "format": "time_series",
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "{{`{{`}}instance{{`}}`}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeRegions": [],
-                "title": "Series read per query ($instance)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 2,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "mode": "time",
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "$$hashKey": "object:2848",
-                        "decimals": 2,
-                        "format": "short",
-                        "logBase": 1,
-                        "min": "0",
-                        "show": true
-                    },
-                    {
-                        "$$hashKey": "object:2849",
-                        "format": "short",
-                        "logBase": 1,
-                        "min": "0",
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "$ds"
-                },
-                "description": "99th percentile of number of raw samples scanner per query.\n\nThis number can exceed number of RowsReadPerQuery if `step` query arg passed to [/api/v1/query_range](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) is smaller than the lookbehind window set in square brackets of [rollup function](https://docs.victoriametrics.com/MetricsQL.html#rollup-functions). For example, if `increase(some_metric[1h])` is executed with the `step=5m`, then the same raw samples on a hour time range are scanned `1h/5m=12` times. See [this article](https://valyala.medium.com/how-to-optimize-promql-and-metricsql-queries-85a1b75bf986) for details.",
-                "fieldConfig": {
-                    "defaults": {
-                        "links": []
-                    },
-                    "overrides": []
-                },
-                "fill": 0,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 8,
-                    "w": 12,
-                    "x": 12,
-                    "y": 30
-                },
-                "hiddenSeries": false,
-                "id": 105,
-                "legend": {
-                    "alignAsTable": true,
-                    "avg": true,
-                    "current": true,
-                    "max": true,
-                    "min": false,
-                    "show": true,
-                    "sort": "current",
-                    "sortDesc": true,
-                    "total": false,
-                    "values": true
-                },
-                "lines": true,
-                "linewidth": 1,
-                "links": [],
-                "nullPointMode": "null as zero",
-                "options": {
-                    "alertThreshold": true
-                },
-                "percentage": false,
-                "pluginVersion": "9.0.3",
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "$ds"
-                        },
-                        "expr": "histogram_quantile(0.99, sum(rate(vm_rows_scanned_per_query_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (vmrange))",
-                        "format": "time_series",
-                        "interval": "",
-                        "intervalFactor": 1,
-                        "legendFormat": "{{`{{`}}instance{{`}}`}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeRegions": [],
-                "title": "Rows scanned per series ($instance)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 2,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "mode": "time",
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "$$hashKey": "object:2848",
-                        "decimals": 2,
-                        "format": "short",
-                        "logBase": 1,
-                        "min": "0",
-                        "show": true
-                    },
-                    {
-                        "$$hashKey": "object:2849",
-                        "format": "short",
-                        "logBase": 1,
-                        "min": "0",
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "$ds"
-                },
-                "description": "99th percentile of number of raw samples read per queried series.",
-                "fieldConfig": {
-                    "defaults": {
-                        "links": []
-                    },
-                    "overrides": []
-                },
-                "fill": 0,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 8,
-                    "w": 12,
-                    "x": 0,
-                    "y": 38
-                },
-                "hiddenSeries": false,
-                "id": 103,
-                "legend": {
-                    "alignAsTable": true,
-                    "avg": true,
-                    "current": true,
-                    "max": true,
-                    "min": false,
-                    "show": true,
-                    "sort": "current",
-                    "sortDesc": true,
-                    "total": false,
-                    "values": true
-                },
-                "lines": true,
-                "linewidth": 1,
-                "links": [],
-                "nullPointMode": "null as zero",
+                "nullPointMode": "null",
                 "options": {
                     "alertThreshold": true
                 },
@@ -1695,18 +1472,20 @@ data:
                             "uid": "$ds"
                         },
                         "editorMode": "code",
-                        "expr": "histogram_quantile(0.99, sum(rate(vm_rows_read_per_series_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (vmrange))",
+                        "exemplar": true,
+                        "expr": "sum(rate(vm_log_messages_total{job=~\"$job\",instance=~\"$instance.*\", level!=\"info\"}[$__rate_interval])) by (job, level) > 0",
                         "format": "time_series",
-                        "interval": "",
+                        "hide": false,
+                        "interval": "5m",
                         "intervalFactor": 1,
-                        "legendFormat": "{{`{{`}}label_name{{`}}`}}",
+                        "legendFormat": "{{`{{`}}job{{`}}`}} - {{`{{`}}level{{`}}`}}",
                         "range": true,
                         "refId": "A"
                     }
                 ],
                 "thresholds": [],
                 "timeRegions": [],
-                "title": "Rows read per series ($instance)",
+                "title": "Logging rate",
                 "tooltip": {
                     "shared": true,
                     "sort": 2,
@@ -1720,15 +1499,228 @@ data:
                 },
                 "yaxes": [
                     {
-                        "$$hashKey": "object:2848",
-                        "decimals": 2,
+                        "$$hashKey": "object:78",
                         "format": "short",
                         "logBase": 1,
                         "min": "0",
                         "show": true
                     },
                     {
-                        "$$hashKey": "object:2849",
+                        "$$hashKey": "object:79",
+                        "format": "short",
+                        "logBase": 1,
+                        "show": true
+                    }
+                ],
+                "yaxis": {
+                    "align": false
+                }
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                    "uid": "$ds"
+                },
+                "description": "Shows the percentage of remaining disk space at `-storageDataPath` by instance",
+                "fieldConfig": {
+                    "defaults": {
+                        "links": []
+                    },
+                    "overrides": []
+                },
+                "fill": 0,
+                "fillGradient": 0,
+                "gridPos": {
+                    "h": 8,
+                    "w": 12,
+                    "x": 0,
+                    "y": 26
+                },
+                "hiddenSeries": false,
+                "id": 110,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": true,
+                    "current": true,
+                    "max": true,
+                    "min": false,
+                    "show": true,
+                    "sort": "current",
+                    "sortDesc": true,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "options": {
+                    "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "9.0.3",
+                "pointradius": 2,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "exemplar": true,
+                        "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) by(instance) /\n(\n  sum(vm_free_disk_space_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) by(instance) +\n  sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) by(instance)\n)",
+                        "format": "time_series",
+                        "interval": "",
+                        "intervalFactor": 1,
+                        "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                        "refId": "A"
+                    }
+                ],
+                "thresholds": [
+                    {
+                        "$$hashKey": "object:89",
+                        "colorMode": "critical",
+                        "fill": true,
+                        "line": true,
+                        "op": "gt",
+                        "value": 0.8,
+                        "yaxis": "left"
+                    }
+                ],
+                "timeRegions": [],
+                "title": "Disk space used ($instance)",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "mode": "time",
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [
+                    {
+                        "format": "percentunit",
+                        "logBase": 1,
+                        "min": "0",
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "logBase": 1,
+                        "show": true
+                    }
+                ],
+                "yaxis": {
+                    "align": false
+                }
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                    "uid": "$ds"
+                },
+                "description": "Shows the number of active time series with new data points inserted during the last hour. High value may result in ingestion slowdown. \n\nSee following link for details:",
+                "fieldConfig": {
+                    "defaults": {
+                        "links": []
+                    },
+                    "overrides": []
+                },
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": {
+                    "h": 8,
+                    "w": 12,
+                    "x": 12,
+                    "y": 26
+                },
+                "hiddenSeries": false,
+                "id": 12,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": true,
+                    "current": true,
+                    "max": true,
+                    "min": false,
+                    "show": true,
+                    "sort": "current",
+                    "sortDesc": true,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [
+                    {
+                        "targetBlank": true,
+                        "title": "troubleshooting",
+                        "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/README.md#troubleshooting"
+                    }
+                ],
+                "nullPointMode": "null",
+                "options": {
+                    "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "9.0.3",
+                "pointradius": 2,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "expr": "sum(vm_cache_entries{job=~\"$job\", instance=~\"$instance.*\", type=\"storage/hour_metric_ids\"})",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "Active time series",
+                        "refId": "A"
+                    }
+                ],
+                "thresholds": [],
+                "timeRegions": [],
+                "title": "Active time series ($instance)",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "mode": "time",
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [
+                    {
+                        "$$hashKey": "object:253",
+                        "format": "short",
+                        "logBase": 1,
+                        "min": "0",
+                        "show": true
+                    },
+                    {
+                        "$$hashKey": "object:254",
                         "format": "short",
                         "logBase": 1,
                         "min": "0",
@@ -1742,17 +1734,113 @@ data:
             {
                 "collapsed": true,
                 "datasource": {
-                    "type": "prometheus",
-                    "uid": "P4169E866C3094E38"
+                    "uid": "$ds"
                 },
                 "gridPos": {
                     "h": 1,
                     "w": 24,
                     "x": 0,
-                    "y": 46
+                    "y": 34
                 },
-                "id": 92,
+                "id": 46,
                 "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Amount of used memory (resident)\nContains memory share which can be freed by OS when needed.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 3
+                        },
+                        "hiddenSeries": false,
+                        "id": 66,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"}) by (job, instance)",
+                                "interval": "",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} ({{`{{`}}job{{`}}`}})",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "RSS memory usage ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
                     {
                         "aliasColors": {},
                         "bars": false,
@@ -1762,24 +1850,1067 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "VictoriaMetrics stores various caches in RAM. Memory size for these caches may be limited with -`memory.allowedPercent` flag. Line `max allowed` shows max allowed memory size for cache.",
-                        "fill": 1,
+                        "description": "RSS share for memory allocated by the process itself. This share cannot be freed by the OS, so it must be taken into account by OOM killer.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
                         "fillGradient": 0,
                         "gridPos": {
                             "h": 8,
-                            "w": 24,
-                            "x": 0,
-                            "y": 31
+                            "w": 12,
+                            "x": 12,
+                            "y": 3
                         },
                         "hiddenSeries": false,
-                        "id": 94,
+                        "id": 138,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
                             "current": true,
-                            "max": false,
+                            "max": true,
                             "min": false,
-                            "rightSide": true,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"}) by (job, instance)",
+                                "interval": "",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} ({{`{{`}}job{{`}}`}})",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "RSS anonymous memory usage ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:271",
+                                "format": "bytes",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:272",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 11
+                        },
+                        "hiddenSeries": false,
+                        "id": 64,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} ({{`{{`}}job{{`}}`}})",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "CPU ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the CPU usage in the percentage from the limit.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 11
+                        },
+                        "hiddenSeries": false,
+                        "id": 146,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": false,
+                                "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance) / sum(process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} ({{`{{`}}job{{`}}`}})",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [
+                            {
+                                "$$hashKey": "object:195",
+                                "colorMode": "critical",
+                                "fill": true,
+                                "line": true,
+                                "op": "gt",
+                                "value": 0.9,
+                                "yaxis": "left"
+                            }
+                        ],
+                        "timeRegions": [],
+                        "title": "CPU percentage ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:75",
+                                "format": "percentunit",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:76",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Panel shows the number of open file descriptors in the OS.\nReaching the limit of open files can cause various issues and must be prevented.\n\nSee how to change limits here https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 19
+                        },
+                        "hiddenSeries": false,
+                        "id": 117,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": false,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "/max.*/",
+                                "color": "#C4162A"
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(process_open_fds{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} ({{`{{`}}job{{`}}`}})",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(process_max_fds{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "max {{`{{`}}instance{{`}}`}} ({{`{{`}}job{{`}}`}})",
+                                "refId": "B"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Open FDs ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "decimals": 0,
+                                "format": "short",
+                                "logBase": 2,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Shows average GC duration by instance",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 19
+                        },
+                        "hiddenSeries": false,
+                        "id": 72,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(rate(go_gc_duration_seconds_sum{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)\n/\nsum(rate(go_gc_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} ({{`{{`}}job{{`}}`}})",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "GC duration ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "s",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 27
+                        },
+                        "hiddenSeries": false,
+                        "id": 68,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(go_goroutines{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} ({{`{{`}}job{{`}}`}})",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Goroutines ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "decimals": 0,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the number of bytes read/write from the storage layer.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 27
+                        },
+                        "hiddenSeries": false,
+                        "id": 122,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "$$hashKey": "object:331",
+                                "alias": "/read .*/",
+                                "transform": "negative-Y"
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
+                                "format": "time_series",
+                                "hide": false,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "read {{`{{`}}instance{{`}}`}}",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
+                                "format": "time_series",
+                                "hide": false,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "write {{`{{`}}instance{{`}}`}}",
+                                "refId": "B"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Disk writes/reads ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:338",
+                                "format": "bytes",
+                                "logBase": 1,
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:339",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 35
+                        },
+                        "hiddenSeries": false,
+                        "id": 70,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(process_num_threads{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} ({{`{{`}}job{{`}}`}})",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Threads ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "decimals": 0,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 35
+                        },
+                        "hiddenSeries": false,
+                        "id": 119,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}) by(job, instance)",
+                                "interval": "",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} ({{`{{`}}job{{`}}`}})",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "TCP connections ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 43
+                        },
+                        "hiddenSeries": false,
+                        "id": 120,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(rate(vm_tcplistener_accepts_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)",
+                                "interval": "",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} ({{`{{`}}job{{`}}`}})",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "TCP connections rate ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    }
+                ],
+                "title": "Resource usage ($job)",
+                "type": "row"
+            },
+            {
+                "collapsed": true,
+                "datasource": {
+                    "uid": "$ds"
+                },
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 35
+                },
+                "id": 106,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the rate and total number of new series created over last 24h.\n\nHigh churn rate tightly connected with database performance and may result in unexpected OOM's or slow queries. It is recommended to always keep an eye on this metric to avoid unexpected cardinality \"explosions\".\n\nThe higher churn rate is, the more resources required to handle it. Consider to keep the churn rate as low as possible.\n\nTo investigate stats about most expensive series use `api/v1/status/tsdb` handler. More details here https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#url-format\n\nGood references to read:\n* https://www.robustperception.io/cardinality-is-key\n* https://valyala.medium.com/high-cardinality-tsdb-benchmarks-victoriametrics-vs-timescaledb-vs-influxdb-13e6ee64dd6b",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 4
+                        },
+                        "hiddenSeries": false,
+                        "id": 102,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
                             "show": true,
                             "sort": "current",
                             "sortDesc": true,
@@ -1799,11 +2930,8 @@ data:
                         "renderer": "flot",
                         "seriesOverrides": [
                             {
-                                "$$hashKey": "object:85",
-                                "alias": "max allowed",
-                                "color": "#F2495C",
-                                "fill": 0,
-                                "stack": false
+                                "alias": "new series over 24h",
+                                "yaxis": 2
                             }
                         ],
                         "spaceLength": 10,
@@ -1816,9 +2944,9 @@ data:
                                     "uid": "$ds"
                                 },
                                 "exemplar": true,
-                                "expr": "sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by(type)",
+                                "expr": "sum(rate(vm_new_timeseries_created_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval]))",
                                 "interval": "",
-                                "legendFormat": "{{`{{`}}type{{`}}`}}",
+                                "legendFormat": "churn rate",
                                 "refId": "A"
                             },
                             {
@@ -1826,17 +2954,635 @@ data:
                                     "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "exemplar": false,
-                                "expr": "sum(vm_allowed_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
+                                "exemplar": true,
+                                "expr": "sum(increase(vm_new_timeseries_created_total{job=~\"$job_storage\", instance=~\"$instance\"}[24h]))",
                                 "hide": false,
                                 "interval": "",
-                                "legendFormat": "max allowed",
+                                "legendFormat": "new series over 24h",
                                 "refId": "B"
                             }
                         ],
                         "thresholds": [],
                         "timeRegions": [],
-                        "title": "Cache size ($instance)",
+                        "title": "Churn rate ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the rate of adding new items to the index. It should correlate with `Slow inserts` and `Churn rate` graphs and could help to determine the pressure on indexdb.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 4
+                        },
+                        "hiddenSeries": false,
+                        "id": 147,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(rate(vm_indexdb_items_added_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval]))",
+                                "interval": "",
+                                "legendFormat": "items",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "IndexDB items rate ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:92",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:93",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "The percentage of slow inserts comparing to total insertion rate during the last 5 minutes. \n\nThe less value is better. If percentage remains high (>10%) during extended periods of time, then it is likely more RAM is needed for optimal handling of the current number of active time series. \n\nIn general, VictoriaMetrics requires ~1KB or RAM per active time series, so it should be easy calculating the required amounts of RAM for the current workload according to capacity planning docs. But the resulting number may be far from the real number because the required amounts of memory depends on may other factors such as the number of labels per time series and the length of label values.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 12
+                        },
+                        "hiddenSeries": false,
+                        "id": 108,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_slow_row_inserts_total{job=~\"$job_storage\"}[$__rate_interval])) / sum(rate(vm_rows_inserted_total{job=~\"$job_insert\"}[$__rate_interval]))",
+                                "interval": "",
+                                "legendFormat": "slow inserts",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [
+                            {
+                                "$$hashKey": "object:72",
+                                "colorMode": "critical",
+                                "fill": true,
+                                "line": true,
+                                "op": "gt",
+                                "value": 0.1,
+                                "yaxis": "left"
+                            }
+                        ],
+                        "timeRegions": [],
+                        "title": "Slow inserts",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:738",
+                                "format": "percentunit",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:739",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Slow queries according to `search.logSlowQueryDuration` flag, which is `5s` by default.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 12
+                        },
+                        "hiddenSeries": false,
+                        "id": 107,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_slow_queries_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval]))",
+                                "interval": "",
+                                "legendFormat": "slow queries rate",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Slow queries rate ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:892",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:893",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "The value is above 0 when the vmstorage at the given `addr` communicates to the given vminsert node that it cannot accept new data because it is in the read-only mode.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 20
+                        },
+                        "hiddenSeries": false,
+                        "id": 142,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [
+                            {
+                                "targetBlank": true,
+                                "title": "Readonly mode",
+                                "url": "https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#readonly-mode"
+                            }
+                        ],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 1,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(vm_rpc_vmstorage_is_read_only{job=~\"$job_insert\", instance=~\"$instance\"}) by(instance, addr)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} => {{`{{`}}addr{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Storage in readonly status for vminsert ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:536",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:537",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "VictoriaMetrics limits the number of labels per each metric with `-maxLabelsPerTimeseries` command-line flag.\n\nThis prevents from ingesting metrics with too many labels. The value of `maxLabelsPerTimeseries` must be adjusted for your workload.\n\nWhen limit is exceeded (graph is > 0) - extra labels are dropped, which could result in unexpected identical time series.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 20
+                        },
+                        "hiddenSeries": false,
+                        "id": 116,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(increase(vm_metrics_with_dropped_labels_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval]))",
+                                "format": "time_series",
+                                "hide": false,
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "metrics with dropped labels",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Labels limit exceeded ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:1046",
+                                "decimals": 2,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:1047",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": true,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Merge assist happens when vmstorage can't keep up with merging parts. This is usually a sign of overload for vmstorage.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 28
+                        },
+                        "hiddenSeries": false,
+                        "id": 170,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": false,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 1,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "exemplar": true,
+                                "expr": "sum(increase(vm_assisted_merges_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(type, instance) > 0",
+                                "format": "time_series",
+                                "interval": "5m",
+                                "intervalFactor": 1,
+                                "legendFormat": "__auto",
+                                "range": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Assisted merges ($instance)",
                         "tooltip": {
                             "shared": true,
                             "sort": 2,
@@ -1850,15 +3596,17 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:111",
-                                "format": "bytes",
+                                "$$hashKey": "object:536",
+                                "format": "short",
                                 "logBase": 1,
+                                "min": "0",
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:112",
+                                "$$hashKey": "object:537",
                                 "format": "short",
                                 "logBase": 1,
+                                "min": "0",
                                 "show": true
                             }
                         ],
@@ -1879,21 +3627,24 @@ data:
                         "fill": 0,
                         "fillGradient": 0,
                         "gridPos": {
-                            "h": 7,
-                            "w": 24,
-                            "x": 0,
-                            "y": 39
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 28
                         },
                         "hiddenSeries": false,
-                        "id": 97,
+                        "id": 144,
                         "legend": {
-                            "avg": false,
-                            "current": false,
-                            "max": false,
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
                             "min": false,
-                            "show": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
                             "total": false,
-                            "values": false
+                            "values": true
                         },
                         "lines": true,
                         "linewidth": 1,
@@ -1916,16 +3667,18 @@ data:
                                     "type": "prometheus",
                                     "uid": "$ds"
                                 },
+                                "editorMode": "code",
                                 "exemplar": true,
-                                "expr": "vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"} / vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}",
+                                "expr": "vm_cache_size_bytes{job=~\"$job_storage\", instance=~\"$instance\"} / vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}",
                                 "interval": "",
-                                "legendFormat": "{{`{{`}}type{{`}}`}}",
+                                "legendFormat": "{{`{{`}} instance {{`}}`}} / {{`{{`}} type {{`}}`}}",
+                                "range": true,
                                 "refId": "A"
                             }
                         ],
                         "thresholds": [],
                         "timeRegions": [],
-                        "title": "Cache usage % ($instance)",
+                        "title": "Cache usage % by vmstorage ($instance)",
                         "tooltip": {
                             "shared": true,
                             "sort": 2,
@@ -1939,13 +3692,259 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:235",
+                                "$$hashKey": "object:107",
                                 "format": "percentunit",
                                 "logBase": 1,
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:236",
+                                "$$hashKey": "object:108",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    }
+                ],
+                "title": "Troubleshooting",
+                "type": "row"
+            },
+            {
+                "collapsed": true,
+                "datasource": {
+                    "uid": "$ds"
+                },
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 36
+                },
+                "id": 48,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Shows number of pushed and sent rows. \n* `Pushed rows` - rows added to internal inserter buffers before send\n* `Sent rows` - successfully transmitted rows to storage nodes\n\nPlease note, it could be that `Sent > Pushed` because of the replication factor.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 0,
+                            "y": 5
+                        },
+                        "hiddenSeries": false,
+                        "id": 76,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 1,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_rpc_rows_pushed_total{job=~\"$job\",instance=~\"$instance\"}[2m]))",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "Pushed",
+                                "refId": "B"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_rpc_rows_sent_total{job=~\"$job\",instance=~\"$instance\"}[2m]))",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "Sent",
+                                "refId": "E"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Rows ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:1108",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:1109",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Rate of RPC errors by type:\n* `Connection` - the number of connection errors to vmstorage node\n* `Dial` -  the number of dial errors to vmstorage node.\n* `Handshake` - the number of handshake errors to vmstorage node\n* `Rerouted` - errors appeared during rerouting of rows from un-healthy storage node to a healthy one.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 12,
+                            "y": 5
+                        },
+                        "hiddenSeries": false,
+                        "id": 86,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 1,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_rpc_connection_errors_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "Connection",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_rpc_dial_errors_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "Dial",
+                                "refId": "B"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_rpc_handshake_errors_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "Handshake",
+                                "refId": "E"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "RPC errors ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
                                 "format": "short",
                                 "logBase": 1,
                                 "show": true
@@ -1964,24 +3963,233 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Cache hit ratio shows cache efficiency. The higher is hit rate the better.",
-                        "fill": 0,
+                        "description": "The number of rows rerouted to the vmstorage node from other nodes when they were unhealthy.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
                         "fillGradient": 0,
                         "gridPos": {
                             "h": 8,
-                            "w": 24,
+                            "w": 12,
                             "x": 0,
-                            "y": 46
+                            "y": 14
                         },
                         "hiddenSeries": false,
-                        "id": 95,
+                        "id": 80,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
                             "current": true,
-                            "max": false,
+                            "max": true,
                             "min": false,
-                            "rightSide": true,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 1,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(rate(vm_rpc_rows_rerouted_to_here_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(addr) > 0",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}addr{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Rows ($instance) rerouted to ",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:701",
+                                "format": "rps",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:702",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "The number of rows rerouted from the vmstorage node to healthy nodes when the given node was unhealthy.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 14
+                        },
+                        "hiddenSeries": false,
+                        "id": 78,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 1,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(rate(vm_rpc_rows_rerouted_from_here_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(addr) > 0",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}addr{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Rows ($instance) rerouted from",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:761",
+                                "format": "rps",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:762",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "The number of rows or bytes that vminesrt internal buffer contains at the moment.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 22
+                        },
+                        "hiddenSeries": false,
+                        "id": 82,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
                             "show": true,
                             "sort": "current",
                             "sortDesc": true,
@@ -2001,11 +4209,8 @@ data:
                         "renderer": "flot",
                         "seriesOverrides": [
                             {
-                                "$$hashKey": "object:85",
-                                "alias": "max allowed",
-                                "color": "#F2495C",
-                                "fill": 0,
-                                "stack": false
+                                "alias": "bytes",
+                                "yaxis": 2
                             }
                         ],
                         "spaceLength": 10,
@@ -2017,9 +4222,448 @@ data:
                                     "type": "prometheus",
                                     "uid": "$ds"
                                 },
+                                "expr": "sum(vm_rpc_buf_pending_bytes{job=~\"$job\", instance=~\"$instance\"})",
+                                "legendFormat": "bytes",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(vm_rpc_rows_pending{job=~\"$job\", instance=~\"$instance\"})",
+                                "legendFormat": "rows",
+                                "refId": "B"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Pending",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:821",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:822",
+                                "format": "bytes",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Network usage by internal VictoriaMetrics RPC protocol",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 22
+                        },
+                        "hiddenSeries": false,
+                        "id": 74,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_tcpdialer_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) * 8",
+                                "legendFormat": "network usage",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "RPC network usage ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bps",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    }
+                ],
+                "title": "Interconnection ($job)",
+                "type": "row"
+            },
+            {
+                "collapsed": true,
+                "datasource": {
+                    "uid": "$ds"
+                },
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 37
+                },
+                "id": 60,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "VictoriaMetrics stores various caches in RAM. Memory size for these caches may be limited with -`memory.allowedPercent` flag. Line `max allowed` shows max allowed memory size for cache.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 24,
+                            "x": 0,
+                            "y": 6
+                        },
+                        "hiddenSeries": false,
+                        "id": 57,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": false,
+                            "min": false,
+                            "rightSide": true,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "max allowed",
+                                "color": "#C4162A",
+                                "fill": 0,
+                                "stack": false
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by(type)",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}type{{`}}`}}",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(vm_allowed_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 1,
+                                "legendFormat": "max allowed",
+                                "refId": "B"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Cache size ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:889",
+                                "format": "bytes",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:890",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the percentage of used cache size from the allowed size by type. \nValues close to 100% show the maximum potential utilization.\nValues close to 0% show that cache is underutilized.",
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 9,
+                            "w": 24,
+                            "x": 0,
+                            "y": 14
+                        },
+                        "hiddenSeries": false,
+                        "id": 172,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "rightSide": true,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "exemplar": true,
+                                "expr": "sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by(type) / \nsum(vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}) by(type)",
+                                "interval": "",
+                                "legendFormat": "{{`{{`}} type {{`}}`}}",
+                                "range": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Cache usage % ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:107",
+                                "format": "percentunit",
+                                "logBase": 1,
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:108",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "VictoriaMetrics stores various caches in RAM. Memory size for these caches may be limited with -`memory.allowedPercent` flag. Line `max allowed` shows max allowed memory size for cache.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 24,
+                            "x": 0,
+                            "y": 23
+                        },
+                        "hiddenSeries": false,
+                        "id": 58,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "rightSide": true,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
                                 "exemplar": true,
                                 "expr": "1 - (\n sum(rate(vm_cache_misses_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) /\n sum(rate(vm_cache_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type)\n)",
+                                "format": "time_series",
+                                "hide": false,
                                 "interval": "",
+                                "intervalFactor": 1,
                                 "legendFormat": "{{`{{`}}type{{`}}`}}",
                                 "refId": "A"
                             }
@@ -2040,15 +4684,16 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:111",
                                 "format": "percentunit",
                                 "logBase": 1,
+                                "max": "1",
+                                "min": "0",
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:112",
                                 "format": "short",
                                 "logBase": 1,
+                                "min": "0",
                                 "show": true
                             }
                         ],
@@ -2057,16 +4702,7 @@ data:
                         }
                     }
                 ],
-                "targets": [
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "P4169E866C3094E38"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Caches",
+                "title": "Caches ($job)",
                 "type": "row"
             },
             {
@@ -2078,9 +4714,9 @@ data:
                     "h": 1,
                     "w": 24,
                     "x": 0,
-                    "y": 47
+                    "y": 38
                 },
-                "id": 14,
+                "id": 24,
                 "panels": [
                     {
                         "aliasColors": {},
@@ -2090,7 +4726,7 @@ data:
                         "datasource": {
                             "uid": "$ds"
                         },
-                        "description": "How many datapoints are inserted into storage per second",
+                        "description": "Shows how many rows per second every storage node accepts. This metric doesn't show all stored rows since some of them may be dropped because of wrong timestamps or decode errors.",
                         "fieldConfig": {
                             "defaults": {
                                 "links": []
@@ -2103,211 +4739,10 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 4
+                            "y": 7
                         },
                         "hiddenSeries": false,
-                        "id": 10,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "hideZero": true,
-                            "max": false,
-                            "min": false,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null as zero",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by (type) > 0",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 1,
-                                "legendFormat": "{{`{{`}}type{{`}}`}}",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "Datapoints ingestion rate ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 2,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "description": "Shows the time needed to reach the 100% of disk capacity based on the following params:\n* free disk space;\n* row ingestion rate;\n* dedup rate;\n* compression.\n\nUse this panel for capacity planning in order to estimate the time remaining for running out of the disk space.\n\n",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 0,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 12,
-                            "y": 4
-                        },
-                        "hiddenSeries": false,
-                        "id": 73,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "hideZero": true,
-                            "max": false,
-                            "min": true,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null as zero",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "vm_free_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"} / ignoring(path) ((rate(vm_rows_added_to_storage_total{job=~\"$job\", instance=~\"$instance\"}[1d]) - ignoring(type) rate(vm_deduplicated_samples_total{job=~\"$job\", instance=~\"$instance\", type=\"merge\"}[1d])) * scalar(sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type!=\"indexdb\"})))",
-                                "format": "time_series",
-                                "hide": false,
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "Storage full ETA ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 2,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "$$hashKey": "object:919",
-                                "format": "s",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "$$hashKey": "object:920",
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "description": "Shows how many datapoints are in the storage and what is average disk usage per datapoint.",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 0,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 0,
-                            "y": 12
-                        },
-                        "hiddenSeries": false,
-                        "id": 30,
+                        "id": 100,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
@@ -2332,38 +4767,220 @@ data:
                         "pointradius": 2,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
                             {
-                                "$$hashKey": "object:997",
-                                "alias": "bytes-per-datapoint",
-                                "yaxis": 2
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_vminsert_metrics_read_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "refId": "A"
                             }
                         ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Ingestion rate ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the time needed to reach the 100% of disk capacity based on the following params:\n* free disk space;\n* row ingestion rate;\n* dedup rate;\n* compression.\n\nUse this panel for capacity planning in order to estimate the time remaining for running out of the disk space.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 7
+                        },
+                        "hiddenSeries": false,
+                        "id": 113,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": false,
+                            "min": true,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
                         "spaceLength": 10,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type != \"indexdb\"})",
+                                "expr": "vm_free_disk_space_bytes{job=~\"$job_storage\", instance=~\"$instance\"} / ignoring(path) ((rate(vm_rows_added_to_storage_total{job=~\"$job_storage\", instance=~\"$instance\"}[1d]) - ignoring(type) rate(vm_deduplicated_samples_total{job=~\"$job_storage\", instance=~\"$instance\", type=\"merge\"}[1d])) * scalar(sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"})))",
                                 "format": "time_series",
                                 "interval": "",
                                 "intervalFactor": 1,
-                                "legendFormat": "total datapoints",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
                                 "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Storage full ETA ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:87",
+                                "format": "s",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
                             },
                             {
+                                "$$hashKey": "object:88",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Shows how many datapoints are in the storage.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 15
+                        },
+                        "hiddenSeries": false,
+                        "id": 16,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!=\"indexdb\"}) / sum(vm_rows{job=~\"$job\", instance=~\"$instance\", type != \"indexdb\"})",
+                                "expr": "sum(vm_rows{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"}) by(instance)",
                                 "format": "time_series",
                                 "interval": "",
                                 "intervalFactor": 1,
-                                "legendFormat": "bytes-per-datapoint",
-                                "refId": "B"
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [],
@@ -2382,16 +4999,15 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:1004",
+                                "$$hashKey": "object:1330",
                                 "format": "short",
                                 "logBase": 1,
                                 "min": "0",
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:1005",
-                                "decimals": 2,
-                                "format": "bytes",
+                                "$$hashKey": "object:1331",
+                                "format": "short",
                                 "logBase": 1,
                                 "min": "0",
                                 "show": true
@@ -2409,29 +5025,30 @@ data:
                         "datasource": {
                             "uid": "$ds"
                         },
-                        "description": "How many datapoints are in RAM queue waiting to be written into storage. The number of pending data points should be in the range from 0 to `2*<ingestion_rate>`, since VictoriaMetrics pushes pending data to persistent storage every second.",
+                        "description": "How many datapoints are in RAM queue waiting to be written into storage. The number of pending data points should be in the range from 0 to `2*<ingestion_rate>`, since VictoriaMetrics pushes pending data to persistent storage every second. The index datapoints value in general is much lower.",
                         "fieldConfig": {
                             "defaults": {
                                 "links": []
                             },
                             "overrides": []
                         },
-                        "fill": 1,
+                        "fill": 0,
                         "fillGradient": 0,
                         "gridPos": {
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 12
+                            "y": 15
                         },
                         "hiddenSeries": false,
-                        "id": 34,
+                        "id": 14,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
                             "current": true,
                             "max": true,
                             "min": false,
+                            "rightSide": false,
                             "show": true,
                             "sort": "current",
                             "sortDesc": true,
@@ -2462,9 +5079,10 @@ data:
                         "targets": [
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "vm_pending_rows{job=~\"$job\", instance=~\"$instance\", type=\"storage\"}",
+                                "expr": "sum(vm_pending_rows{job=~\"$job_storage\", instance=~\"$instance\", type=\"storage\"})",
                                 "format": "time_series",
                                 "hide": false,
                                 "intervalFactor": 1,
@@ -2473,9 +5091,10 @@ data:
                             },
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "vm_pending_rows{job=~\"$job\", instance=~\"$instance\", type=\"indexdb\"}",
+                                "expr": "sum(vm_pending_rows{job=~\"$job_storage\", instance=~\"$instance\", type=\"indexdb\"})",
                                 "format": "time_series",
                                 "hide": false,
                                 "intervalFactor": 1,
@@ -2499,12 +5118,14 @@ data:
                         },
                         "yaxes": [
                             {
+                                "$$hashKey": "object:1262",
                                 "format": "short",
                                 "logBase": 1,
                                 "min": "0",
                                 "show": true
                             },
                             {
+                                "$$hashKey": "object:1263",
                                 "decimals": 3,
                                 "format": "none",
                                 "logBase": 1,
@@ -2524,30 +5145,29 @@ data:
                         "datasource": {
                             "uid": "$ds"
                         },
-                        "description": "Shows amount of on-disk space occupied by data points and the remaining disk space at `-storageDataPath`",
+                        "description": "Shows amount of on-disk space occupied by data points.",
                         "fieldConfig": {
                             "defaults": {
                                 "links": []
                             },
                             "overrides": []
                         },
-                        "fill": 0,
+                        "fill": 1,
                         "fillGradient": 0,
                         "gridPos": {
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 20
+                            "y": 23
                         },
                         "hiddenSeries": false,
-                        "id": 53,
+                        "id": 18,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
                             "current": true,
                             "max": true,
                             "min": false,
-                            "rightSide": false,
                             "show": true,
                             "sort": "current",
                             "sortDesc": true,
@@ -2568,35 +5188,24 @@ data:
                         "renderer": "flot",
                         "seriesOverrides": [],
                         "spaceLength": 10,
-                        "stack": false,
+                        "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "sum(vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type!=\"indexdb\"})",
+                                "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\", type!=\"indexdb\"}) by(instance)",
                                 "format": "time_series",
-                                "interval": "",
                                 "intervalFactor": 1,
-                                "legendFormat": "Used",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
                                 "refId": "A"
-                            },
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "vm_free_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"}",
-                                "format": "time_series",
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "Free",
-                                "refId": "B"
                             }
                         ],
                         "thresholds": [],
                         "timeRegions": [],
-                        "title": "Disk space usage - datapoints ($instance)",
+                        "title": "Disk space usage (datapoints) ($instance)",
                         "tooltip": {
                             "shared": true,
                             "sort": 0,
@@ -2610,113 +5219,12 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:1136",
                                 "format": "bytes",
                                 "logBase": 1,
                                 "min": "0",
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:1137",
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "description": "Data parts of LSM tree.\nHigh number of parts could be an evidence of slow merge performance - check the resource utilization.\n* `indexdb` - inverted index\n* `storage/small` - recently added parts of data ingested into storage(hot data)\n* `storage/big` -  small parts gradually merged into big parts (cold data)",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 0,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 12,
-                            "y": 20
-                        },
-                        "hiddenSeries": false,
-                        "id": 36,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "max": true,
-                            "min": false,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(vm_parts{job=~\"$job\", instance=~\"$instance\"}) by (type)",
-                                "format": "time_series",
-                                "intervalFactor": 1,
-                                "legendFormat": "{{`{{`}}type{{`}}`}}",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "LSM parts ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 2,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "$$hashKey": "object:1066",
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "$$hashKey": "object:1067",
                                 "format": "short",
                                 "logBase": 1,
                                 "min": "0",
@@ -2747,11 +5255,11 @@ data:
                         "gridPos": {
                             "h": 8,
                             "w": 12,
-                            "x": 0,
-                            "y": 28
+                            "x": 12,
+                            "y": 23
                         },
                         "hiddenSeries": false,
-                        "id": 55,
+                        "id": 20,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
@@ -2778,25 +5286,24 @@ data:
                         "renderer": "flot",
                         "seriesOverrides": [],
                         "spaceLength": 10,
-                        "stack": false,
+                        "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "exemplar": true,
-                                "expr": "vm_data_size_bytes{job=~\"$job\", instance=~\"$instance\", type=\"indexdb\"}",
+                                "expr": "sum(vm_data_size_bytes{job=~\"$job_storage\", instance=~\"$instance\", type=\"indexdb\"}) by(instance)",
                                 "format": "time_series",
-                                "interval": "",
                                 "intervalFactor": 1,
-                                "legendFormat": "disk space used",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
                                 "refId": "A"
                             }
                         ],
                         "thresholds": [],
                         "timeRegions": [],
-                        "title": "Disk space usage - index ($instance)",
+                        "title": "Disk space usage (index)  ($instance)",
                         "tooltip": {
                             "shared": true,
                             "sort": 0,
@@ -2846,11 +5353,11 @@ data:
                         "gridPos": {
                             "h": 8,
                             "w": 12,
-                            "x": 12,
-                            "y": 28
+                            "x": 0,
+                            "y": 31
                         },
                         "hiddenSeries": false,
-                        "id": 62,
+                        "id": 54,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
@@ -2881,9 +5388,10 @@ data:
                         "targets": [
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "sum(vm_active_merges{job=~\"$job\", instance=~\"$instance\"}) by(type)",
+                                "expr": "sum(vm_active_merges{job=~\"$job_storage\", instance=~\"$instance\"}) by(type)",
                                 "legendFormat": "{{`{{`}}type{{`}}`}}",
                                 "refId": "A"
                             }
@@ -2893,7 +5401,7 @@ data:
                         "title": "Active merges ($instance)",
                         "tooltip": {
                             "shared": true,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -2904,7 +5412,7 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:1262",
+                                "$$hashKey": "object:1399",
                                 "decimals": 0,
                                 "format": "short",
                                 "logBase": 1,
@@ -2912,107 +5420,7 @@ data:
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:1263",
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "description": "Shows how many rows were ignored on insertion due to corrupted or out of retention timestamps.",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 1,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 0,
-                            "y": 36
-                        },
-                        "hiddenSeries": false,
-                        "id": 58,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "max": true,
-                            "min": false,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "exemplar": true,
-                                "expr": "sum(vm_rows_ignored_total{job=~\"$job\", instance=~\"$instance\"}) by (reason)",
-                                "format": "time_series",
-                                "hide": false,
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "{{`{{`}}reason{{`}}`}}",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "Rows ignored ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
+                                "$$hashKey": "object:1400",
                                 "format": "short",
                                 "logBase": 1,
                                 "min": "0",
@@ -3044,10 +5452,10 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 36
+                            "y": 31
                         },
                         "hiddenSeries": false,
-                        "id": 64,
+                        "id": 55,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
@@ -3078,19 +5486,20 @@ data:
                         "targets": [
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "sum(rate(vm_rows_merged_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(type)",
+                                "expr": "sum(rate(vm_rows_merged_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(type)",
                                 "legendFormat": "{{`{{`}}type{{`}}`}}",
                                 "refId": "A"
                             }
                         ],
                         "thresholds": [],
                         "timeRegions": [],
-                        "title": "Merge speed ($instance)",
+                        "title": "Merge speed",
                         "tooltip": {
                             "shared": true,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -3101,7 +5510,7 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:867",
+                                "$$hashKey": "object:1516",
                                 "decimals": 0,
                                 "format": "short",
                                 "logBase": 1,
@@ -3109,7 +5518,7 @@ data:
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:868",
+                                "$$hashKey": "object:1517",
                                 "format": "short",
                                 "logBase": 1,
                                 "min": "0",
@@ -3128,256 +5537,17 @@ data:
                         "datasource": {
                             "uid": "$ds"
                         },
-                        "description": "Shows the rate of logging the messages by their level. Unexpected spike in rate is a good reason to check logs.",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 1,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 12,
-                            "y": 44
-                        },
-                        "hiddenSeries": false,
-                        "id": 67,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "max": true,
-                            "min": false,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (level) ",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 1,
-                                "legendFormat": "{{`{{`}}level{{`}}`}}",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "Logging rate ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    }
-                ],
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Storage",
-                "type": "row"
-            },
-            {
-                "collapsed": true,
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "gridPos": {
-                    "h": 1,
-                    "w": 24,
-                    "x": 0,
-                    "y": 48
-                },
-                "id": 71,
-                "panels": [
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "description": "Shows the rate and total number of new series created over last 24h.\n\nHigh churn rate tightly connected with database performance and may result in unexpected OOM's or slow queries. It is recommended to always keep an eye on this metric to avoid unexpected cardinality \"explosions\".\n\nThe higher churn rate is, the more resources required to handle it. Consider to keep the churn rate as low as possible.\n\nGood references to read:\n* https://www.robustperception.io/cardinality-is-key\n* https://www.robustperception.io/using-tsdb-analyze-to-investigate-churn-and-cardinality",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 1,
+                        "description": "Shows how many rows were ignored on insertion due to corrupted or out of retention timestamps.",
+                        "fill": 0,
                         "fillGradient": 0,
                         "gridPos": {
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 5
+                            "y": 39
                         },
                         "hiddenSeries": false,
-                        "id": 66,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "max": true,
-                            "min": false,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "nullPointMode": "null",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [
-                            {
-                                "alias": "new series over 24h",
-                                "yaxis": 2
-                            }
-                        ],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(rate(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
-                                "interval": "",
-                                "legendFormat": "churn rate",
-                                "refId": "A"
-                            },
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(increase(vm_new_timeseries_created_total{job=~\"$job\", instance=~\"$instance\"}[24h]))",
-                                "interval": "",
-                                "legendFormat": "new series over 24h",
-                                "refId": "B"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "Churn rate ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "$ds"
-                        },
-                        "description": "Shows the rate of adding new items to the index. It should correlate with `Slow inserts` and `Churn rate` graphs and could help to determine the pressure on indexdb.",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 1,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 12,
-                            "y": 5
-                        },
-                        "hiddenSeries": false,
-                        "id": 96,
+                        "id": 135,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
@@ -3412,15 +5582,15 @@ data:
                                     "uid": "$ds"
                                 },
                                 "exemplar": true,
-                                "expr": "sum(rate(vm_indexdb_items_added_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+                                "expr": "sum(vm_rows_ignored_total{job=~\"$job_storage\", instance=~\"$instance\"}) by (reason)",
                                 "interval": "",
-                                "legendFormat": "items",
+                                "legendFormat": "{{`{{`}}reason{{`}}`}}",
                                 "refId": "A"
                             }
                         ],
                         "thresholds": [],
                         "timeRegions": [],
-                        "title": "IndexDB items rate ($instance)",
+                        "title": "Rows ignored ($instance)",
                         "tooltip": {
                             "shared": true,
                             "sort": 0,
@@ -3434,17 +5604,15 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:76",
+                                "$$hashKey": "object:1584",
                                 "format": "short",
                                 "logBase": 1,
-                                "min": "0",
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:77",
+                                "$$hashKey": "object:1585",
                                 "format": "short",
                                 "logBase": 1,
-                                "min": "0",
                                 "show": true
                             }
                         ],
@@ -3458,135 +5626,26 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": {
+                            "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "The percentage of slow inserts comparing to total insertion rate during the last 5 minutes. \n\nThe less value is better. If percentage remains high (>10%) during extended periods of time, then it is likely more RAM is needed for optimal handling of the current number of active time series. \n\nIn general, VictoriaMetrics requires ~1KB or RAM per active time series, so it should be easy calculating the required amounts of RAM for the current workload according to capacity planning docs. But the resulting number may be far from the real number because the required amounts of memory depends on may other factors such as the number of labels per time series and the length of label values.",
+                        "description": "The max number of data parts of LSM tree across all storage nodes.\nHigh number of parts (the hard limit is 512) is an evidence of slow merge performance - check the resource utilization.\n* `indexdb` - inverted index\n* `storage/small` - recently added parts of data ingested into storage (hot data)\n* `storage/big` -  small parts gradually merged into big parts (cold data)",
                         "fieldConfig": {
                             "defaults": {
                                 "links": []
                             },
                             "overrides": []
                         },
-                        "fill": 1,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 0,
-                            "y": 13
-                        },
-                        "hiddenSeries": false,
-                        "id": 68,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "max": true,
-                            "min": false,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(rate(vm_slow_row_inserts_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) / sum(rate(vm_rows_inserted_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
-                                "format": "time_series",
-                                "hide": false,
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "slow inserts percentage",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [
-                            {
-                                "$$hashKey": "object:60",
-                                "colorMode": "critical",
-                                "fill": true,
-                                "line": true,
-                                "op": "gt",
-                                "value": 0.1,
-                                "yaxis": "left"
-                            }
-                        ],
-                        "timeRegions": [],
-                        "title": "Slow inserts ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "decimals": 2,
-                                "format": "percentunit",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "description": "Slow queries rate according to `search.logSlowQueryDuration` flag, which is `5s` by default.",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 1,
+                        "fill": 0,
                         "fillGradient": 0,
                         "gridPos": {
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 13
+                            "y": 39
                         },
                         "hiddenSeries": false,
-                        "id": 60,
+                        "id": 22,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
@@ -3618,22 +5677,23 @@ data:
                         "targets": [
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "sum(rate(vm_slow_queries_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+                                "expr": "max(sum(vm_parts{job=~\"$job_storage\", instance=~\"$instance\"}) by (type, instance)) by(type)",
                                 "format": "time_series",
-                                "hide": false,
+                                "interval": "",
                                 "intervalFactor": 1,
-                                "legendFormat": "slow queries rate",
+                                "legendFormat": "{{`{{`}}type{{`}}`}}",
                                 "refId": "A"
                             }
                         ],
                         "thresholds": [],
                         "timeRegions": [],
-                        "title": "Slow queries rate ($instance)",
+                        "title": "LSM parts ($instance)",
                         "tooltip": {
                             "shared": true,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -3644,12 +5704,14 @@ data:
                         },
                         "yaxes": [
                             {
+                                "$$hashKey": "object:1644",
                                 "format": "short",
                                 "logBase": 1,
                                 "min": "0",
                                 "show": true
                             },
                             {
+                                "$$hashKey": "object:1645",
                                 "format": "short",
                                 "logBase": 1,
                                 "min": "0",
@@ -3669,17 +5731,17 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Shows the percentage of used cache size from the allowed size by type. \nValues close to 100% show the maximum potential utilization.\nValues close to 0% show that cache is underutilized.",
-                        "fill": 0,
+                        "description": "Value > 0 means vmstorage is in readonly mode.",
+                        "fill": 1,
                         "fillGradient": 0,
                         "gridPos": {
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 21
+                            "y": 47
                         },
                         "hiddenSeries": false,
-                        "id": 90,
+                        "id": 141,
                         "legend": {
                             "avg": false,
                             "current": false,
@@ -3691,6 +5753,13 @@ data:
                         },
                         "lines": true,
                         "linewidth": 1,
+                        "links": [
+                            {
+                                "targetBlank": true,
+                                "title": "Readonly mode",
+                                "url": "https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#readonly-mode"
+                            }
+                        ],
                         "nullPointMode": "null",
                         "options": {
                             "alertThreshold": true
@@ -3711,15 +5780,15 @@ data:
                                     "uid": "$ds"
                                 },
                                 "exemplar": true,
-                                "expr": "vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"} / vm_cache_size_max_bytes{job=~\"$job\", instance=~\"$instance\"}",
+                                "expr": "vm_storage_is_read_only{job=~\"$job_storage\", instance=~\"$instance\"}",
                                 "interval": "",
-                                "legendFormat": "{{`{{`}}type{{`}}`}}",
+                                "legendFormat": "{{`{{`}} instance {{`}}`}}",
                                 "refId": "A"
                             }
                         ],
                         "thresholds": [],
                         "timeRegions": [],
-                        "title": "Cache usage % ($instance)",
+                        "title": "Readonly mode",
                         "tooltip": {
                             "shared": true,
                             "sort": 2,
@@ -3733,13 +5802,13 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:235",
-                                "format": "percentunit",
+                                "$$hashKey": "object:131",
+                                "format": "short",
                                 "logBase": 1,
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:236",
+                                "$$hashKey": "object:132",
                                 "format": "short",
                                 "logBase": 1,
                                 "show": true
@@ -3755,149 +5824,20 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": {
+                            "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "VictoriaMetrics limits the number of labels per each metric with `-maxLabelsPerTimeseries` command-line flag.\n\nThis prevents from ingesting metrics with too many labels. The value of `maxLabelsPerTimeseries` must be adjusted for your workload.\n\nWhen limit is exceeded (graph is > 0) - extra labels are dropped, which could result in unexpected identical time series.",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 1,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 12,
-                            "y": 21
-                        },
-                        "hiddenSeries": false,
-                        "id": 74,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "max": true,
-                            "min": false,
-                            "show": false,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "exemplar": true,
-                                "expr": "sum(increase(vm_metrics_with_dropped_labels_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
-                                "format": "time_series",
-                                "hide": false,
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "limit exceeded",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "Labels limit exceeded ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "decimals": 2,
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    }
-                ],
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Troubleshooting",
-                "type": "row"
-            },
-            {
-                "collapsed": true,
-                "datasource": {
-                    "uid": "$ds"
-                },
-                "gridPos": {
-                    "h": 1,
-                    "w": 24,
-                    "x": 0,
-                    "y": 49
-                },
-                "id": 46,
-                "panels": [
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "description": "",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
+                        "description": "Shows how many ongoing insertions (not API /write calls) on disk are taking place, where:\n* `max` - equal to number of CPUs;\n* `current` - current number of goroutines busy with inserting rows into underlying storage.\n\nEvery successful API /write call results into flush on disk. The `max` is an internal limit and can't be changed. It is always equal to the number of CPUs. \n\nWhen `current` hits `max` constantly, it means storage is overloaded and requires more CPU or faster disk.",
                         "fill": 0,
                         "fillGradient": 0,
                         "gridPos": {
                             "h": 8,
                             "w": 12,
-                            "x": 0,
-                            "y": 50
+                            "x": 12,
+                            "y": 47
                         },
                         "hiddenSeries": false,
-                        "id": 44,
+                        "id": 133,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
@@ -3912,7 +5852,13 @@ data:
                         },
                         "lines": true,
                         "linewidth": 1,
-                        "links": [],
+                        "links": [
+                            {
+                                "targetBlank": true,
+                                "title": "Related discussion",
+                                "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/issues/632"
+                            }
+                        ],
                         "nullPointMode": "null",
                         "options": {
                             "alertThreshold": true
@@ -3922,76 +5868,46 @@ data:
                         "pointradius": 2,
                         "points": false,
                         "renderer": "flot",
-                        "seriesOverrides": [],
+                        "seriesOverrides": [
+                            {
+                                "alias": "max",
+                                "color": "#C4162A"
+                            }
+                        ],
                         "spaceLength": 10,
                         "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "sum(go_memstats_sys_bytes{job=~\"$job\", instance=~\"$instance\"}) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 1,
-                                "legendFormat": "requested from system",
+                                "exemplar": true,
+                                "expr": "max(vm_concurrent_addrows_capacity{job=~\"$job_storage\", instance=~\"$instance\"})",
+                                "interval": "",
+                                "legendFormat": "max",
                                 "refId": "A"
                             },
                             {
                                 "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(go_memstats_heap_inuse_bytes{job=~\"$job\", instance=~\"$instance\"}) + sum(vm_cache_size_bytes{job=~\"$job\", instance=~\"$instance\"})",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 1,
-                                "legendFormat": "heap inuse",
-                                "refId": "B"
-                            },
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(go_memstats_stack_inuse_bytes{job=~\"$job\", instance=~\"$instance\"})",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 1,
-                                "legendFormat": "stack inuse",
-                                "refId": "C"
-                            },
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"})",
-                                "format": "time_series",
-                                "hide": false,
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "resident",
-                                "refId": "D"
-                            },
-                            {
-                                "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
                                 "exemplar": true,
-                                "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"})",
-                                "format": "time_series",
+                                "expr": "sum(avg_over_time(vm_concurrent_addrows_current{job=~\"$job_storage\", instance=~\"$instance\"}[1m])) by(instance)",
                                 "hide": false,
                                 "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "resident anonymous",
-                                "refId": "E"
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "refId": "B"
                             }
                         ],
                         "thresholds": [],
                         "timeRegions": [],
-                        "title": "Memory usage ($instance)",
+                        "title": "Concurrent flushes on disk ($instance)",
                         "tooltip": {
                             "shared": true,
-                            "sort": 2,
+                            "sort": 0,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -4002,17 +5918,15 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:1432",
-                                "format": "bytes",
+                                "$$hashKey": "object:1768",
+                                "format": "short",
                                 "logBase": 1,
-                                "min": "0",
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:1433",
+                                "$$hashKey": "object:1769",
                                 "format": "short",
                                 "logBase": 1,
-                                "min": "0",
                                 "show": true
                             }
                         ],
@@ -4039,13 +5953,13 @@ data:
                         "fill": 0,
                         "fillGradient": 0,
                         "gridPos": {
-                            "h": 8,
+                            "h": 7,
                             "w": 12,
-                            "x": 12,
-                            "y": 50
+                            "x": 0,
+                            "y": 55
                         },
                         "hiddenSeries": false,
-                        "id": 57,
+                        "id": 151,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
@@ -4072,9 +5986,9 @@ data:
                         "renderer": "flot",
                         "seriesOverrides": [
                             {
-                                "$$hashKey": "object:85",
-                                "alias": "Limit",
-                                "color": "#F2495C"
+                                "$$hashKey": "object:186",
+                                "alias": "limit",
+                                "color": "#C4162A"
                             }
                         ],
                         "spaceLength": 10,
@@ -4086,11 +6000,14 @@ data:
                                     "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
+                                "editorMode": "code",
+                                "exemplar": true,
+                                "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
                                 "format": "time_series",
                                 "interval": "",
                                 "intervalFactor": 1,
-                                "legendFormat": "CPU cores used",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "range": true,
                                 "refId": "A"
                             },
                             {
@@ -4098,13 +6015,1023 @@ data:
                                     "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "exemplar": false,
-                                "expr": "process_cpu_cores_available{job=~\"$job\", instance=~\"$instance\"}",
-                                "format": "time_series",
+                                "editorMode": "code",
+                                "expr": "min(process_cpu_cores_available{job=~\"$job_storage\", instance=~\"$instance\"})",
                                 "hide": false,
+                                "legendFormat": "limit",
+                                "range": true,
+                                "refId": "B"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "CPU ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:1827",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:1828",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 7,
+                            "w": 12,
+                            "x": 12,
+                            "y": 55
+                        },
+                        "hiddenSeries": false,
+                        "id": 167,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "$$hashKey": "object:186",
+                                "alias": "limit",
+                                "color": "#C4162A"
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "exemplar": true,
+                                "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job_storage\", instance=~\"$instance\"}) by(instance) ",
+                                "format": "time_series",
                                 "interval": "",
                                 "intervalFactor": 1,
-                                "legendFormat": "Limit",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "range": true,
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "min(vm_available_memory_bytes{job=~\"$job_storage\", instance=~\"$instance\"})",
+                                "hide": false,
+                                "legendFormat": "limit",
+                                "range": true,
+                                "refId": "B"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Memory ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:164",
+                                "format": "bytes",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:165",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    }
+                ],
+                "title": "vmstorage ($instance)",
+                "type": "row"
+            },
+            {
+                "collapsed": true,
+                "datasource": {
+                    "uid": "$ds"
+                },
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 39
+                },
+                "id": 42,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Request rate accepted by vmselect nodes",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 8
+                        },
+                        "hiddenSeries": false,
+                        "id": 92,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_http_requests_total{job=~\"$job_select\", instance=~\"$instance.*\", path!~\"/favicon.ico|/metrics\"}[$__rate_interval])) by (path) > 0",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}path{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Requests rate ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:2088",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:2089",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the max number of concurrent selects across instances.\n* `max` - equal to number of CPU * 2 by default. May be configured with `search.maxConcurrentRequests` flag\n* `current` - current number of goroutines busy with processing requests\n\nWhen `current` hits `max` constantly, it means one or more vmselect nodes are overloaded and require more CPU or better load balancing. If CPU panel shows there are free resources - try increasing  `search.maxConcurrentRequests`.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 8
+                        },
+                        "hiddenSeries": false,
+                        "id": 95,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "hideEmpty": false,
+                            "hideZero": false,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "$$hashKey": "object:2150",
+                                "alias": "max",
+                                "color": "#C4162A",
+                                "fill": 0
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "max(max_over_time(vm_concurrent_select_current{job=~\"$job_select\", instance=~\"$instance\"}[1m])) ",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "current",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "min(vm_concurrent_select_capacity{job=~\"$job_select\", instance=~\"$instance\"})",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "max",
+                                "refId": "B"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Concurrent selects ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:2159",
+                                "decimals": 0,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:2160",
+                                "decimals": 0,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "99th percentile of number of series read per query.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 16
+                        },
+                        "hiddenSeries": false,
+                        "id": 178,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "histogram_quantile(0.99, sum(rate(vm_series_read_per_query_bucket{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Series read per query ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:2848",
+                                "decimals": 2,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:2849",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "99th percentile of number of raw samples read per query.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 16
+                        },
+                        "hiddenSeries": false,
+                        "id": 179,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "histogram_quantile(0.99, sum(rate(vm_rows_read_per_query_bucket{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Rows read per query ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:2848",
+                                "decimals": 2,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:2849",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "99th percentile of number of raw samples read per queried series.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 24
+                        },
+                        "hiddenSeries": false,
+                        "id": 180,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "histogram_quantile(0.99, sum(rate(vm_rows_read_per_series_bucket{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Rows read per series ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:2848",
+                                "decimals": 2,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:2849",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "99th percentile of number of raw samples scanner per query.\n\nThis number can exceed number of RowsReadPerQuery if `step` query arg passed to [/api/v1/query_range](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) is smaller than the lookbehind window set in square brackets of [rollup function](https://docs.victoriametrics.com/MetricsQL.html#rollup-functions). For example, if `increase(some_metric[1h])` is executed with the `step=5m`, then the same raw samples on a hour time range are scanned `1h/5m=12` times. See [this article](https://valyala.medium.com/how-to-optimize-promql-and-metricsql-queries-85a1b75bf986) for details.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 24
+                        },
+                        "hiddenSeries": false,
+                        "id": 181,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "histogram_quantile(0.99, sum(rate(vm_rows_scanned_per_query_bucket{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Rows scanned per series ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:2848",
+                                "decimals": 2,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:2849",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 24,
+                            "x": 0,
+                            "y": 32
+                        },
+                        "hiddenSeries": false,
+                        "id": 93,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "$$hashKey": "object:2229",
+                                "alias": "/read.*/",
+                                "transform": "negative-Y"
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by (instance) * 8 > 0",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "read - {{`{{`}}instance{{`}}`}}",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_tcplistener_written_bytes_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by (instance) * 8 > 0",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 1,
+                                "legendFormat": "write - {{`{{`}}instance{{`}}`}}",
+                                "refId": "B"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Network usage ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:2236",
+                                "format": "bps",
+                                "logBase": 1,
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:2237",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 40
+                        },
+                        "hiddenSeries": false,
+                        "id": 163,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "$$hashKey": "object:186",
+                                "alias": "limit",
+                                "color": "#C4162A"
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "exemplar": true,
+                                "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "range": true,
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "min(process_cpu_cores_available{job=~\"$job_select\", instance=~\"$instance\"})",
+                                "hide": false,
+                                "legendFormat": "limit",
+                                "range": true,
                                 "refId": "B"
                             }
                         ],
@@ -4124,17 +7051,16 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:1370",
+                                "$$hashKey": "object:2303",
                                 "format": "short",
                                 "logBase": 1,
                                 "min": "0",
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:1371",
+                                "$$hashKey": "object:2304",
                                 "format": "short",
                                 "logBase": 1,
-                                "min": "0",
                                 "show": true
                             }
                         ],
@@ -4148,9 +7074,147 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": {
+                            "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Panel shows the number of open file descriptors in the OS.\nReaching the limit of open files can cause various issues and must be prevented.\n\nSee how to change limits here https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 40
+                        },
+                        "hiddenSeries": false,
+                        "id": 165,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "$$hashKey": "object:186",
+                                "alias": "limit",
+                                "color": "#C4162A"
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "exemplar": true,
+                                "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job_select\", instance=~\"$instance\"}) by(instance) ",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "range": true,
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "min(vm_available_memory_bytes{job=~\"$job_select\", instance=~\"$instance\"})",
+                                "hide": false,
+                                "legendFormat": "limit",
+                                "range": true,
+                                "refId": "B"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Memory ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 0,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:164",
+                                "format": "bytes",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:165",
+                                "format": "short",
+                                "logBase": 1,
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    }
+                ],
+                "title": "vmselect ($instance)",
+                "type": "row"
+            },
+            {
+                "collapsed": true,
+                "datasource": {
+                    "uid": "$ds"
+                },
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 40
+                },
+                "id": 40,
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "* `*` - unsupported query path\n* `/write` - insert into VM\n* `/metrics` - query VM system metrics\n* `/query` - query instant values\n* `/query_range` - query over a range of time\n* `/series` - match a certain label set\n* `/label/{}/values` - query a list of label values (variables mostly)",
                         "fieldConfig": {
                             "defaults": {
                                 "links": []
@@ -4163,10 +7227,655 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 58
+                            "y": 41
                         },
                         "hiddenSeries": false,
-                        "id": 75,
+                        "id": 97,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "sum(rate(vm_http_requests_total{job=~\"$job_insert\", instance=~\"$instance.*\", path!~\"/favicon.ico\"}[$__rate_interval])) by (path) > 0",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}path{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Requests rate ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:2715",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:2716",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows how many ongoing insertions are taking place.\n* `max` - equal to number of CPU * 4 by default. May be configured with `maxConcurrentInserts` flag;\n* `current` - current number of goroutines busy with processing requests.\n\n`-maxConcurrentInserts` limits the number of insert requests which may be actively processed at any given point in time. All the other insert requests are queued for up to `-insert.maxQueueDuration` in the hope they will get a chance to be processed. This queue is used mostly for absorbing spikes for incoming insert request rate.\n\nWhen `current` hits `max` constantly, it means vminsert node is overloaded and requires more CPU or higher limits.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 41
+                        },
+                        "hiddenSeries": false,
+                        "id": 99,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "hideEmpty": false,
+                            "hideZero": false,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "$$hashKey": "object:2777",
+                                "alias": "max",
+                                "color": "#C4162A",
+                                "fill": 0
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "max(vm_concurrent_insert_current{job=~\"$job_insert\", instance=~\"$instance\"}) by(instance)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "range": true,
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "min(vm_concurrent_insert_capacity{job=~\"$job_insert\", instance=~\"$instance\"})",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "max",
+                                "refId": "B"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Concurrent inserts ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:2786",
+                                "decimals": 0,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:2787",
+                                "decimals": 0,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 49
+                        },
+                        "hiddenSeries": false,
+                        "id": 90,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval])) by (instance) * 8 > 0",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Network usage ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bps",
+                                "logBase": 1,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 49
+                        },
+                        "hiddenSeries": false,
+                        "id": 88,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": true,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "histogram_quantile(0.99, sum(increase(vm_rows_per_insert_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange))",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Rows per insert ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:2848",
+                                "decimals": 2,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:2849",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the saturation level of connection between vminsert and vmstorage components. If the threshold of 0.9sec is reached, then the connection is saturated by more than 90% and vminsert won't be able to keep up. This usually means that more vminsert or vmstorage nodes must be added to the cluster in order to increase the total number of vminsert -> vmstorage links.\n",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 57
+                        },
+                        "hiddenSeries": false,
+                        "id": 139,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "exemplar": true,
+                                "expr": "rate(vm_rpc_send_duration_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} => {{`{{`}}addr{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [
+                            {
+                                "$$hashKey": "object:234",
+                                "colorMode": "critical",
+                                "fill": true,
+                                "line": true,
+                                "op": "gt",
+                                "value": 0.9,
+                                "yaxis": "left"
+                            }
+                        ],
+                        "timeRegions": [],
+                        "title": "Storage connection saturation ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:156",
+                                "decimals": 0,
+                                "format": "s",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:157",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "uid": "$ds"
+                        },
+                        "description": "Shows if vmstorage node is reachable for vminsert. If below 1 means vmstorage is not reachable at this moment of time. ",
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 57
+                        },
+                        "hiddenSeries": false,
+                        "id": 114,
+                        "legend": {
+                            "alignAsTable": true,
+                            "avg": true,
+                            "current": true,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "sort": "current",
+                            "sortDesc": true,
+                            "total": false,
+                            "values": true
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "options": {
+                            "alertThreshold": true
+                        },
+                        "percentage": false,
+                        "pluginVersion": "9.0.3",
+                        "pointradius": 2,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "expr": "vm_rpc_vmstorage_is_reachable{job=~\"$job\", instance=~\"$instance\"}",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}} => {{`{{`}}addr{{`}}`}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeRegions": [],
+                        "title": "Storage reachability ($instance)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "mode": "time",
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "$$hashKey": "object:1534",
+                                "decimals": 0,
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            },
+                            {
+                                "$$hashKey": "object:1535",
+                                "format": "short",
+                                "logBase": 1,
+                                "min": "0",
+                                "show": true
+                            }
+                        ],
+                        "yaxis": {
+                            "align": false
+                        }
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "links": []
+                            },
+                            "overrides": []
+                        },
+                        "fill": 0,
+                        "fillGradient": 0,
+                        "gridPos": {
+                            "h": 7,
+                            "w": 12,
+                            "x": 0,
+                            "y": 65
+                        },
+                        "hiddenSeries": false,
+                        "id": 164,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
@@ -4193,8 +7902,8 @@ data:
                         "renderer": "flot",
                         "seriesOverrides": [
                             {
-                                "$$hashKey": "object:1514",
-                                "alias": "max",
+                                "$$hashKey": "object:186",
+                                "alias": "limit",
                                 "color": "#C4162A"
                             }
                         ],
@@ -4204,30 +7913,35 @@ data:
                         "targets": [
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "sum(process_open_fds{job=~\"$job\", instance=~\"$instance\"})",
+                                "editorMode": "code",
+                                "exemplar": true,
+                                "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval])) by(instance)",
                                 "format": "time_series",
                                 "interval": "",
-                                "intervalFactor": 2,
-                                "legendFormat": "open",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "range": true,
                                 "refId": "A"
                             },
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "min(process_max_fds{job=~\"$job\", instance=~\"$instance\"})",
-                                "format": "time_series",
-                                "interval": "",
-                                "intervalFactor": 2,
-                                "legendFormat": "max",
+                                "editorMode": "code",
+                                "expr": "min(process_cpu_cores_available{job=~\"$job_insert\", instance=~\"$instance\"})",
+                                "hide": false,
+                                "legendFormat": "limit",
+                                "range": true,
                                 "refId": "B"
                             }
                         ],
                         "thresholds": [],
                         "timeRegions": [],
-                        "title": "Open FDs ($instance)",
+                        "title": "CPU ($instance)",
                         "tooltip": {
                             "shared": true,
                             "sort": 0,
@@ -4241,18 +7955,16 @@ data:
                         },
                         "yaxes": [
                             {
-                                "$$hashKey": "object:1521",
-                                "decimals": 0,
+                                "$$hashKey": "object:887",
                                 "format": "short",
-                                "logBase": 2,
+                                "logBase": 1,
                                 "min": "0",
                                 "show": true
                             },
                             {
-                                "$$hashKey": "object:1522",
+                                "$$hashKey": "object:888",
                                 "format": "short",
                                 "logBase": 1,
-                                "min": "0",
                                 "show": true
                             }
                         ],
@@ -4266,25 +7978,25 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": {
+                            "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Shows the number of bytes read/write from the storage layer.",
                         "fieldConfig": {
                             "defaults": {
                                 "links": []
                             },
                             "overrides": []
                         },
-                        "fill": 1,
+                        "fill": 0,
                         "fillGradient": 0,
                         "gridPos": {
-                            "h": 8,
+                            "h": 7,
                             "w": 12,
                             "x": 12,
-                            "y": 58
+                            "y": 65
                         },
                         "hiddenSeries": false,
-                        "id": 76,
+                        "id": 169,
                         "legend": {
                             "alignAsTable": true,
                             "avg": true,
@@ -4311,8 +8023,9 @@ data:
                         "renderer": "flot",
                         "seriesOverrides": [
                             {
-                                "alias": "read",
-                                "transform": "negative-Y"
+                                "$$hashKey": "object:186",
+                                "alias": "limit",
+                                "color": "#C4162A"
                             }
                         ],
                         "spaceLength": 10,
@@ -4321,32 +8034,35 @@ data:
                         "targets": [
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+                                "editorMode": "code",
+                                "exemplar": true,
+                                "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job_insert\", instance=~\"$instance\"}) by(instance)",
                                 "format": "time_series",
-                                "hide": false,
                                 "interval": "",
                                 "intervalFactor": 1,
-                                "legendFormat": "read",
+                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
+                                "range": true,
                                 "refId": "A"
                             },
                             {
                                 "datasource": {
+                                    "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
-                                "format": "time_series",
+                                "editorMode": "code",
+                                "expr": "min(vm_available_memory_bytes{job=~\"$job_insert\", instance=~\"$instance\"})",
                                 "hide": false,
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "write",
+                                "legendFormat": "limit",
+                                "range": true,
                                 "refId": "B"
                             }
                         ],
                         "thresholds": [],
                         "timeRegions": [],
-                        "title": "Disk writes/reads ($instance)",
+                        "title": "Memory ($instance)",
                         "tooltip": {
                             "shared": true,
                             "sort": 0,
@@ -4360,501 +8076,16 @@ data:
                         },
                         "yaxes": [
                             {
+                                "$$hashKey": "object:164",
                                 "format": "bytes",
                                 "logBase": 1,
+                                "min": "0",
                                 "show": true
                             },
                             {
+                                "$$hashKey": "object:165",
                                 "format": "short",
                                 "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 1,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 0,
-                            "y": 66
-                        },
-                        "hiddenSeries": false,
-                        "id": 47,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "max": true,
-                            "min": false,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(go_goroutines{job=~\"$job\", instance=~\"$instance\"})",
-                                "format": "time_series",
-                                "intervalFactor": 2,
-                                "legendFormat": "gc duration",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "Goroutines ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "decimals": 0,
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "description": "Shows avg GC duration",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 1,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 12,
-                            "y": 66
-                        },
-                        "hiddenSeries": false,
-                        "id": 42,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "max": true,
-                            "min": false,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(rate(go_gc_duration_seconds_sum{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n/\nsum(rate(go_gc_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
-                                "format": "time_series",
-                                "intervalFactor": 2,
-                                "legendFormat": "avg gc duration",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "GC duration ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "format": "s",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 1,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 0,
-                            "y": 74
-                        },
-                        "hiddenSeries": false,
-                        "id": 48,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "max": true,
-                            "min": false,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(process_num_threads{job=~\"$job\", instance=~\"$instance\"})",
-                                "format": "time_series",
-                                "intervalFactor": 2,
-                                "legendFormat": "threads",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "Threads ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "decimals": 0,
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "description": "",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 1,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 12,
-                            "y": 74
-                        },
-                        "hiddenSeries": false,
-                        "id": 37,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "max": true,
-                            "min": false,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"})",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 1,
-                                "legendFormat": "connections",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "TCP connections ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            }
-                        ],
-                        "yaxis": {
-                            "align": false
-                        }
-                    },
-                    {
-                        "aliasColors": {},
-                        "bars": false,
-                        "dashLength": 10,
-                        "dashes": false,
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "description": "",
-                        "fieldConfig": {
-                            "defaults": {
-                                "links": []
-                            },
-                            "overrides": []
-                        },
-                        "fill": 1,
-                        "fillGradient": 0,
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 12,
-                            "y": 82
-                        },
-                        "hiddenSeries": false,
-                        "id": 49,
-                        "legend": {
-                            "alignAsTable": true,
-                            "avg": true,
-                            "current": true,
-                            "max": true,
-                            "min": false,
-                            "show": true,
-                            "sort": "current",
-                            "sortDesc": true,
-                            "total": false,
-                            "values": true
-                        },
-                        "lines": true,
-                        "linewidth": 1,
-                        "links": [],
-                        "nullPointMode": "null",
-                        "options": {
-                            "alertThreshold": true
-                        },
-                        "percentage": false,
-                        "pluginVersion": "9.0.3",
-                        "pointradius": 2,
-                        "points": false,
-                        "renderer": "flot",
-                        "seriesOverrides": [],
-                        "spaceLength": 10,
-                        "stack": false,
-                        "steppedLine": false,
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "uid": "$ds"
-                                },
-                                "expr": "sum(rate(vm_tcplistener_accepts_total{job=~\"$job\", instance=~\"$instance\"}[$__interval]))",
-                                "format": "time_series",
-                                "hide": false,
-                                "intervalFactor": 1,
-                                "legendFormat": "connections",
-                                "refId": "A"
-                            }
-                        ],
-                        "thresholds": [],
-                        "timeRegions": [],
-                        "title": "TCP connections rate ($instance)",
-                        "tooltip": {
-                            "shared": true,
-                            "sort": 0,
-                            "value_type": "individual"
-                        },
-                        "type": "graph",
-                        "xaxis": {
-                            "mode": "time",
-                            "show": true,
-                            "values": []
-                        },
-                        "yaxes": [
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
-                                "show": true
-                            },
-                            {
-                                "format": "short",
-                                "logBase": 1,
-                                "min": "0",
                                 "show": true
                             }
                         ],
@@ -4863,32 +8094,21 @@ data:
                         }
                     }
                 ],
-                "targets": [
-                    {
-                        "datasource": {
-                            "uid": "$ds"
-                        },
-                        "refId": "A"
-                    }
-                ],
-                "title": "Resource usage",
+                "title": "vminsert ($instance)",
                 "type": "row"
             }
         ],
-        "refresh": "30s",
+        "refresh": false,
         "schemaVersion": 36,
         "style": "dark",
-        "tags": [
-            "victoriametrics",
-            "vmsingle"
-        ],
+        "tags": [],
         "templating": {
             "list": [
                 {
                     "current": {
                         "selected": false,
-                        "text": "VictoriaMetrics",
-                        "value": "VictoriaMetrics"
+                        "text": "VictoriaMetrics - cluster",
+                        "value": "VictoriaMetrics - cluster"
                     },
                     "hide": 0,
                     "includeAll": false,
@@ -4907,14 +8127,86 @@ data:
                     "datasource": {
                         "uid": "$ds"
                     },
-                    "definition": "label_values(vm_app_version{version=~\"victoria-metrics-.*\"}, job)",
-                    "hide": 0,
+                    "definition": "label_values(vm_app_version{version=~\"^vminsert.*\"}, job)",
+                    "hide": 2,
                     "includeAll": false,
                     "multi": false,
+                    "name": "job_insert",
+                    "options": [],
+                    "query": {
+                        "query": "label_values(vm_app_version{version=~\"^vminsert.*\"}, job)",
+                        "refId": "VictoriaMetrics-job_insert-Variable-Query"
+                    },
+                    "refresh": 1,
+                    "regex": "",
+                    "skipUrlSync": false,
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "current": {},
+                    "datasource": {
+                        "uid": "$ds"
+                    },
+                    "definition": "label_values(vm_app_version{version=~\"^vmselect.*\"}, job)",
+                    "hide": 2,
+                    "includeAll": false,
+                    "multi": false,
+                    "name": "job_select",
+                    "options": [],
+                    "query": {
+                        "query": "label_values(vm_app_version{version=~\"^vmselect.*\"}, job)",
+                        "refId": "VictoriaMetrics-job_select-Variable-Query"
+                    },
+                    "refresh": 1,
+                    "regex": "",
+                    "skipUrlSync": false,
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "current": {},
+                    "datasource": {
+                        "uid": "$ds"
+                    },
+                    "definition": "label_values(vm_app_version{version=~\"^vmstorage.*\"}, job)",
+                    "hide": 2,
+                    "includeAll": false,
+                    "multi": false,
+                    "name": "job_storage",
+                    "options": [],
+                    "query": {
+                        "query": "label_values(vm_app_version{version=~\"^vmstorage.*\"}, job)",
+                        "refId": "VictoriaMetrics-job_storage-Variable-Query"
+                    },
+                    "refresh": 1,
+                    "regex": "",
+                    "skipUrlSync": false,
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "current": {},
+                    "datasource": {
+                        "uid": "$ds"
+                    },
+                    "definition": "label_values(vm_app_version{version=~\"^vm(insert|select|storage).*\"}, job)",
+                    "hide": 0,
+                    "includeAll": true,
+                    "multi": true,
                     "name": "job",
                     "options": [],
                     "query": {
-                        "query": "label_values(vm_app_version{version=~\"victoria-metrics-.*\"}, job)",
+                        "query": "label_values(vm_app_version{version=~\"^vm(insert|select|storage).*\"}, job)",
                         "refId": "VictoriaMetrics-job-Variable-Query"
                     },
                     "refresh": 1,
@@ -4927,38 +8219,15 @@ data:
                     "useTags": false
                 },
                 {
-                    "current": {},
-                    "datasource": {
-                        "uid": "$ds"
-                    },
-                    "definition": "label_values(vm_app_version{job=~\"$job\", instance=~\"$instance\"},  version)",
-                    "hide": 2,
-                    "includeAll": false,
-                    "multi": false,
-                    "name": "version",
-                    "options": [],
-                    "query": {
-                        "query": "label_values(vm_app_version{job=~\"$job\", instance=~\"$instance\"},  version)",
-                        "refId": "VictoriaMetrics-version-Variable-Query"
-                    },
-                    "refresh": 1,
-                    "regex": "/.*-tags-(v\\d+\\.\\d+\\.\\d+)/",
-                    "skipUrlSync": false,
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
+                    "allValue": ".*",
                     "current": {},
                     "datasource": {
                         "uid": "$ds"
                     },
                     "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
                     "hide": 0,
-                    "includeAll": false,
-                    "multi": false,
+                    "includeAll": true,
+                    "multi": true,
                     "name": "instance",
                     "options": [],
                     "query": {
@@ -4969,10 +8238,7 @@ data:
                     "regex": "",
                     "skipUrlSync": false,
                     "sort": 0,
-                    "tagValuesQuery": "",
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
+                    "type": "query"
                 },
                 {
                     "datasource": {
@@ -5002,22 +8268,11 @@ data:
                 "1h",
                 "2h",
                 "1d"
-            ],
-            "time_options": [
-                "5m",
-                "15m",
-                "1h",
-                "6h",
-                "12h",
-                "24h",
-                "2d",
-                "7d",
-                "30d"
             ]
         },
         "timezone": "",
-        "title": "VictoriaMetrics",
-        "uid": "wNf0q_kZk",
+        "title": "VictoriaMetrics - cluster",
+        "uid": "oS7Bi_0Wz",
         "version": 1,
         "weekStart": ""
     }


### PR DESCRIPTION
Due typo in the script vm-cluster dashboard was replaced with the vm-single version.