### PR TITLE
[victoria-metrics-cluster] add 'appProtocol' and 'enableHttp2' options

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: 1.90.0
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.9.61
+version: 0.9.62
 sources:
 - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for Cluster Version
 
- ![Version: 0.9.61](https://img.shields.io/badge/Version-0.9.61-informational?style=flat-square)
+ ![Version: 0.9.62](https://img.shields.io/badge/Version-0.9.62-informational?style=flat-square)
 
 Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 
@@ -163,6 +163,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vminsert.resources | object | `{}` | Resource object |
 | vminsert.securityContext | object | `{}` | Pod's security context. Ref: [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | vminsert.service.annotations | object | `{}` | Service annotations |
+| vminsert.service.appProtocol | string | `""` | Adds the optional appProtocol field to the service. This allows the service to work with Istio protocol-selection. Documentation: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/ |
 | vminsert.service.clusterIP | string | `""` | Service ClusterIP |
 | vminsert.service.externalIPs | list | `[]` | Service External IPs. Ref: [https://kubernetes.io/docs/user-guide/services/#external-ips]( https://kubernetes.io/docs/user-guide/services/#external-ips) |
 | vminsert.service.extraServicePorts | list | `[]` | Extra service ports |
@@ -174,6 +175,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vminsert.service.type | string | `"ClusterIP"` | Service type |
 | vminsert.service.udp | bool | `false` | Make sure that service is not type "LoadBalancer", as it requires "MixedProtocolLBService" feature gate. ref: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/ |
 | vminsert.serviceMonitor.annotations | object | `{}` | Service Monitor annotations |
+| vminsert.serviceMonitor.enableHttp2 | bool | `nil` | Optional. Whether to enable or disable HTTP2. Documentation: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitorSpec |
 | vminsert.serviceMonitor.enabled | bool | `false` | Enable deployment of Service Monitor for vminsert component. This is Prometheus operator object |
 | vminsert.serviceMonitor.extraLabels | object | `{}` | Service Monitor labels |
 | vminsert.serviceMonitor.namespace | string | `""` | Target namespace of ServiceMonitor manifest |
@@ -237,6 +239,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmselect.resources | object | `{}` | Resource object |
 | vmselect.securityContext | object | `{}` | Pod's security context. Ref: [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | vmselect.service.annotations | object | `{}` | Service annotations |
+| vmselect.service.appProtocol | string | `""` | Adds the optional appProtocol field to the service. This allows the service to work with Istio protocol-selection. Documentation: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/ |
 | vmselect.service.clusterIP | string | `""` | Service ClusterIP |
 | vmselect.service.externalIPs | list | `[]` | Service External IPs. Ref: [https://kubernetes.io/docs/user-guide/services/#external-ips](https://kubernetes.io/docs/user-guide/services/#external-ips) |
 | vmselect.service.extraServicePorts | list | `[]` | Extra service ports |
@@ -247,6 +250,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmselect.service.targetPort | string | `"http"` | Target port |
 | vmselect.service.type | string | `"ClusterIP"` | Service type |
 | vmselect.serviceMonitor.annotations | object | `{}` | Service Monitor annotations |
+| vmselect.serviceMonitor.enableHttp2 | bool | `nil` | Optional. Whether to enable or disable HTTP2. Documentation: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitorSpec |
 | vmselect.serviceMonitor.enabled | bool | `false` | Enable deployment of Service Monitor for vmselect component. This is Prometheus operator object |
 | vmselect.serviceMonitor.extraLabels | object | `{}` | Service Monitor labels |
 | vmselect.serviceMonitor.namespace | string | `""` | Target namespace of ServiceMonitor manifest |
@@ -312,12 +316,14 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmstorage.retentionPeriod | int | `1` | Data retention period. Supported values 1w, 1d, number without measurement means month, e.g. 2 = 2month |
 | vmstorage.securityContext | object | `{}` | Pod's security context. Ref: [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | vmstorage.service.annotations | object | `{}` | Service annotations |
+| vmstorage.service.appProtocol | string | `""` | Adds the optional appProtocol field to the service. This allows the service to work with Istio protocol-selection. Documentation: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/ |
 | vmstorage.service.extraServicePorts | list | `[]` | Extra service ports |
 | vmstorage.service.labels | object | `{}` | Service labels |
 | vmstorage.service.servicePort | int | `8482` | Service port |
 | vmstorage.service.vminsertPort | int | `8400` | Port for accepting connections from vminsert |
 | vmstorage.service.vmselectPort | int | `8401` | Port for accepting connections from vmselect |
 | vmstorage.serviceMonitor.annotations | object | `{}` | Service Monitor annotations |
+| vmstorage.serviceMonitor.enableHttp2 | bool | `nil` | Optional. Whether to enable or disable HTTP2. Documentation: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitorSpec |
 | vmstorage.serviceMonitor.enabled | bool | `false` | Enable deployment of Service Monitor for vmstorage component. This is Prometheus operator object |
 | vmstorage.serviceMonitor.extraLabels | object | `{}` | Service Monitor labels |
 | vmstorage.serviceMonitor.namespace | string | `""` | Target namespace of ServiceMonitor manifest |

--- a/charts/victoria-metrics-cluster/templates/vminsert-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-service-monitor.yaml
@@ -41,4 +41,7 @@ spec:
       relabelings:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if (kindIs "bool" .Values.vminsert.serviceMonitor.enableHttp2) }}
+      enableHttp2: {{ .Values.vminsert.serviceMonitor.enableHttp2 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vminsert-service.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-service.yaml
@@ -35,11 +35,17 @@ spec:
       port: {{ .Values.vminsert.service.servicePort }}
       protocol: TCP
       targetPort: {{ .Values.vminsert.service.targetPort }}
+      {{- with .Values.vminsert.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
 {{- range .Values.vminsert.service.extraPorts }}
     - name: {{ .name }}
       port: {{ .port }}
       protocol: TCP
       targetPort: {{ .targetPort }}
+      {{- with .appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
 {{- end }}
 {{- if .Values.vminsert.extraArgs.clusternativeListenAddr }}
     - name: cluster-tcp

--- a/charts/victoria-metrics-cluster/templates/vmselect-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service-monitor.yaml
@@ -41,4 +41,7 @@ spec:
       relabelings:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if (kindIs "bool" .Values.vmselect.serviceMonitor.enableHttp2) }}
+      enableHttp2: {{ .Values.vmselect.serviceMonitor.enableHttp2 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-service.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-service.yaml
@@ -35,11 +35,17 @@ spec:
       port: {{ .Values.vmselect.service.servicePort }}
       protocol: TCP
       targetPort: {{ .Values.vmselect.service.targetPort }}
+      {{- with .Values.vmselect.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
   {{- range .Values.vmselect.service.extraPorts }}
     - name: {{ .name }}
       port: {{ .port }}
       protocol: TCP
       targetPort: {{ .targetPort }}
+      {{- with .appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
   {{- end }}
   {{- if .Values.vmselect.extraArgs.clusternativeListenAddr }}
     - name: cluster-tcp

--- a/charts/victoria-metrics-cluster/templates/vmstorage-service-monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-service-monitor.yaml
@@ -41,4 +41,7 @@ spec:
       relabelings:
           {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if (kindIs "bool" .Values.vmstorage.serviceMonitor.enableHttp2) }}
+      enableHttp2: {{ .Values.vmstorage.serviceMonitor.enableHttp2 }}
+      {{- end }}
   {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-service.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-service.yaml
@@ -20,19 +20,31 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- with .Values.vmstorage.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
     - port: {{ .Values.vmstorage.service.vmselectPort }}
       targetPort: vmselect
       protocol: TCP
       name: vmselect
+      {{- with .Values.vmstorage.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
     - port: {{ .Values.vmstorage.service.vminsertPort }}
       targetPort: vminsert
       protocol: TCP
       name: vminsert
+      {{- with .Values.vmstorage.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
   {{- range .Values.vmstorage.service.extraPorts }}
     - name: {{ .name }}
       port: {{ .port }}
       protocol: TCP
       targetPort: {{ .targetPort }}
+      {{- with .appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
   {{- end }}
   selector:
     {{- include "victoria-metrics.vmstorage.matchLabels" . | nindent 4 }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -180,6 +180,8 @@ vmselect:
     targetPort: http
     # -- Service type
     type: ClusterIP
+    # -- Adds the optional appProtocol field to the service. This allows the service to work with Istio protocol-selection. Documentation: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/
+    appProtocol: ""
   ingress:
     # -- Enable deployment of ingress for vmselect component
     enabled: false
@@ -259,6 +261,8 @@ vmselect:
 #      insecureSkipVerify: true
     # -- Service Monitor relabelings
     relabelings: []
+    # -- (bool) Optional. Whether to enable or disable HTTP2. Documentation: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitorSpec
+    enableHttp2: null
 
 vminsert:
   # -- Enable deployment of vminsert component. Deployment is used
@@ -400,6 +404,8 @@ vminsert:
     # -- Enable UDP port. used if you have "spec.opentsdbListenAddr" specified
     # -- Make sure that service is not type "LoadBalancer", as it requires "MixedProtocolLBService" feature gate. ref: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
     udp: false
+    # -- Adds the optional appProtocol field to the service. This allows the service to work with Istio protocol-selection. Documentation: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/
+    appProtocol: ""
   ingress:
     # -- Enable deployment of ingress for vminsert component
     enabled: false
@@ -443,6 +449,8 @@ vminsert:
 #      insecureSkipVerify: true
     # -- Service Monitor relabelings
     relabelings: []
+    # -- (bool) Optional. Whether to enable or disable HTTP2. Documentation: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitorSpec
+    enableHttp2: null
 
 vmstorage:
   # -- Enable deployment of vmstorage component. StatefulSet is used
@@ -606,6 +614,8 @@ vmstorage:
     vmselectPort: 8401
     # -- Extra service ports
     extraServicePorts: []
+    # -- Adds the optional appProtocol field to the service. This allows the service to work with Istio protocol-selection. Documentation: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/
+    appProtocol: ""
   # -- Pod's termination grace period in seconds
   terminationGracePeriodSeconds: 60
   probe:
@@ -709,3 +719,5 @@ vmstorage:
 #      insecureSkipVerify: true
     # -- Service Monitor relabelings
     relabelings: []
+    # -- (bool) Optional. Whether to enable or disable HTTP2. Documentation: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitorSpec
+    enableHttp2: null


### PR DESCRIPTION
When Istio is configured with PeerAuthentication-[policy](https://istio.io/latest/docs/concepts/security/#authentication-policies) mode set to STRICT, mutual TLS is enforced by default. Istio is relying on [protocol selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/) to proxy traffic. This pull-request will add the optional `appProtocol`-filed to the service file.

This pull-request will also add the optional `enableHttp2` ([prometheus-operator](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitorSpec)) filed to the serviceMonitor-file. To make the `enableHttp2` field optional the Helm [kindIs helper function](https://helm.sh/docs/chart_template_guide/function_list/#kind-functions) is used.

```yaml
{{- if (kindIs "bool" .Values.vmselect.serviceMonitor.enableHttp2) }}
enableHttp2: {{ .Values.vmselect.serviceMonitor.enableHttp2 }}
{{- end }}
```

This snippet will only set the `enableHttp2` filed if `serviceMonitor.vmselect.enableHttp2` is either `true` or `false`. If it is empty or set to something else, it will be ignored.

Feedback and improvements are welcome.