### PR TITLE
[charts/victoria-metrics-cluster] add PVC labels

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: 1.88.1
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.9.56
+version: 0.9.57
 sources:
 - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for Cluster Version
 
- ![Version: 0.9.56](https://img.shields.io/badge/Version-0.9.56-informational?style=flat-square)
+ ![Version: 0.9.57](https://img.shields.io/badge/Version-0.9.57-informational?style=flat-square)
 
 Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 
@@ -217,6 +217,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmselect.persistentVolume.annotations | object | `{}` | Persistent volume annotations |
 | vmselect.persistentVolume.enabled | bool | `false` | Create/use Persistent Volume Claim for vmselect component. Empty dir if false. If true, vmselect will create/use a Persistent Volume Claim |
 | vmselect.persistentVolume.existingClaim | string | `""` | Existing Claim name. Requires vmselect.persistentVolume.enabled: true. If defined, PVC must be created manually before volume will be bound |
+| vmselect.persistentVolume.labels | object | `{}` | Persistent volume labels |
 | vmselect.persistentVolume.size | string | `"2Gi"` | Size of the volume. Better to set the same as resource limit memory property |
 | vmselect.persistentVolume.subPath | string | `""` | Mount subpath |
 | vmselect.podAnnotations | object | `{}` | Pod's annotations |
@@ -285,6 +286,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmstorage.persistentVolume.annotations | object | `{}` | Persistent volume annotations |
 | vmstorage.persistentVolume.enabled | bool | `true` | Create/use Persistent Volume Claim for vmstorage component. Empty dir if false. If true,  vmstorage will create/use a Persistent Volume Claim |
 | vmstorage.persistentVolume.existingClaim | string | `""` | Existing Claim name. Requires vmstorage.persistentVolume.enabled: true. If defined, PVC must be created manually before volume will be bound |
+| vmstorage.persistentVolume.labels | object | `{}` | Persistent volume labels |
 | vmstorage.persistentVolume.mountPath | string | `"/storage"` | Data root path. Vmstorage data Persistent Volume mount root path |
 | vmstorage.persistentVolume.size | string | `"8Gi"` | Size of the volume. Better to set the same as resource limit memory property |
 | vmstorage.persistentVolume.storageClass | string | `""` | Storage class name. Will be empty if not setted |

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -135,8 +135,12 @@ spec:
         name: cache-volume
         {{- if .Values.vmselect.persistentVolume.annotations }}
         annotations:
-    {{ toYaml .Values.vmselect.persistentVolume.annotations | indent 10 }}
-    {{- end }}
+        {{ toYaml .Values.vmselect.persistentVolume.annotations | indent 10 }}
+        {{- end }}
+        {{- if .Values.vmstorage.persistentVolume.labels }}
+        labels:
+        {{ toYaml .Values.vmstorage.persistentVolume.labels | indent 10 }}
+        {{- end }}
       spec:
         accessModes:
         {{ toYaml .Values.vmselect.persistentVolume.accessModes | indent 10 }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -203,6 +203,10 @@ spec:
         annotations:
 {{ toYaml .Values.vmstorage.persistentVolume.annotations | indent 10 }}
         {{- end }}
+        {{- if .Values.vmstorage.persistentVolume.labels }}
+        labels:
+{{ toYaml .Values.vmstorage.persistentVolume.labels | indent 10 }}
+        {{- end }}
       spec:
         accessModes:
 {{ toYaml .Values.vmstorage.persistentVolume.accessModes | indent 10 }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -227,6 +227,9 @@ vmselect:
     # -- Persistent volume annotations
     annotations: {}
 
+    # -- Persistent volume labels
+    labels: {}
+
     # -- Existing Claim name. Requires vmselect.persistentVolume.enabled: true. If defined, PVC must be created manually before volume will be bound
     existingClaim: ""
 
@@ -553,6 +556,8 @@ vmstorage:
       - ReadWriteOnce
     # -- Persistent volume annotations
     annotations: {}
+    # -- Persistent volume labels
+    labels: {}
     # -- Storage class name. Will be empty if not setted
     storageClass: ""
     # --  Existing Claim name. Requires vmstorage.persistentVolume.enabled: true. If defined, PVC must be created manually before volume will be bound


### PR DESCRIPTION
**Description of the change**
This PR adds the configuration of labels to PVC.

**Benefits**
We use this chart to provision temporary database and then remove it in CI/CD. This labels let us to delete PVC after uninstall chart.