### PR TITLE
Update to new HPA apiVersion, and allow specifying in values

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vminsert-hpa.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.vminsert.horizontalPodAutoscaler.enabled }}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+apiVersion: autoscaling/v2
+{{- else}}
 apiVersion: autoscaling/v2beta2
+{{- end}}
 kind: HorizontalPodAutoscaler
 metadata:
   labels:

--- a/charts/victoria-metrics-cluster/templates/vmselect-hpa.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.vmselect.horizontalPodAutoscaler.enabled }}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+apiVersion: autoscaling/v2
+{{- else}}
 apiVersion: autoscaling/v2beta2
+{{- end}}
 kind: HorizontalPodAutoscaler
 metadata:
   labels:


### PR DESCRIPTION
1. Upgrade to new apiVersion. autoscaling/v2beta2 is no longer supported as of 1.26, and has been deprecated for a few versions now
2. Allow specifying the apiVersion in values. This is a fairly common pattern and will allow users to workaround this change.

Resolves #514 