### PR TITLE
[victoria-metrics-k8s-stack]: add tpl to vmagent, vmalert, vmcluster and vmsingle spec

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -132,15 +132,6 @@ configMaps:
 {{- end -}}
 
 {{/*
-VMAlert externalLabels
-*/}}
-{{- define "victoria-metrics-k8s-stack.vmAlertExternalLabels" -}}
-{{- if .Values.vmalert.spec.externalLabels }}
-{{- tpl (toYaml .Values.vmalert.spec.externalLabels | nindent 2) . }}
-{{- end }}
-{{- end -}}
-
-{{/*
 VMAlert spec
 */}}
 {{- define "victoria-metrics-k8s-stack.vmAlertSpec" -}}
@@ -149,8 +140,7 @@ VMAlert spec
 {{- $_ := set $extraArgs "rule.templates" (print "/etc/vm/configs/" (printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "vmalert-extra-tpl" | trunc 63 | trimSuffix "-" ) "/*.tmpl") -}}
 {{- end -}}
 {{- $_ := set $extraArgs "remoteWrite.disablePathAppend" "true" -}}
-{{- $_ := set .Values.vmalert.spec "externalLabels" (include "victoria-metrics-k8s-stack.vmAlertExternalLabels" . | fromYaml) -}}
-{{ deepCopy .Values.vmalert.spec | mergeOverwrite (include "victoria-metrics-k8s-stack.vmAlertRemotes" . | fromYaml) | mergeOverwrite (include "victoria-metrics-k8s-stack.vmAlertTemplates" . | fromYaml) | mergeOverwrite (dict "extraArgs" $extraArgs) | toYaml }}
+{{ tpl (deepCopy .Values.vmalert.spec | mergeOverwrite (include "victoria-metrics-k8s-stack.vmAlertRemotes" . | fromYaml) | mergeOverwrite (include "victoria-metrics-k8s-stack.vmAlertTemplates" . | fromYaml) | mergeOverwrite (dict "extraArgs" $extraArgs) | toYaml) . }}
 {{- end }}
 
 
@@ -171,7 +161,7 @@ remoteWrite:
 VMAgent spec
 */}}
 {{- define "victoria-metrics-k8s-stack.vmAgentSpec" -}}
-{{ deepCopy .Values.vmagent.spec | mergeOverwrite ( include "victoria-metrics-k8s-stack.vmAgentRemoteWrite" . | fromYaml) | toYaml }}
+{{ tpl (deepCopy .Values.vmagent.spec | mergeOverwrite ( include "victoria-metrics-k8s-stack.vmAgentRemoteWrite" . | fromYaml) | toYaml) . }}
 {{- end }}
 
 
@@ -220,7 +210,7 @@ Single spec
 {{- if .Values.vmalert.enabled }}
 {{- $_ := set $extraArgsProxy "vmalert.proxyURL" (include "vmalertProxyURL" . ) -}}
 {{- end }}
-{{ deepCopy .Values.vmsingle.spec | mergeOverwrite (dict "extraArgs" $extraArgsProxy) | toYaml }}
+{{ tpl (deepCopy .Values.vmsingle.spec | mergeOverwrite (dict "extraArgs" $extraArgsProxy) | toYaml) . }}
 {{- end }}
 
 
@@ -235,5 +225,5 @@ vmselect:
 
 
 {{ define "victoria-metrics-k8s-stack.VMClusterSpec"}}
-{{ deepCopy .Values.vmcluster.spec | mergeOverwrite ( include "vmselectSpec" . | fromYaml) | toYaml }}
+{{ tpl (deepCopy .Values.vmcluster.spec | mergeOverwrite ( include "vmselectSpec" . | fromYaml) | toYaml) . }}
 {{- end }}


### PR DESCRIPTION
This is adding the `tpl` function to all the spec of the operator. It basically allows us to use helm template language inside the `spec` section of `vmagent`, `vmalert`, `vmcluster` and `vmsingle`. For example, I would prefer to set one global variable for the cluster name (`global.clusterName` for example) and use that as an external labels for both vmagent and vmalert `vmagent.spec.externalLabels.cluster: {{ .Values.global.clusterName }}`.

This is used extensively in kube-prometheus-stack chart, although, it is used in more precise places than what I have here.

Let me know your thoughts.