### PR TITLE
[victoria-metrics-alert] Bumped default alertmanager version to v0.25.0

### DIFF
--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -260,7 +260,7 @@ alertmanager:
     labels: {}
     annotations: {}
   image: prom/alertmanager
-  tag: v0.20.0
+  tag: v0.25.0
   retention: 120h
   nodeSelector: {}
   priorityClassName: ""


### PR DESCRIPTION
Bumped alertmanager version to v0.25.0 because the default version is more than obsolete (v0.20.0 from 2019).