### PR TITLE
fix vmReadEndpoint and vmWriteEndpoint

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -83,7 +83,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.vmsingle.enabled -}}
 url: {{ printf "http://%s.%s.svc:%s%s" (include "victoria-metrics-k8s-stack.vmsingleName" .) .Release.Namespace (.Values.vmsingle.spec.port | default "8429") (index .Values "vmsingle" "spec" "extraArgs" "http.pathPrefix" | default "/") }}
 {{- else if .Values.vmcluster.enabled -}}
-url: {{ printf "http://%s-%s.%s.svc:%s%s/select/%s/prometheus" "vmselect" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vmselect.port | default "8481") (index .Values "vmcluster" "spec" "vmselect" "extraArgs" "http.pathPrefix" | default "/") (.Values.tenant | default "0") }}
+url: {{ printf "http://%s-%s.%s.svc:%s%s/select/%s/prometheus" "vmselect" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vmselect.port | default "8481") (index .Values "vmcluster" "spec" "vmselect" "extraArgs" "http.pathPrefix" | default "") (.Values.tenant | default "0") }}
 {{- else if .Values.externalVM.read.url -}}
 {{ .Values.externalVM.read | toYaml }}
 {{- end }}
@@ -93,7 +93,7 @@ url: {{ printf "http://%s-%s.%s.svc:%s%s/select/%s/prometheus" "vmselect" (inclu
 {{- if .Values.vmsingle.enabled -}}
 url: {{ printf "http://%s.%s.svc:%s%s/api/v1/write" (include "victoria-metrics-k8s-stack.vmsingleName" .) .Release.Namespace (.Values.vmsingle.spec.port | default "8429") (index .Values "vmsingle" "spec" "extraArgs" "http.pathPrefix" | default "") }}
 {{- else if .Values.vmcluster.enabled -}}
-url: {{ printf "http://%s-%s.%s.svc:%s%s/insert/%s/prometheus/api/v1/write" "vminsert" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vminsert.port | default "8480") (index .Values "vmcluster" "spec" "vminsert" "extraArgs" "http.pathPrefix" | default "/") (.Values.tenant | default "0")  }}
+url: {{ printf "http://%s-%s.%s.svc:%s%s/insert/%s/prometheus/api/v1/write" "vminsert" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace (.Values.vmcluster.spec.vminsert.port | default "8480") (index .Values "vmcluster" "spec" "vminsert" "extraArgs" "http.pathPrefix" | default "") (.Values.tenant | default "0")  }}
 {{- else if .Values.externalVM.write.url -}}
 {{ .Values.externalVM.write | toYaml }}
 {{- end }}


### PR DESCRIPTION
When vmcluster.spec.vmselect.extraArgs.http.pathPrefix and vmcluster.spec.vminsert.extraArgs.http.pathPrefix is not defined(as it is by default) address becomes invalid as it adds extra slash after port number.  
i.e: http://vmselect-k8s-stack.default.svc:8481//select/0/prometheus