### PR TITLE
Bug in vmagent ConfigurationReloadFailure alert causes false alerting with vmsingle

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/rules/vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/vmagent.yaml
@@ -148,7 +148,7 @@ spec:
         description: Configuration hot-reload failed for vmagent on instance {{`{{`}} $labels.instance {{`}}`}}. Check vmagent's logs for detailed error message.
         summary: Configuration reload failed for vmagent instance {{`{{`}} $labels.instance {{`}}`}}
       expr: |-
-        vm_promscrape_config_last_reload_successful != 1
+        vm_promscrape_config_last_reload_successful{container="vmagent"} != 1
         or
         vmagent_relabel_config_last_reload_successful != 1
       labels:


### PR DESCRIPTION
vm_promscrape_config_last_reload_successful metric is emitted by vmagent and the victoriametrics pod. This update causes the alert to only fire if vmagent fails to reload.