### PR TITLE
charts/cluster: fix naming for vmbackupmanager init container

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: 1.91.0
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.9.63
+version: 0.9.64
 sources:
 - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -216,7 +216,7 @@ Return if ingress supports pathType.
 {{ toYaml . }}
 {{- end -}}
 {{- if .Values.vmstorage.vmbackupmanager.restore.onStart.enabled }}
-- name: {{ template "victoria-metrics.name" . }}-vmbackupmanager
+- name: {{ template "victoria-metrics.name" . }}-vmbackupmanager-restore
   image: "{{ .Values.vmstorage.vmbackupmanager.image.repository }}:{{ .Values.vmstorage.vmbackupmanager.image.tag }}"
   imagePullPolicy: "{{ .Values.vmstorage.image.pullPolicy }}"
   args:


### PR DESCRIPTION
Name must be suffixed with `-restore` to keep all containers names of pod unique.