### PR TITLE
vmanomaly: fix config formatting, make naming consistent

### DIFF
--- a/charts/victoria-metrics-anomaly/templates/configmap.yaml
+++ b/charts/victoria-metrics-anomaly/templates/configmap.yaml
@@ -70,9 +70,9 @@ data:
         {{- with .Values.extra_labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.monitoring.pull.enable .Values.monitoring.push.endpoint_url }}
+      {{ if or .Values.monitoring.pull.enabled .Values.monitoring.push.endpoint_url }}
       monitoring:
-        {{- if .Values.monitoring.pull.enable }}
+        {{- if .Values.monitoring.pull.enabled }}
         pull:
           {{- toYaml .Values.monitoring.pull | nindent 10 }}
         {{- end }}

--- a/charts/victoria-metrics-anomaly/templates/configmap.yaml
+++ b/charts/victoria-metrics-anomaly/templates/configmap.yaml
@@ -74,7 +74,8 @@ data:
       monitoring:
         {{- if .Values.monitoring.pull.enabled }}
         pull:
-          {{- toYaml .Values.monitoring.pull | nindent 10 }}
+          enable: {{ .Values.monitoring.pull.enabled }}
+          {{- unset .Values.monitoring.pull "enabled" | toYaml | nindent 10 }}
         {{- end }}
         {{- if .Values.monitoring.push.endpoint_url }}
         push:

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -174,7 +174,7 @@ monitoring:
   # /metrics server.
   pull:
     # -- if true expose metrics on /metric endpoint
-    enable: true
+    enabled: true
     port: 8440
   push:
     # -- push metrics on prometheus format if defined


### PR DESCRIPTION
Makes `monitoring` top-level config option as required for `vmanomaly`

Use `enabled` for consistency with another parameters.