### PR TITLE
update default retentionPeriod to 14d

### DIFF
--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -110,7 +110,7 @@ vmsingle:
   spec:
     image:
       tag: v1.87.0
-    retentionPeriod: "14"
+    retentionPeriod: "14d"
     replicaCount: 1
     extraArgs: {}
     storage:
@@ -161,7 +161,7 @@ vmcluster:
   # spec for VMSingle crd
   # https://docs.victoriametrics.com/operator/api.html#vmclusterspec
   spec:
-    retentionPeriod: "14"
+    retentionPeriod: "14d"
     replicationFactor: 2
     vmstorage:
       image:


### PR DESCRIPTION
If the time unit is not specified, it defaults to months. So the current default retention period is 14 months, which *probably* wasn't intended.