### PR TITLE
k8s-stack: Allow configuring the timezone for the default Grafana dashboards

### DIFF
--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -392,6 +392,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | grafana.dashboards.default.nodeexporter.gnetId | int | `1860` |  |
 | grafana.dashboards.default.nodeexporter.revision | int | `22` |  |
 | grafana.defaultDashboardsEnabled | bool | `true` |  |
+| grafana.defaultDashboardsTimezone | string | `"utc"` |  |
 | grafana.enabled | bool | `true` |  |
 | grafana.forceDeployDatasource | bool | `false` |  |
 | grafana.ingress.annotations | object | `{}` |  |

--- a/charts/victoria-metrics-k8s-stack/hack/sync_grafana_dashboards.py
+++ b/charts/victoria-metrics-k8s-stack/hack/sync_grafana_dashboards.py
@@ -3,6 +3,7 @@
 from ast import operator
 from faulthandler import enable
 import json
+import re
 import textwrap
 from os import makedirs, path
 
@@ -218,6 +219,11 @@ def patch_dashboards_json(content):
     return content
 
 
+def patch_json_set_timezone_as_variable(content):
+    # content is no more in json format, so we have to replace using regex
+    return re.sub(r'"timezone"\s*:\s*"(?:\\.|[^\"])*"', '"timezone": "\{\{ .Values.grafana.defaultDashboardsTimezone \}\}"', content, flags=re.IGNORECASE)
+
+
 def write_group_to_file(resource_name, content, url, destination):
     if condition_map.get(resource_name, ""):
         cond = f'if and .Values.defaultDashboardsEnabled {condition_map.get(resource_name, "")}'
@@ -232,6 +238,7 @@ def write_group_to_file(resource_name, content, url, destination):
     }
 
     content = patch_dashboards_json(content)
+    content = patch_json_set_timezone_as_variable(content)
 
     filename_struct = {resource_name + '.json': (LiteralStr(content))}
     # rules themselves

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/alertmanager-overview.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/alertmanager-overview.yaml
@@ -615,7 +615,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Alertmanager / Overview",
         "uid": "alertmanager-overview",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/apiserver.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/apiserver.yaml
@@ -1773,7 +1773,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / API server",
         "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/backupmanager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/backupmanager.yaml
@@ -1778,7 +1778,7 @@ data:
             "to": "now"
         },
         "timepicker": {},
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "VictoriaMetrics - backupmanager",
         "uid": "gF-lxRdVz",
         "version": 1,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/cluster-total.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/cluster-total.yaml
@@ -1883,7 +1883,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Cluster",
         "uid": "ff635a025bcfea7bc3dd4f508990a3e9",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/controller-manager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/controller-manager.yaml
@@ -1191,7 +1191,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Controller Manager",
         "uid": "72e0e05bef5099e5f049b05fdc429ed4",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/etcd.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/etcd.yaml
@@ -1125,7 +1125,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "browser",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "etcd",
         "version": 215
     }

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/grafana-overview.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/grafana-overview.yaml
@@ -636,7 +636,7 @@ data:
                 "1d"
             ]
         },
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Grafana Overview",
         "uid": "6be0s85Mk",
         "version": 2

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-coredns.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-coredns.yaml
@@ -2337,7 +2337,7 @@ data:
             "30d"
             ]
         },
-        "timezone": "browser",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "K8S CoreDNS",
         "uid": "87f283d9c4c7426ca420a25e884a99e9",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-cluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-cluster.yaml
@@ -3089,7 +3089,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Cluster",
         "uid": "efa86fd1d0c121a26444b636a3f509a8",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-namespace.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-namespace.yaml
@@ -2798,7 +2798,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Namespace (Pods)",
         "uid": "85a562078cdf77779eaa1add43ccec1e",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-node.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-node.yaml
@@ -1027,7 +1027,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Node (Pods)",
         "uid": "200ac8fdbfbb74b39aff88118e4d1c2c",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-pod.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-pod.yaml
@@ -2470,7 +2470,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Pod",
         "uid": "6581e46e4e5c7ba40a07646395ef7b23",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-workload.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-workload.yaml
@@ -2025,7 +2025,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Workload",
         "uid": "a164a7f0339f99e89cea5cb47e9be617",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-workloads-namespace.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-resources-workloads-namespace.yaml
@@ -2190,7 +2190,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Namespace (Workloads)",
         "uid": "a87fb0d919ec0ea5f6543124e16c42a5",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-system-api-server.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-system-api-server.yaml
@@ -1353,7 +1353,7 @@ data:
             "to": "now"
         },
         "timepicker": {},
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / System / API Server",
         "uid": "k8s_system_apisrv",
         "version": 11,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-system-coredns.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-system-coredns.yaml
