### PR TITLE
charts: fix k8s v1.25 compatibility for PSP

### DIFF
--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         chart: ${{ fromJSON(needs.get-changed-charts.outputs.charts) }}
-        k8s_version: ["v1.22.16", "v1.23.14", "v1.24.8"]
+        k8s_version: ["v1.22.16", "v1.23.14", "v1.24.8", "v1.25.8"]
       fail-fast: false
     steps:
       - name: Checkout

--- a/charts/victoria-metrics-agent/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrole.yaml
@@ -41,7 +41,7 @@ rules:
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 {{- end }}
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']

--- a/charts/victoria-metrics-agent/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-agent/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-alert/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-alert/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-alert/templates/role.yaml
+++ b/charts/victoria-metrics-alert/templates/role.yaml
@@ -14,7 +14,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 rules:
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']

--- a/charts/victoria-metrics-auth/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-auth/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-cluster/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-cluster/templates/clusterrole.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 rules:
   - apiGroups:      ['extensions']
     resources:      ['podsecuritypolicies']

--- a/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-cluster/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-cluster/templates/role.yaml
+++ b/charts/victoria-metrics-cluster/templates/role.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 rules:
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']

--- a/charts/victoria-metrics-operator/templates/psp.yaml
+++ b/charts/victoria-metrics-operator/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-single/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-single/templates/clusterrole.yaml
@@ -38,7 +38,7 @@ rules:
   - nonResourceURLs: [ "/metrics" ]
     verbs: [ "get" ]
   {{- end }}
-  {{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+  {{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:      ['extensions']
     resources:      ['podsecuritypolicies']
     verbs:          ['use']

--- a/charts/victoria-metrics-single/templates/podsecuritypolicy.yaml
+++ b/charts/victoria-metrics-single/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/victoria-metrics-single/templates/role.yaml
+++ b/charts/victoria-metrics-single/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/victoria-metrics-single/templates/rolebinding.yaml
+++ b/charts/victoria-metrics-single/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1") }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
- adds k8s v1.25 into testing matrix
- replaces `(.Capabilities.APIVersions.Has "policy/v1beta1")` calls with `(.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy")` to make it compatible with ArgoCD

See #505 for more details.