### PR TITLE
charts/victoria-metrics-anomaly: make monitoring config more configurable

### DIFF
--- a/charts/victoria-metrics-anomaly/README.md
+++ b/charts/victoria-metrics-anomaly/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for vmanomaly
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square)
 [![Slack](https://img.shields.io/badge/join%20slack-%23victoriametrics-brightgreen.svg)](https://slack.victoriametrics.com/)
 [![GitHub license](https://img.shields.io/github/license/VictoriaMetrics/VictoriaMetrics.svg)](https://github.com/VictoriaMetrics/helm-charts/blob/master/LICENSE)
 ![Twitter Follow](https://img.shields.io/twitter/follow/VictoriaMetrics?style=social)
@@ -131,8 +131,9 @@ Change the values according to the need of the environment in ``victoria-metrics
 | model.holt_winters.seasonality | string | `"1d"` |  |
 | model.prophet.interval_width | float | `0.98` |  |
 | model.zscore.z_threshold | float | `2.5` |  |
-| monitoring | object | `{"pull":{"port":8440},"push":{"extra_labels":{"job":"vmanomaly-push"},"url":""}}` | vmanomaly internal monitoring in Prometheus format |
-| monitoring.pull.port | int | `8440` | if true expose metrics on /metric endpoint |
+| monitoring | object | `{"pull":{"enabled":false,"port":8440},"push":{"extra_labels":{"job":"vmanomaly-push"},"url":""}}` | vmanomaly internal monitoring in Prometheus format |
+| monitoring.pull.enabled | bool | `false` | if true expose metrics on /metrics endpoint |
+| monitoring.pull.port | int | `8440` | port for /metrics endpoint |
 | monitoring.push.url | string | `""` | push metrics on prometheus format if defined |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | NodeSelector configurations. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |

--- a/charts/victoria-metrics-anomaly/templates/configmap.yaml
+++ b/charts/victoria-metrics-anomaly/templates/configmap.yaml
@@ -54,5 +54,15 @@ data:
         __name__: "$VAR"
         query: "$QUERY_KEY"
         model: {{ .Values.model.enabled }}
+    {{ if or .Values.monitoring.pull.enabled .Values.monitoring.push.url }}
     monitoring:
-      {{- toYaml .Values.monitoring | nindent 8 }}
+    {{- if .Values.monitoring.pull.enabled }}
+      pull:
+        {{- $v := deepCopy .Values.monitoring.pull }}
+        {{- unset $v "enabled" | toYaml | nindent 6 }}
+      {{- end }}
+      {{- if .Values.monitoring.push.url }}
+      push:
+        {{- toYaml .Values.monitoring.push | nindent 6 }}
+      {{- end }}
+    {{- end }}

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -178,7 +178,9 @@ samplingPeriod: "1m"
 monitoring:
   # /metrics server.
   pull:
-    # -- if true expose metrics on /metric endpoint
+    # -- if true expose metrics on /metrics endpoint
+    enabled: false
+    # -- port for /metrics endpoint
     port: 8440
   push:
     # -- push metrics on prometheus format if defined

--- a/hack/helm/victoria-metrics-anomaly.yaml
+++ b/hack/helm/victoria-metrics-anomaly.yaml
@@ -16,7 +16,6 @@ monitoring:
     enabled: true
     port: 8440
   push:
-    endpoint_url: "http://cluster-victoria-metrics-cluster-vminsert.default.svc.cluster.local:8480/insert/"
+    url: "http://cluster-victoria-metrics-cluster-vminsert.default.svc.cluster.local:8480/insert/"
     extra_labels:
       job: "vmanomaly"
-

--- a/hack/vmanomaly-lint-hack.yaml
+++ b/hack/vmanomaly-lint-hack.yaml
@@ -11,3 +11,6 @@ queries:
   insertion_rate: 'sum(rate(vm_http_requests_total{path=~"/api/v1/write|.*insert.*"}[5m])) by (path) > 0'
   slow_inserts: 'sum(rate(vm_slow_row_inserts_total[5m])) / sum(rate(vm_rows_inserted_total[5m]))'
 
+monitoring:
+  pull:
+    enabled: true


### PR DESCRIPTION
Update configuration to template `pull` and `push` sections only in case configuration for these is defined. Fixes compatibility with latest vmanomaly config version.