### PR TITLE
ci: fix k3s versions

### DIFF
--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         chart: ${{ fromJSON(needs.get-changed-charts.outputs.charts) }}
-        k8s_version: ["v1.22.17", "v1.23.15", "v1.24.9"]
+        k8s_version: ["v1.22.16", "v1.23.14", "v1.24.8"]
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
Downgrade version to match versions supported by k3s.
Current versions were taken to be latest k8s versions, but k3s doesn't support these versions yet.