### PR TITLE
vmanomaly: fix config for pull-based monitoring

### DIFF
--- a/charts/victoria-metrics-anomaly/templates/configmap.yaml
+++ b/charts/victoria-metrics-anomaly/templates/configmap.yaml
@@ -58,7 +58,8 @@ data:
         {{- if .Values.monitoring.pull.enabled }}
         pull:
           enable: {{ .Values.monitoring.pull.enabled }}
-          {{- unset .Values.monitoring.pull "enabled" | toYaml | nindent 10 }}
+          {{- $v := deepCopy .Values.monitoring.pull }}
+          {{- unset $v "enabled" | toYaml | nindent 10 }}
         {{- end }}
         {{- if .Values.monitoring.push.endpoint_url }}
         push:

--- a/charts/victoria-metrics-anomaly/templates/deployment.yaml
+++ b/charts/victoria-metrics-anomaly/templates/deployment.yaml
@@ -33,6 +33,11 @@ spec:
         - name: model
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           workingDir: {{ .Values.containerWorkingDir }}
+          {{- if and .Values.monitoring.pull.enabled .Values.monitoring.pull.port }}
+          ports:
+            - containerPort: {{ .Values.monitoring.pull.port }}
+              name: metrics
+          {{- end }}
           args:
             - /etc/config/config.yml
           securityContext:


### PR DESCRIPTION
- `unset` was removing value from dict, so that `if` in CM was not evaluating to `true`
- added port definition for pod to make it easier to configure pod scraping