### PR TITLE
fix custom vmstorage node address render in vmselect and vminsert args

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -56,6 +56,10 @@ spec:
           args:
           {{- if not .Values.vminsert.suppresStorageFQDNsRender }}
             {{- include "victoria-metrics.vminsert.vmstorage-pod-fqdn" . | nindent 12 }}
+          {{- else }}
+          {{- range $vmstorageNode := .Values.vminsert.vmstorageNodes }}
+            - --storageNode={{ $vmstorageNode }}
+          {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.vminsert.extraArgs }}
             - --{{ $key }}={{ $value }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -57,6 +57,10 @@ spec:
             - {{ printf "%s=%s" "--cacheDataPath" .Values.vmselect.cacheMountPath | quote}}
           {{- if not .Values.vmselect.suppresStorageFQDNsRender }}
           {{- include "victoria-metrics.vmselect.vmstorage-pod-fqdn" . | nindent 12 }}
+          {{- else }}
+          {{- range $vmstorageNode := .Values.vmselect.vmstorageNodes }}
+            - --storageNode={{ $vmstorageNode }}
+          {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.vmselect.extraArgs }}
             - --{{ $key }}={{ $value }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -51,8 +51,10 @@ vmselect:
   priorityClassName: ""
   # -- Overrides the full name of vmselect component
   fullnameOverride: ""
-  # -- Suppress rendering `--storageNode` FQDNs based on `vmstorage.replicaCount` value. If true suppress rendering `--storageNodes`, they can be re-defined in extraArgs
+  # -- Suppress rendering `--storageNode` FQDNs based on `vmstorage.replicaCount` value.
   suppresStorageFQDNsRender: false
+  # -- If suppresStorageFQDNsRender true suppress rendering `--stroageNodes`, they can be re-defined in vmstorageNodes.
+  vmstorageNodes: []
   automountServiceAccountToken: true
   # Extra command line arguments for vmselect component
   extraArgs:
@@ -290,8 +292,10 @@ vminsert:
   extraLabels: {}
   # -- Additional environment variables (ex.: secret tokens, flags) https://github.com/VictoriaMetrics/VictoriaMetrics#environment-variables
   env: []
-  # -- Suppress rendering `--storageNode` FQDNs based on `vmstorage.replicaCount` value. If true suppress rendering `--storageNodes`, they can be re-defined in extraArgs
+  # -- Suppress rendering `--storageNode` FQDNs based on `vmstorage.replicaCount` value.
   suppresStorageFQDNsRender: false
+  # -- If suppresStorageFQDNsRender true suppress rendering `--stroageNodes`, they can be re-defined in vmstorageNodes.
+  vmstorageNodes: []
   automountServiceAccountToken: true
 
   # Readiness & Liveness probes


### PR DESCRIPTION
When specified vmstorage node address in extraArgs, multiple vmstorage nodes would be deduplicated because of same key `storageNode`. 
If adding these address in a list, it could resolve the problem.
