### PR TITLE
fix: Update pdb for k8s 1.25

### DIFF
--- a/charts/victoria-metrics-agent/templates/pdb.yaml
+++ b/charts/victoria-metrics-agent/templates/pdb.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
-apiVersion: policy/v1beta1
-{{- else -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/victoria-metrics-alert/templates/server-pdb.yaml
+++ b/charts/victoria-metrics-alert/templates/server-pdb.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.server.podDisruptionBudget.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
-apiVersion: policy/v1beta1
-{{- else -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/victoria-metrics-auth/templates/pdb.yaml
+++ b/charts/victoria-metrics-auth/templates/pdb.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
-apiVersion: policy/v1beta1
-{{- else -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/victoria-metrics-cluster/templates/vminsert-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-pdb.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.vminsert.podDisruptionBudget.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
-apiVersion: policy/v1beta1
-{{- else -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/victoria-metrics-cluster/templates/vmselect-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-pdb.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.vmselect.podDisruptionBudget.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
-apiVersion: policy/v1beta1
-{{- else -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-pdb.yaml
@@ -1,8 +1,8 @@
 {{- if and .Values.vmstorage.enabled .Values.vmstorage.podDisruptionBudget.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
-apiVersion: policy/v1beta1
-{{- else -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/victoria-metrics-gateway/templates/pdb.yaml
+++ b/charts/victoria-metrics-gateway/templates/pdb.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
-apiVersion: policy/v1beta1
-{{- else -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/victoria-metrics-single/templates/pdb.yaml
+++ b/charts/victoria-metrics-single/templates/pdb.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
-apiVersion: policy/v1beta1
-{{- else -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
Hi,

pdb generation on k8s 1.25 is not working properly.

`helm template vm/victoria-metrics-agent --set podDisruptionBudget.enabled=true --api-versions policy/v1/PodDisruptionBudget --kube-version 1.25.9`

```
---
# Source: victoria-metrics-agent/templates/pdb.yaml
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  name: release-name-victoria-metrics-agent
  namespace: default
  labels:
    helm.sh/chart: victoria-metrics-agent-0.8.37
    app.kubernetes.io/name: victoria-metrics-agent
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v1.90.0"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: victoria-metrics-agent
      app.kubernetes.io/instance: release-name
```