### PR TITLE
[victoria-metrics-auth] add 'appProtocol' and 'enableHttp2' options

### DIFF
--- a/charts/victoria-metrics-auth/Chart.yaml
+++ b/charts/victoria-metrics-auth/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: 1.90.0
 description: Victoria Metrics Auth - is a simple auth proxy and router for VictoriaMetrics.
 name: victoria-metrics-auth
-version: 0.2.80
+version: 0.2.81
 sources:
 - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-auth/README.md
+++ b/charts/victoria-metrics-auth/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Victoria Metrics Auth.
 
- ![Version: 0.2.80](https://img.shields.io/badge/Version-0.2.80-informational?style=flat-square)
+ ![Version: 0.2.81](https://img.shields.io/badge/Version-0.2.81-informational?style=flat-square)
 
 Victoria Metrics Auth - is a simple auth proxy and router for VictoriaMetrics.
 
@@ -140,6 +140,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | secretName | string | `""` | Use existing secret if specified otherwise .config values will be used. Ref: https://victoriametrics.github.io/vmauth.html. Configuration in the given secret must be stored under `auth.yml` key. |
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |
+| service.appProtocol | string | `""` | Adds the optional appProtocol field to the service. This allows the service to work with Istio protocol-selection. Documentation: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/ |
 | service.clusterIP | string | `""` |  |
 | service.enabled | bool | `true` |  |
 | service.externalIPs | list | `[]` |  |
@@ -152,6 +153,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor.annotations | object | `{}` |  |
+| serviceMonitor.enableHttp2 | bool | `nil` | Optional. Whether to enable or disable HTTP2. Documentation: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitorSpec |
 | serviceMonitor.enabled | bool | `false` |  |
 | serviceMonitor.extraLabels | object | `{}` |  |
 | serviceMonitor.relabelings | list | `[]` |  |

--- a/charts/victoria-metrics-auth/templates/service-monitor.yaml
+++ b/charts/victoria-metrics-auth/templates/service-monitor.yaml
@@ -41,4 +41,7 @@ spec:
       relabelings:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if (kindIs "bool" .Values.serviceMonitor.enableHttp2) }}
+      enableHttp2: {{ .Values.serviceMonitor.enableHttp2 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-auth/templates/service.yaml
+++ b/charts/victoria-metrics-auth/templates/service.yaml
@@ -38,6 +38,9 @@ spec:
       {{- with .Values.service.nodePort }}
       nodePort: {{ . }}
       {{- end }}
+      {{- with .Values.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.service.type }}"

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -100,6 +100,8 @@ service:
   # Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   # externalTrafficPolicy: "local"
   # healthCheckNodePort: 0
+  # -- Adds the optional appProtocol field to the service. This allows the service to work with Istio protocol-selection. Documentation: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/
+  appProtocol: ""
 
 ingress:
   enabled: false
@@ -183,6 +185,8 @@ serviceMonitor:
   # -- Commented. TLS configuration to use when scraping the endpoint
 #    tlsConfig:
 #      insecureSkipVerify: true
+  # -- (bool) Optional. Whether to enable or disable HTTP2. Documentation: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitorSpec
+  enableHttp2: null
 
 # -- Use existing secret if specified otherwise .config values will be used. Ref: https://victoriametrics.github.io/vmauth.html.
 # Configuration in the given secret must be stored under `auth.yml` key.


### PR DESCRIPTION
When Istio is configured with PeerAuthentication-[policy](https://istio.io/latest/docs/concepts/security/#authentication-policies) mode set to STRICT, mutual TLS is enforced by default. Istio is relying on [protocol selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/) to proxy traffic. This pull-request will add the optional `appProtocol`-filed to the service file.

This pull-request will also add the optional `enableHttp2` ([prometheus-operator](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitorSpec)) filed to the serviceMonitor-file. To make the `enableHttp2` field optional the Helm [kindIs helper function](https://helm.sh/docs/chart_template_guide/function_list/#kind-functions) is used.

```yaml
{{- if (kindIs "bool" .Values.serviceMonitor.enableHttp2) }}
enableHttp2: {{ .Values.serviceMonitor.enableHttp2 }}
{{- end }}
```

This snippet will only set the `enableHttp2` filed if `serviceMonitor.enableHttp2` is either `true` or `false`. If it is empty or set to something else, it will be ignored.

Feedback and improvements are welcome.