### PR TITLE
Add extraVolumeMounts to the vmbackupmanager

### DIFF
--- a/charts/victoria-metrics-single/templates/_helpers.tpl
+++ b/charts/victoria-metrics-single/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Return if ingress supports pathType.
 {{ toYaml . }}
 {{- end -}}
 {{- if .Values.server.vmbackupmanager.restore.onStart.enabled }}
-- name: {{ template "victoria-metrics.name" . }}-vmbackupmanager
+- name: {{ template "victoria-metrics.name" . }}-vmbackupmanager-restore
   image: "{{ .Values.server.vmbackupmanager.image.repository }}:{{ .Values.server.vmbackupmanager.image.tag }}"
   imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
   args:
@@ -166,6 +166,9 @@ Return if ingress supports pathType.
     - name: server-volume
       mountPath: {{ .Values.server.persistentVolume.mountPath }}
       subPath: {{ .Values.server.persistentVolume.subPath }}
+  {{- with .Values.server.vmbackupmanager.extraVolumeMounts }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}
 {{- else -}}
 []

--- a/charts/victoria-metrics-single/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-single/templates/server-deployment.yaml
@@ -188,6 +188,9 @@ spec:
             - name: server-volume
               mountPath: {{ .Values.server.persistentVolume.mountPath }}
               subPath: {{ .Values.server.persistentVolume.subPath }}
+          {{- with .Values.server.vmbackupmanager.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- with .Values.server.extraContainers }}
         {{- toYaml . | nindent 8 }}

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -186,6 +186,9 @@ spec:
             - name: server-volume
               mountPath: {{ .Values.server.persistentVolume.mountPath }}
               subPath: {{ .Values.server.persistentVolume.subPath }}
+          {{- with .Values.server.vmbackupmanager.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
       {{- with .Values.server.extraContainers }}
       {{- toYaml . | nindent 8 }}

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -154,7 +154,7 @@ server:
   podLabels: {}
   # -- Pod's annotations
   podAnnotations: {}
-  # -- Pod's management policy 
+  # -- Pod's management policy
   podManagementPolicy: OrderedReady
 
   # -- Resource object. Ref: [http://kubernetes.io/docs/user-guide/compute-resources/](http://kubernetes.io/docs/user-guide/compute-resources/
@@ -264,6 +264,11 @@ server:
       envflag.enable: "true"
       envflag.prefix: VM_
       loggerFormat: json
+    # Extra Volume Mounts for the container
+    extraVolumeMounts:
+      []
+      # - name: example
+      #   mountPath: /example
     # -- Allows to enable restore options for pod.
     # Read more: https://docs.victoriametrics.com/vmbackupmanager.html#restore-commands
     restore:


### PR DESCRIPTION
* Add extraVolumeMounts to the vmbackupmanager container.
  It helps to mount s3/gcp config for the vmbackup utils.
* Fix duplicate container name.