### PR TITLE
[victoria-metrics-k8s-stack] add extraArgs options for operator

### DIFF
--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -22,6 +22,7 @@ victoria-metrics-operator:
   operator:
     # -- By default, operator converts prometheus-operator objects.
     disable_prometheus_converter: true
+  extraArgs: {}
 
 serviceAccount:
   # -- Specifies whether a service account should be created


### PR DESCRIPTION
When I'm using `victoria-metrics-k8s-stack`, I want to set the args of the operator, but I can't find it in the chart. Then I found that `operator` supports extraArgs option on v0.30.4(https://github.com/VictoriaMetrics/helm-charts/commit/26450278f9853cbd5ff48a81d8880c10ea420e36), so probably `victoria-metrics-k8s-stack` should support it too.