@@ -1580,7 +1580,7 @@ data:
             "to": "now"
         },
         "timepicker": {},
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / System / CoreDNS",
         "uid": "k8s_system_coredns",
         "version": 9,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-global.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-global.yaml
@@ -2091,7 +2091,7 @@ data:
             "to": "now"
         },
         "timepicker": {},
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Views / Global",
         "uid": "k8s_views_global",
         "version": 20,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-namespaces.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-namespaces.yaml
@@ -1609,7 +1609,7 @@ data:
             "to": "now"
         },
         "timepicker": {},
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Views / Namespaces",
         "uid": "k8s_views_ns",
         "version": 15,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-nodes.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-nodes.yaml
@@ -3807,7 +3807,7 @@ data:
             "to": "now"
         },
         "timepicker": {},
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Views / Nodes",
         "uid": "k8s_views_nodes",
         "version": 14,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-pods.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-pods.yaml
@@ -1923,7 +1923,7 @@ data:
             "to": "now"
         },
         "timepicker": {},
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Views / Pods",
         "uid": "k8s_views_pods",
         "version": 15,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/kubelet.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/kubelet.yaml
@@ -2255,7 +2255,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Kubelet",
         "uid": "3138fa155d5915769fbded898ac09fd9",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/namespace-by-pod.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/namespace-by-pod.yaml
@@ -1465,7 +1465,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Namespace (Pods)",
         "uid": "8b7a8b326d7a6f1f04244066368c67af",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/namespace-by-workload.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/namespace-by-workload.yaml
@@ -1737,7 +1737,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Namespace (Workload)",
         "uid": "bbb2a765a623ae38130206c7d94a160f",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/node-cluster-rsrc-use.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/node-cluster-rsrc-use.yaml
@@ -1065,7 +1065,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Node Exporter / USE Method / Cluster",
         "version": 0
     }

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/node-rsrc-use.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/node-rsrc-use.yaml
@@ -1091,7 +1091,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Node Exporter / USE Method / Node",
         "version": 0
     }

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/nodes-darwin.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/nodes-darwin.yaml
@@ -1075,7 +1075,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Node Exporter / MacOS",
         "version": 0
     }

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/nodes.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/nodes.yaml
@@ -1068,7 +1068,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Node Exporter / Nodes",
         "version": 0
     }

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/operator.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/operator.yaml
@@ -1311,7 +1311,7 @@ data:
             "to": "now"
         },
         "timepicker": {},
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "VictoriaMetrics - operator",
         "uid": "1H179hunk",
         "version": 1,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/persistentvolumesusage.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/persistentvolumesusage.yaml
@@ -588,7 +588,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Persistent Volumes",
         "uid": "919b92a8e8041bd567af9edab12c840c",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/pod-total.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/pod-total.yaml
@@ -1229,7 +1229,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Pod",
         "uid": "7a18067ce943a40ae25454675c19ff5c",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/proxy.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/proxy.yaml
@@ -1272,7 +1272,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Proxy",
         "uid": "632e265de029684c40b21cb76bca4f94",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/scheduler.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/scheduler.yaml
@@ -1113,7 +1113,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Scheduler",
         "uid": "2e6b6a3b4bddf1427b3a55aa1311c656",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
@@ -8541,7 +8541,7 @@ data:
                 "1d"
             ]
         },
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "VictoriaMetrics - cluster",
         "uid": "oS7Bi_0Wz",
         "version": 1,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics.yaml
@@ -5112,7 +5112,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "VictoriaMetrics",
         "uid": "wNf0q_kZk",
         "version": 1,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmagent.yaml
@@ -5070,7 +5070,7 @@ data:
                 "1d"
             ]
         },
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "VictoriaMetrics - vmagent",
         "uid": "G7Z9GzMGz",
         "version": 1,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmalert.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmalert.yaml
@@ -2356,7 +2356,7 @@ data:
             "to": "now"
         },
         "timepicker": {},
-        "timezone": "",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "VictoriaMetrics - vmalert",
         "uid": "LzldHAVnz",
         "version": 1,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/workload-total.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/workload-total.yaml
@@ -1439,7 +1439,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Workload",
         "uid": "728bf77cc1166d2f3133bf25846876cc",
         "version": 0

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -665,6 +665,8 @@ grafana:
 
   defaultDashboardsEnabled: true
 
+  defaultDashboardsTimezone: utc
+
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName


### PR DESCRIPTION
Provides an option to configure the default timezone for all the default dashboards in Grafana.

Based on the option available in the `kube-prometheus-stack` Helm chart: https://github.com/prometheus-community/helm-charts/pull/1326