### PR TITLE
Fix sidecar support

### DIFF
--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -169,6 +169,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vminsert.service.loadBalancerIP | string | `""` | Service load balancer IP |
 | vminsert.service.loadBalancerSourceRanges | list | `[]` | Load balancer source range |
 | vminsert.service.servicePort | int | `8480` | Service port |
+| vminsert.service.targetPort | string | http | Service port |
 | vminsert.service.type | string | `"ClusterIP"` | Service type |
 | vminsert.service.udp | bool | `false` | Make sure that service is not type "LoadBalancer", as it requires "MixedProtocolLBService" feature gate. ref: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/ |
 | vminsert.serviceMonitor.annotations | object | `{}` | Service Monitor annotations |
@@ -240,6 +241,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmselect.service.loadBalancerIP | string | `""` | Service load balacner IP |
 | vmselect.service.loadBalancerSourceRanges | list | `[]` | Load balancer source range |
 | vmselect.service.servicePort | int | `8481` | Service port |
+| vmselect.service.targetPort | string | http | Service port |
 | vmselect.service.type | string | `"ClusterIP"` | Service type |
 | vmselect.serviceMonitor.annotations | object | `{}` | Service Monitor annotations |
 | vmselect.serviceMonitor.enabled | bool | `false` | Enable deployment of Service Monitor for vmselect component. This is Prometheus operator object |

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -125,6 +125,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vminsert.extraArgs."envflag.enable" | string | `"true"` |  |
 | vminsert.extraArgs."envflag.prefix" | string | `"VM_"` |  |
 | vminsert.extraArgs.loggerFormat | string | `"json"` |  |
+| vminsert.extraContainers | list | `[]` |  |
 | vminsert.extraLabels | object | `{}` |  |
 | vminsert.extraVolumeMounts | list | `[]` |  |
 | vminsert.extraVolumes | list | `[]` |  |

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -126,6 +126,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources: {{- toYaml .Values.vminsert.resources | nindent 12 }}
+        {{- with .Values.vminsert.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{ toYaml . | nindent 8 }}

--- a/charts/victoria-metrics-cluster/templates/vminsert-service.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-service.yaml
@@ -34,7 +34,7 @@ spec:
     - name: http
       port: {{ .Values.vminsert.service.servicePort }}
       protocol: TCP
-      targetPort: http
+      targetPort: {{ .Values.vminsert.service.targetPort }}
 {{- if .Values.vminsert.extraArgs.clusternativeListenAddr }}
     - name: cluster-tcp
       protocol: TCP

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -104,7 +104,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- with .Values.vmselect.extraContainers }}
-        {{- toYaml . | nindent 10 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/victoria-metrics-cluster/templates/vmselect-service.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service.yaml
@@ -34,7 +34,7 @@ spec:
     - name: http
       port: {{ .Values.vmselect.service.servicePort }}
       protocol: TCP
-      targetPort: http
+      targetPort: {{ .Values.vmselect.service.targetPort }}
   {{- if .Values.vmselect.extraArgs.clusternativeListenAddr }}
     - name: cluster-tcp
       protocol: TCP

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -324,6 +324,11 @@ vminsert:
     # - name: example
     #   mountPath: /example
 
+  extraContainers:
+    []
+    # - name: config-reloader
+    #   image: reloader-image
+
   initContainers:
     []
     # - name: example

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -174,6 +174,8 @@ vmselect:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: 8481
+    # -- Target port
+    targetPort: http
     # -- Service type
     type: ClusterIP
   ingress:
@@ -384,6 +386,8 @@ vminsert:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: 8480
+    # -- Target port
+    targetPort: http
     # -- Service type
     type: ClusterIP
     # -- Enable UDP port. used if you have "spec.opentsdbListenAddr" specified


### PR DESCRIPTION
The extraContainer support was partly broken, partly missing. With these changes it is possible to inject a sidecar container into vminsert & vmselect PODs. Such extra container can terminate incoming traffic, perform authentication and proxy traffic to the "real" container.