### PR TITLE
fix label selector for argocd

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/servicescrape.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/servicescrape.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ default $.Release.Name $.Values.argocdReleaseOverride | quote }}
       app.kubernetes.io/name: victoria-metrics-operator
   endpoints:
     - port: http


### PR DESCRIPTION
When deployed via argocd servicescrape is selecting wrong labels