### PR TITLE
Add namespaced flag for vmagent

### DIFF
--- a/charts/victoria-metrics-agent/README.md
+++ b/charts/victoria-metrics-agent/README.md
@@ -326,6 +326,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | rbac.annotations | object | `{}` |  |
 | rbac.create | bool | `true` |  |
 | rbac.extraLabels | object | `{}` |  |
+| rbac.namespaced | bool | `false` | if true and `rbac.enabled`, will deploy a Role/Rolebinding instead of a ClusterRole/ClusterRoleBinding |
 | rbac.pspEnabled | bool | `true` |  |
 | remoteWriteUrls | list | `[]` |  |
 | replicaCount | int | `1` |  |

--- a/charts/victoria-metrics-agent/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrole.yaml
@@ -1,8 +1,12 @@
 {{- if .Values.rbac.create -}}
+{{- $namespaced := .Values.rbac.namespaced }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ ternary "Role" "ClusterRole" $namespaced }}
 metadata:
-  name: {{ template "chart.fullname" . }}-clusterrole
+  name: {{ template "chart.fullname" . }}{{- ternary "" "-clusterrole" $namespaced }}
+  {{- if not $namespaced }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 {{- with .Values.rbac.extraLabels }}
@@ -33,8 +37,10 @@ rules:
   resources:
   - ingresses
   verbs: ["get", "list", "watch"]
+{{- if not $namespaced }}
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
+{{- end }}
 {{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']

--- a/charts/victoria-metrics-agent/templates/clusterrolebinding.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrolebinding.yaml
@@ -1,8 +1,12 @@
 {{- if .Values.rbac.create -}}
+{{- $namespaced := .Values.rbac.namespaced }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ ternary "RoleBinding" "ClusterRoleBinding" $namespaced }}
 metadata:
-  name: {{ template "chart.fullname" . }}-clusterrolebinding
+  name: {{ template "chart.fullname" . }}{{- ternary "" "-clusterrolebinding" $namespaced }}
+  {{- if not $namespaced }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 {{- with .Values.rbac.extraLabels }}
@@ -14,8 +18,8 @@ metadata:
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "chart.fullname" . }}-clusterrole
+  kind: {{ ternary "Role" "ClusterRole" $namespaced }}
+  name: {{ template "chart.fullname" . }}{{- ternary "" "-clusterrole" $namespaced }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "chart.serviceAccountName" . }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -44,6 +44,8 @@ rbac:
   pspEnabled: true
   annotations: {}
   extraLabels: {}
+  # -- if true and `rbac.enabled`, will deploy a Role/Rolebinding instead of a ClusterRole/ClusterRoleBinding
+  namespaced: false
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
For a certain use case, I need to run victoria-metrics-agent in a single namespace w/o clusterroles/clusterrolebinding.

The chart as is does give me the option of installing without the ClusterRole/ClusterRoleBinding via the .Values.rbac.create. It would be useful for me if I could tell it to created a namespaced RBAC.

I am aware this is different than some of the other helm charts here. For example, I do see that the `victoria-metrics-alert` chart used the same flag and behaves as following (if .Values.rbac.create is true):
- Create the Role/RoleBinding
- If not namespaced, also create the ClusterRole/ClusterRoleBinding

I went with the approach in this PR as it is the least code changes and the most maintainable (as it doesn't add an additional two files/CRs).