### PR TITLE
Fix service ports

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vminsert-service.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-service.yaml
@@ -35,6 +35,12 @@ spec:
       port: {{ .Values.vminsert.service.servicePort }}
       protocol: TCP
       targetPort: {{ .Values.vminsert.service.targetPort }}
+{{- range .Values.vminsert.service.extraPorts }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      protocol: TCP
+      targetPort: {{ .targetPort }}
+{{- end }}
 {{- if .Values.vminsert.extraArgs.clusternativeListenAddr }}
     - name: cluster-tcp
       protocol: TCP

--- a/charts/victoria-metrics-cluster/templates/vmselect-service-headless.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service-headless.yaml
@@ -20,6 +20,12 @@ spec:
       port: {{ .Values.vmselect.statefulSet.service.servicePort }}
       protocol: TCP
       targetPort: http
+  {{- range .Values.vmselect.service.extraPorts }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      protocol: TCP
+      targetPort: {{ .targetPort }}
+  {{- end }}
   {{- if .Values.vmselect.extraArgs.clusternativeListenAddr }}
     - name: cluster-tcp
       protocol: TCP

--- a/charts/victoria-metrics-cluster/templates/vmselect-service.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service.yaml
@@ -35,6 +35,12 @@ spec:
       port: {{ .Values.vmselect.service.servicePort }}
       protocol: TCP
       targetPort: {{ .Values.vmselect.service.targetPort }}
+  {{- range .Values.vmselect.service.extraPorts }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      protocol: TCP
+      targetPort: {{ .targetPort }}
+  {{- end }}
   {{- if .Values.vmselect.extraArgs.clusternativeListenAddr }}
     - name: cluster-tcp
       protocol: TCP

--- a/charts/victoria-metrics-cluster/templates/vmstorage-service.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-service.yaml
@@ -28,6 +28,12 @@ spec:
       targetPort: vminsert
       protocol: TCP
       name: vminsert
+  {{- range .Values.vmstorage.service.extraPorts }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      protocol: TCP
+      targetPort: {{ .targetPort }}
+  {{- end }}
   selector:
     {{- include "victoria-metrics.vmstorage.matchLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/victoria-metrics-cluster/values-sidecar.yaml
+++ b/charts/victoria-metrics-cluster/values-sidecar.yaml
@@ -1,0 +1,58 @@
+# Example extra values files to add an auth proxy sidecar container
+---
+extraContainers: &extraContainers
+  - name: vmauth
+    securityContext:
+      {}
+    image: "victoriametrics/vmauth:latest"
+    workingDir: /
+    args:
+      - -auth.config=/config/auth.yml
+      - -envflag.enable=true
+      - -envflag.prefix=VM_
+      - -loggerFormat=json
+    imagePullPolicy: IfNotPresent
+    ports:
+      - name: proxy
+        containerPort: 8427
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: proxy
+      initialDelaySeconds: 5
+      periodSeconds: 15
+    livenessProbe:
+      tcpSocket:
+        port: proxy
+      initialDelaySeconds: 5
+      periodSeconds: 15
+      timeoutSeconds: 5
+    volumeMounts:
+      - name: auth-config
+        mountPath: /config
+    resources:
+      {}
+
+vminsert:
+  extraContainers: *extraContainers
+  extraVolumes:
+  - name: auth-config
+    secret:
+      secretName: vminsert-auth-config
+  service:
+    extraPorts:
+    - name: proxy
+      port: 8427
+      targetPort: proxy
+
+vmselect:
+  extraContainers: *extraContainers
+  extraVolumes:
+  - name: auth-config
+    secret:
+      secretName: vmselect-auth-config
+  service:
+    extraPorts:
+    - name: proxy
+      port: 8427
+      targetPort: proxy

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -168,6 +168,8 @@ vmselect:
     clusterIP: ""
     # -- Service External IPs. Ref: [https://kubernetes.io/docs/user-guide/services/#external-ips](https://kubernetes.io/docs/user-guide/services/#external-ips)
     externalIPs: []
+    # -- Extra service ports
+    extraServicePorts: []
     # -- Service load balacner IP
     loadBalancerIP: ""
     # -- Load balancer source range
@@ -380,6 +382,8 @@ vminsert:
     clusterIP: ""
     # -- Service External IPs. Ref: [https://kubernetes.io/docs/user-guide/services/#external-ips]( https://kubernetes.io/docs/user-guide/services/#external-ips)
     externalIPs: []
+    # -- Extra service ports
+    extraServicePorts: []
     # -- Service load balancer IP
     loadBalancerIP: ""
     # -- Load balancer source range
@@ -595,6 +599,8 @@ vmstorage:
     vminsertPort: 8400
     # -- Port for accepting connections from vmselect
     vmselectPort: 8401
+    # -- Extra service ports
+    extraServicePorts: []
   # -- Pod's termination grace period in seconds
   terminationGracePeriodSeconds: 60
   probe:


### PR DESCRIPTION
When adding a sidecar for tls&auth in the vminsert/vmselect pods, the corresponding service needs 2 ports. One for external traffic and one for metrics.