### PR TITLE
[victoria-metrics-operator]:fix extraArgs options

### DIFF
--- a/charts/victoria-metrics-operator/templates/deployment.yaml
+++ b/charts/victoria-metrics-operator/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             - --webhook.enable=true
             {{- end }}
             {{- range $key, $value := .Values.extraArgs }}
-            - -{{ $key }}={{ $value }}
+            - --{{ $key }}={{ $value }}
             {{- end }}
           command:
             - manager


### PR DESCRIPTION
I found some bugs when I used `extraArgs` of operators. The chart resolves `extraArgs` as shorthand and `operator` via `pflag` so that `--` and `-` have different meanings.