### PR TITLE
operator: fix VMServiceScrape label and annotation templating

### DIFF
--- a/charts/victoria-metrics-operator/templates/service_scrape.yaml
+++ b/charts/victoria-metrics-operator/templates/service_scrape.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.serviceMonitor.enabled -}}
+{{- $mergedVMServiceScrapeAnnotations := mustMerge .Values.serviceMonitor.annotations .Values.annotations -}}
+{{- $mergedVMServiceScrapeLabels := mustMerge .Values.serviceMonitor.extraLabels .Values.extraLabels -}}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
@@ -6,10 +8,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
 {{ include "vm-operator.labels" . | indent 4 }}
-{{- with .Values.extraLabels }}
+{{- with $mergedVMServiceScrapeLabels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.annotations }}
+{{- with $mergedVMServiceScrapeAnnotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
There are [labels and annotations](https://github.com/VictoriaMetrics/helm-charts/blob/db45a16700c187a0be77ca2566de26b56c8fffa7/charts/victoria-metrics-operator/values.yaml#L155-L156) in values.yaml for VMServiceScrape. Those are unused for VMServiceScrape resource now.
Fix it by merging main labels and annotations with the VMServiceScrape labels and annotations giving precedence to the VMServiceScrape ones.