### PR TITLE
Fix wrong condition on fluent-bit dependency

### DIFF
--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -10,4 +10,4 @@ dependencies:
 - name: fluent-bit
   version: "0.31.0"
   repository: "https://fluent.github.io/helm-charts"
-  condition: fluentbit.enabled
+  condition: fluent-bit.enabled


### PR DESCRIPTION
The condition of the fluent-bit dependy contains a typo that will deploy fluent-bit even if disabled in values.yaml.
As the values is correct according to the dependency name, I've only fixed the dependency condition for minimal impact