### PR TITLE
PDB is still created when vmstorage.enabled is set to false

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.vmstorage.enabled -}}
 {{- if .Values.vmstorage.podDisruptionBudget.enabled }}
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1

--- a/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.vmstorage.enabled -}}
-{{- if .Values.vmstorage.podDisruptionBudget.enabled }}
+{{- if and .Values.vmstorage.enabled .Values.vmstorage.podDisruptionBudget.enabled }}
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
 {{- else -}}
@@ -24,5 +23,4 @@ spec:
   selector:
     matchLabels:
       {{- include "victoria-metrics.vmstorage.matchLabels" . | nindent 6 }}
-{{- end }}
 {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
@@ -25,3 +25,4 @@ spec:
     matchLabels:
       {{- include "victoria-metrics.vmstorage.matchLabels" . | nindent 6 }}
 {{- end }}
+{{- end }}


### PR DESCRIPTION
While switching the `vmstorage.enabled` flag to false, the **Service** and **StatefulSet** are removed from the rendered manifest but not the **PDB**. Looking at all the templates, it looks like this `if` statement is missing from the PDB template.