### PR TITLE
Remove namespaces from cluster-scoped objects

### DIFF
--- a/charts/victoria-metrics-agent/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "chart.fullname" . }}-clusterrole
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 {{- with .Values.rbac.extraLabels }}

--- a/charts/victoria-metrics-agent/templates/clusterrolebinding.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "chart.fullname" . }}-clusterrolebinding
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 {{- with .Values.rbac.extraLabels }}

--- a/charts/victoria-metrics-agent/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-agent/templates/podsecuritypolicy.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "chart.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "chart.labels" . | nindent 4 }}
 {{- with .Values.rbac.extraLabels }}

--- a/charts/victoria-metrics-alert/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-alert/templates/podsecuritypolicy.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "vmalert.server.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "vmalert.server.labels" . | nindent 4 }}
 {{- with .Values.rbac.extraLabels }}

--- a/charts/victoria-metrics-auth/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-auth/templates/podsecuritypolicy.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "chart.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "chart.labels" . | nindent 4 }}
 {{- with .Values.rbac.extraLabels }}

--- a/charts/victoria-metrics-cluster/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "victoria-metrics.fullname" . }}-clusterrole
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}

--- a/charts/victoria-metrics-cluster/templates/clusterrolebinding.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "victoria-metrics.fullname" . }}-clusterrolebinding
-  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}

--- a/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "victoria-metrics.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}

--- a/charts/victoria-metrics-single/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-single/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "victoria-metrics.fullname" . }}-clusterrole
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}

--- a/charts/victoria-metrics-single/templates/clusterrolebinding.yaml
+++ b/charts/victoria-metrics-single/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "victoria-metrics.fullname" . }}-clusterrolebinding
-  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}

--- a/charts/victoria-metrics-single/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-single/templates/podsecuritypolicy.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "victoria-metrics.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "victoria-metrics.common.metaLabels" . | nindent 4 }}
   {{- if .Values.rbac.extraLabels }}


### PR DESCRIPTION
Fixes [#354](https://github.com/VictoriaMetrics/helm-charts/issues/354) 
Cluster-scoped resources need no namespace field. Some tools, like terraform-kustomization-provider, will throw validation errors if these fields exist