### PR TITLE
vmanomaly: add annotation for pods to trigger recreating pod after config change

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -12,3 +12,5 @@ operator:
   - charts/victoria-metrics-operator/**/*
 single: 
   - charts/victoria-metrics-single/**/*
+anomaly:
+  - charts/victoria-metrics-anomaly/**/*

--- a/charts/victoria-metrics-anomaly/templates/deployment.yaml
+++ b/charts/victoria-metrics-anomaly/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
       {{- include "chart.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "chart.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
Currently, pod won't be recreated after CM change, so it will require either waiting until next restart or manual restart.
This PR adds annotation which will be changed after CM change, this will force pod recreation.