### PR TITLE
[victoria-metrics-k8s-stack] Bump chart dependencies

### DIFF
--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -13,14 +13,14 @@ dependencies:
     repository: https://victoriametrics.github.io/helm-charts
     condition: victoria-metrics-operator.enabled
   - name: kube-state-metrics
-    version: "4.24.*"
+    version: "5.5.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-state-metrics.enabled
   - name: prometheus-node-exporter
-    version: "4.7.*"
+    version: "4.16.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-node-exporter.enabled
   - name: grafana
-    version: "6.44.*"
+    version: "6.54.*"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled


### PR DESCRIPTION
Hi,
I've recently switched from kube-prometheus-stack to victoria-metrics-k8s-stack and noticed that the sub charts are older.

In this MR i would propose to bump the sub charts to the same versions as used in kube-prometheus-stack.