### PR TITLE
Use non-hardcoded `app.kubernetes.io/name` match label in victoria-metrics-k8s-stack VMServiceScrapes

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/grafana.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/grafana.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: grafana
+      app.kubernetes.io/name: {{ include "grafana.name" .Subcharts.grafana }}
       app.kubernetes.io/instance: {{ default $.Release.Name $.Values.argocdReleaseOverride | quote }}
 {{- if empty .Values.grafana.vmServiceScrape.spec }}
   endpoints:

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-state-metrics.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/kube-state-metrics.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/name: {{ include "kube-state-metrics.name" (index .Subcharts "kube-state-metrics") }}
       app.kubernetes.io/instance: {{ default $.Release.Name $.Values.argocdReleaseOverride | quote }}
 {{- if empty (index .Values "kube-state-metrics" "vmServiceScrape" "spec") }}
   endpoints:

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors/nodeexporter.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors/nodeexporter.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: prometheus-node-exporter
+      app.kubernetes.io/name: {{ include "prometheus-node-exporter.name" (index .Subcharts "prometheus-node-exporter") }}
 {{- if empty (index .Values "prometheus-node-exporter" "vmServiceScrape" "spec") }}
   endpoints:
   - port: metrics


### PR DESCRIPTION
The Grafana, kube-state-metrics, and node_exporter subcharts derive the `app.kubernetes.io/name` label in their Service manifests from a helper, usually `{chartname}.name`. If `nameOverride` is given (for whatever reason) then the output of that helper will not match the label value for the VMServiceScrape label selector, which causes it to not work.

Here's a minimum `values.yaml` to reproduce the issue:

```
prometheus-node-exporter:
  nameOverride: vm-node-exporter
```

With the current version of the victoria-metrics-k8s-stack the above will cause node_exporter metrics to not work. This PR will fix that. It executes the helper in the context of the subchart so all of the `.Values` and such lookups it does will work as intended.