### PR TITLE
k8s-stack: fix ingress API check to be compatible with ArgoCD

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/ingress.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/ingress.yaml
@@ -4,10 +4,10 @@
 {{- $serviceName := printf "%s-%s" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- $ingressPathType := .Values.alertmanager.ingress.pathType | default "" -}}
 {{- $extraPaths := .Values.alertmanager.ingress.extraPaths -}}
-{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{- if $newAPI -}}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmagent.yaml
@@ -21,10 +21,10 @@ spec:
 {{- $serviceName := printf "%s-%s" "vmagent" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- $ingressPathType := .Values.vmagent.ingress.pathType | default "" -}}
 {{- $extraPaths := .Values.vmagent.ingress.extraPaths -}}
-{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{- if $newAPI -}}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/vmalert.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/vmalert.yaml
@@ -21,10 +21,10 @@ spec:
 {{- $serviceName := printf "%s-%s" "vmalert" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- $ingressPathType := .Values.vmalert.ingress.pathType | default "" -}}
 {{- $extraPaths := .Values.vmalert.ingress.extraPaths -}}
-{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{- if $newAPI -}}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmcluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmcluster.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
 {{ include "victoria-metrics-k8s-stack.VMClusterSpec" . | nindent 2}}
 
-{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{ if .Values.vmcluster.ingress.storage.enabled }}
 ---
 {{- with .Values.vmcluster.ingress.storage }}
@@ -24,7 +24,7 @@ spec:
 {{- $extraPaths := .extraPaths -}}
 {{- if $newAPI -}}
 apiVersion: networking.k8s.io/v1
-{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1
@@ -107,7 +107,7 @@ spec:
 {{- $extraPaths := .extraPaths -}}
 {{- if $newAPI -}}
 apiVersion: networking.k8s.io/v1
-{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1
@@ -190,7 +190,7 @@ spec:
 {{- $extraPaths := .extraPaths -}}
 {{- if $newAPI -}}
 apiVersion: networking.k8s.io/v1
-{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmsingle.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmsingle.yaml
@@ -20,10 +20,10 @@ spec:
 {{- $serviceName := printf "%s-%s" "vmsingle" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- $ingressPathType := .Values.vmsingle.ingress.pathType | default "" -}}
 {{- $extraPaths := .Values.vmsingle.ingress.extraPaths -}}
-{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{- if $newAPI -}}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -826,8 +826,8 @@ kubeControllerManager:
   ##
   service:
     enabled: true
-    port: 10252
-    targetPort: 10252
+    port: 10257
+    targetPort: 10257
     # selector:
     #   component: kube-controller-manager
 

--- a/hack/helm/victoria-metrics-k8s-stack.yaml
+++ b/hack/helm/victoria-metrics-k8s-stack.yaml
@@ -1,0 +1,3 @@
+vmsingle:
+  ingress:
+    enabled: true


### PR DESCRIPTION
ArgoCD checks were not working due to https://github.com/argoproj/argo-cd/issues/7291

This PR makes checks on per-API basis instead of resources ones.

Fixes  #435