### PR TITLE
charts/vmalert: note that chart does not allow to setup HA Alertmanager

### DIFF
--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -68,6 +68,13 @@ See the history of versions of ``vmalert`` application with command.
 helm history vmalert -n NAMESPACE
 ```
 
+## HA configuration for Alertmanager
+
+There is no option on this chart to set up Alertmanager with [HA mode](https://github.com/prometheus/alertmanager#high-availability).
+To enable the HA configuration, you can use:
+- [VictoriaMetrics Operator](https://docs.victoriametrics.com/operator/VictoriaMetrics-Operator.html)
+- official [Alertmanager Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/alertmanager)
+
 # How to uninstall
 
 Remove application with command.
@@ -131,7 +138,6 @@ Change the values according to the need of the environment in ``victoria-metrics
 | alertmanager.podMetadata.labels | object | `{}` |  |
 | alertmanager.podSecurityContext | object | `{}` |  |
 | alertmanager.priorityClassName | string | `""` |  |
-| alertmanager.replicaCount | int | `1` |  |
 | alertmanager.resources | object | `{}` |  |
 | alertmanager.retention | string | `"120h"` |  |
 | alertmanager.service.annotations | object | `{}` |  |

--- a/charts/victoria-metrics-alert/README.md.gotmpl
+++ b/charts/victoria-metrics-alert/README.md.gotmpl
@@ -68,6 +68,13 @@ See the history of versions of ``vmalert`` application with command.
 helm history vmalert -n NAMESPACE
 ```
 
+## HA configuration for Alertmanager
+
+There is no option on this chart to set up Alertmanager with [HA mode](https://github.com/prometheus/alertmanager#high-availability).
+To enable the HA configuration, you can use:
+- [VictoriaMetrics Operator](https://docs.victoriametrics.com/operator/VictoriaMetrics-Operator.html)
+- official [Alertmanager Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/alertmanager)
+
 # How to uninstall
 
 Remove application with command.

--- a/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "vmalert.alertmanager.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.alertmanager.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "vmalert.alertmanager.matchLabels" . | nindent 6 }}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -255,7 +255,6 @@ serviceMonitor:
 
 alertmanager:
   enabled: false
-  replicaCount: 1
   podMetadata:
     labels: {}
     annotations: {}


### PR DESCRIPTION
- remove `alertmanger.replicaCount`
- add a note with workarounds for HA setup

Existing `alertmanager.replicaCount` would only set multiple instance of pod to be running, this does not provide a real HA configuration as users assume when using this. Also, since it uses `Deployment` using multiple replicas will fail to deploy as single PVC cannot be attached to multiple pods for `ReadWriteOnce`. For `ReadWriteMany` it might lead to data corruption since multiple Alertmanager instance might modify the same data.