### PR TITLE
Feat: Add custom objects to vma helm charts

### DIFF
--- a/charts/victoria-metrics-agent/templates/extra-objects.yaml
+++ b/charts/victoria-metrics-agent/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -559,3 +559,6 @@ config:
 
 # -- Extra scrape configs that will be appended to `config`
 extraScrapeConfigs: []
+
+# Add extra specs dynamically to this chart
+extraObjects: []


### PR DESCRIPTION
Allow pass through of additional objects, to allow for such things as secrets to be mounted.