### PR TITLE
victoria-metrics-operator chart: split securityContext

### DIFF
--- a/charts/victoria-metrics-operator/templates/deployment.yaml
+++ b/charts/victoria-metrics-operator/templates/deployment.yaml
@@ -38,9 +38,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-{{- with .Values.securityContext }}
+{{- with .Values.podSecurityContext }}
       securityContext:
-{{ toYaml . | nindent 8 }}
+{{- toYaml . | nindent 8 }}
 {{- end }}
       serviceAccountName: {{ template "vm-operator.serviceAccountName" . }}
       containers:
@@ -112,6 +112,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- with.Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -41,7 +41,9 @@ podLabels: {}
 # -- Annotations to be added to the all resources
 annotations: {}
 
+podSecurityContext: {}
 securityContext: {}
+
 operator:
   # -- By default, operator converts prometheus-operator objects.
   disable_prometheus_converter: false


### PR DESCRIPTION
Currently victoria-metrics operator chart (0.21.0) has securityContext option in values.yaml
It sets securityContext for the pod only. But there is no way to set securityContext for the container.
This matter since those contexts have different configuration options (some of them interfere though):
- [container security context](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#securitycontext-v1-core)
- [pod security context](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podsecuritycontext-v1-core)

For example, there is a really crucial readOnlyRootFilesystem option. It can be set only on container security context level. No way to set it on pod security context level.

Divide securityContext into two parts: pod and container. This breaks values.yaml backward compatibility with previous chart versions. So if merged then a proper note should be put into corresponding release notes.  