### PR TITLE
[victoria-metrics-k8s-stack]:adding tpl upstream for external labels …

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -132,6 +132,15 @@ configMaps:
 {{- end -}}
 
 {{/*
+VMAlert externalLabels
+*/}}
+{{- define "victoria-metrics-k8s-stack.vmAlertExternalLabels" -}}
+{{- if .Values.vmalert.spec.externalLabels }}
+{{- tpl (toYaml .Values.vmalert.spec.externalLabels | nindent 2) . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 VMAlert spec
 */}}
 {{- define "victoria-metrics-k8s-stack.vmAlertSpec" -}}
@@ -140,6 +149,7 @@ VMAlert spec
 {{- $_ := set $extraArgs "rule.templates" (print "/etc/vm/configs/" (printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "vmalert-extra-tpl" | trunc 63 | trimSuffix "-" ) "/*.tmpl") -}}
 {{- end -}}
 {{- $_ := set $extraArgs "remoteWrite.disablePathAppend" "true" -}}
+{{- $_ := set .Values.vmalert.spec "externalLabels" (include "victoria-metrics-k8s-stack.vmAlertExternalLabels" . | fromYaml) -}}
 {{ deepCopy .Values.vmalert.spec | mergeOverwrite (include "victoria-metrics-k8s-stack.vmAlertRemotes" . | fromYaml) | mergeOverwrite (include "victoria-metrics-k8s-stack.vmAlertTemplates" . | fromYaml) | mergeOverwrite (dict "extraArgs" $extraArgs) | toYaml }}
 {{- end }}
 

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -503,6 +503,9 @@ vmalert:
       tag: v1.89.1
     evaluationInterval: 15s
 
+    # External labels to add to all generated recording rules and alerts
+    externalLabels: {}
+
   # extra vmalert annotation templates
   templateFiles:
     {}


### PR DESCRIPTION
hi,
When I use `prom` to add external labels, it supports tpl upstream. But the chart doesn't support tpl upstream to set `-externalLabels` parameter  of `vmalert`.