### PR TITLE
charts/vmauth: use `.Values.configMap` value for config volume spec

### DIFF
--- a/charts/victoria-metrics-auth/README.md
+++ b/charts/victoria-metrics-auth/README.md
@@ -101,7 +101,6 @@ Change the values according to the need of the environment in ``victoria-metrics
 | affinity | object | `{}` | Affinity configurations |
 | annotations | object | `{}` | Annotations to be added to the deployment |
 | config | string | `nil` | Config file content. |
-| configMap | string | `""` | Use existing configmap if specified otherwise .config values will be used. Ref: https://victoriametrics.github.io/vmauth.html |
 | containerWorkingDir | string | `"/"` |  |
 | env | list | `[]` | Additional environment variables (ex.: secret tokens, flags) https://github.com/VictoriaMetrics/VictoriaMetrics#environment-variables |
 | extraArgs."envflag.enable" | string | `"true"` |  |
@@ -138,6 +137,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | rbac.pspEnabled | bool | `true` |  |
 | replicaCount | int | `1` | Number of replicas of vmauth |
 | resources | object | `{}` | We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. If you do want to specify resources, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'resources:'. |
+| secretName | string | `""` | Use existing secret if specified otherwise .config values will be used. Ref: https://victoriametrics.github.io/vmauth.html |
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |
 | service.clusterIP | string | `""` |  |

--- a/charts/victoria-metrics-auth/README.md
+++ b/charts/victoria-metrics-auth/README.md
@@ -137,7 +137,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | rbac.pspEnabled | bool | `true` |  |
 | replicaCount | int | `1` | Number of replicas of vmauth |
 | resources | object | `{}` | We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. If you do want to specify resources, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'resources:'. |
-| secretName | string | `""` | Use existing secret if specified otherwise .config values will be used. Ref: https://victoriametrics.github.io/vmauth.html |
+| secretName | string | `""` | Use existing secret if specified otherwise .config values will be used. Ref: https://victoriametrics.github.io/vmauth.html. Configuration in the given secret must be stored under `auth.yml` key. |
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |
 | service.clusterIP | string | `""` |  |

--- a/charts/victoria-metrics-auth/templates/deployment.yaml
+++ b/charts/victoria-metrics-auth/templates/deployment.yaml
@@ -92,11 +92,10 @@ spec:
     {{- end }}
       volumes:
         - name: config
-          {{- if .Values.configMap }}
-          configMap:
-            name: {{ .Values.configMap }}
-          {{- else }}
           secret:
+          {{- if .Values.secretName }}
+            secretName: {{ .Values.secretName }}
+          {{- else }}
             secretName: {{ include "chart.fullname" .}}
           {{- end }}
       {{- range .Values.extraHostPathMounts }}

--- a/charts/victoria-metrics-auth/templates/deployment.yaml
+++ b/charts/victoria-metrics-auth/templates/deployment.yaml
@@ -92,8 +92,13 @@ spec:
     {{- end }}
       volumes:
         - name: config
+          {{- if .Values.configMap }}
+          configMap:
+            name: {{ .Values.configMap }}
+          {{- else }}
           secret:
             secretName: {{ include "chart.fullname" .}}
+          {{- end }}
       {{- range .Values.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:

--- a/charts/victoria-metrics-auth/templates/secret.yaml
+++ b/charts/victoria-metrics-auth/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.configMap "" }}
+{{- if eq .Values.secretName "" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -184,8 +184,8 @@ serviceMonitor:
 #    tlsConfig:
 #      insecureSkipVerify: true
 
-# -- Use existing configmap if specified otherwise .config values will be used. Ref: https://victoriametrics.github.io/vmauth.html
-configMap: ""
+# -- Use existing secret if specified otherwise .config values will be used. Ref: https://victoriametrics.github.io/vmauth.html
+secretName: ""
 
 # -- Config file content.
 config:

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -184,7 +184,8 @@ serviceMonitor:
 #    tlsConfig:
 #      insecureSkipVerify: true
 
-# -- Use existing secret if specified otherwise .config values will be used. Ref: https://victoriametrics.github.io/vmauth.html
+# -- Use existing secret if specified otherwise .config values will be used. Ref: https://victoriametrics.github.io/vmauth.html.
+# Configuration in the given secret must be stored under `auth.yml` key.
 secretName: ""
 
 # -- Config file content.


### PR DESCRIPTION
Currently, this setting is only disabling creating secret which makes vmauth config volume reference invalid and failing deployment.