### PR TITLE
Fix double "rules" on no-PodSecurityPolicy path

### DIFF
--- a/charts/victoria-metrics-alert/templates/role.yaml
+++ b/charts/victoria-metrics-alert/templates/role.yaml
@@ -13,8 +13,8 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-rules:
 {{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+rules:
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']


### PR DESCRIPTION
Discovered when trying to use this chart on EKS k8s v1.25 (PSP API removed).  In our case, we are using FluxCD HelmRelease x helm-controller to perform the install.  Possibly helm CLI will ignore the dupe (not sure).