### PR TITLE
feat(vm-alert): add notifier config support

### DIFF
--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -184,8 +184,9 @@ Change the values according to the need of the environment in ``victoria-metrics
 | server.name | string | `"server"` |  |
 | server.nameOverride | string | `""` |  |
 | server.nodeSelector | object | `{}` |  |
-| server.notifier | object | `{"alertmanager":{"basicAuth":{"password":"","username":""},"bearer":{"token":"","tokenFile":""},"url":""},"config":""}` | Notifier to use for alerts. Multiple notifiers can be enabled by using `notifiers` section |
-| server.notifier.config | object | `""` | Path to configuration file for notifiers |
+| server.notifier | object | `{"alertmanager":{"basicAuth":{"password":"","username":""},"bearer":{"token":"","tokenFile":""},"url":""},"config":{},"configPath":""}` | Notifier to use for alerts. Multiple notifiers can be enabled by using `notifiers` section |
+| server.notifier.config | object | `{}` | Path to configuration file for notifiers |
+| server.notifier.configPath | object | `""` | Path to configuration file for notifiers (injected externally) |
 | server.notifier.alertmanager.basicAuth | object | `{"password":"","username":""}` | Basic auth for alertmanager |
 | server.notifier.alertmanager.bearer.token | string | `""` | Token with Bearer token. You can use one of token or tokenFile. You don't need to add "Bearer" prefix string |
 | server.notifier.alertmanager.bearer.tokenFile | string | `""` | Token Auth file with Bearer token. You can use one of token or tokenFile |

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -184,7 +184,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | server.name | string | `"server"` |  |
 | server.nameOverride | string | `""` |  |
 | server.nodeSelector | object | `{}` |  |
-| server.notifier | object | `{"alertmanager":{"basicAuth":{"password":"","username":""},"bearer":{"token":"","tokenFile":""},"url":"","config":""}}` | Notifier to use for alerts. Multiple notifiers can be enabled by using `notifiers` section |
+| server.notifier | object | `{"alertmanager":{"basicAuth":{"password":"","username":""},"bearer":{"token":"","tokenFile":""},"url":""},"config":""}` | Notifier to use for alerts. Multiple notifiers can be enabled by using `notifiers` section |
 | server.notifier.config | object | `""` | Path to configuration file for notifiers |
 | server.notifier.alertmanager.basicAuth | object | `{"password":"","username":""}` | Basic auth for alertmanager |
 | server.notifier.alertmanager.bearer.token | string | `""` | Token with Bearer token. You can use one of token or tokenFile. You don't need to add "Bearer" prefix string |

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -184,7 +184,8 @@ Change the values according to the need of the environment in ``victoria-metrics
 | server.name | string | `"server"` |  |
 | server.nameOverride | string | `""` |  |
 | server.nodeSelector | object | `{}` |  |
-| server.notifier | object | `{"alertmanager":{"basicAuth":{"password":"","username":""},"bearer":{"token":"","tokenFile":""},"url":""}}` | Notifier to use for alerts. Multiple notifiers can be enabled by using `notifiers` section |
+| server.notifier | object | `{"alertmanager":{"basicAuth":{"password":"","username":""},"bearer":{"token":"","tokenFile":""},"url":"","config":""}}` | Notifier to use for alerts. Multiple notifiers can be enabled by using `notifiers` section |
+| server.notifier.config | object | `""` | Path to configuration file for notifiers |
 | server.notifier.alertmanager.basicAuth | object | `{"password":"","username":""}` | Basic auth for alertmanager |
 | server.notifier.alertmanager.bearer.token | string | `""` | Token with Bearer token. You can use one of token or tokenFile. You don't need to add "Bearer" prefix string |
 | server.notifier.alertmanager.bearer.tokenFile | string | `""` | Token Auth file with Bearer token. You can use one of token or tokenFile |

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -184,9 +184,12 @@ Change the values according to the need of the environment in ``victoria-metrics
 | server.name | string | `"server"` |  |
 | server.nameOverride | string | `""` |  |
 | server.nodeSelector | object | `{}` |  |
-| server.notifier | object | `{"alertmanager":{"basicAuth":{"password":"","username":""},"bearer":{"token":"","tokenFile":""},"url":""},"config":{},"configPath":""}` | Notifier to use for alerts. Multiple notifiers can be enabled by using `notifiers` section |
-| server.notifier.config | object | `{}` | Path to configuration file for notifiers |
-| server.notifier.configPath | object | `""` | Path to configuration file for notifiers (injected externally) |
+| server.notifier | object | `{"alertmanager":{"basicAuth":{"password":"","username":""},"bearer":{"token":"","tokenFile":""},"url":""},"config":{},"configMap":""}` | Notifier to use for alerts. Multiple notifiers can be enabled by using `notifiers` section |
+| server.notifier.config | object | `{}` | Configuration for notifiers |
+| server.notifier.configMap | object | `""` | Path to an existing configuration file for notifiers from Kubernetes ConfigMap. It has precedence over `config`. |
+| server.notifier.configMapKey | object | `"notifier.yaml"` | Key name of `server.notifier.configMap` |
+| server.notifier.existingSecret | object | `""` | Path to an existing configuration file for notifiers from Kubernetes Secret. It has precedence over `configMap`. |
+| server.notifier.existingSecretKey | object | `"notifier.yaml"` | Key name of `server.notifier.existingSecret` |
 | server.notifier.alertmanager.basicAuth | object | `{"password":"","username":""}` | Basic auth for alertmanager |
 | server.notifier.alertmanager.bearer.token | string | `""` | Token with Bearer token. You can use one of token or tokenFile. You don't need to add "Bearer" prefix string |
 | server.notifier.alertmanager.bearer.tokenFile | string | `""` | Token Auth file with Bearer token. You can use one of token or tokenFile |

--- a/charts/victoria-metrics-alert/templates/_helpers.tpl
+++ b/charts/victoria-metrics-alert/templates/_helpers.tpl
@@ -80,6 +80,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{- define "vmalert.notifier.configname" -}}
+{{- include "vmalert.server.fullname" . -}}-notifier-config
+{{- end -}}
+
 {{/*
 Create the name of the service account to use
 */}}

--- a/charts/victoria-metrics-alert/templates/_helpers.tpl
+++ b/charts/victoria-metrics-alert/templates/_helpers.tpl
@@ -81,7 +81,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "vmalert.notifier.configname" -}}
+{{- if .Values.server.notifier.existingSecret -}}
+{{- .Values.server.notifier.existingSecret -}}
+{{- else if .Values.server.notifier.configMap -}}
+{{- .Values.server.notifier.configMap -}}
+{{- else -}}
 {{- include "vmalert.server.fullname" . -}}-notifier-config
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -4,8 +4,8 @@
 {{- fail "at least one item in `.server.config.alerts.groups` or `.server.extraArgs.rule` must be set " -}}
 {{- end -}}
 {{- end -}}
-{{- if (eq (include "vmalert.alertmanager.urls" . ) "") -}}
-{{- fail "alert manager URL must be specified. Please fill server.notifier.alertmanager.url or server.notifiers or enable Alertmanager in values file" -}}
+{{- if and (eq (include "vmalert.alertmanager.urls" . ) "") (eq .Values.server.notifier.alertmanager.config "") -}}
+{{- fail "alert manager URL must be specified. Please fill server.notifier.alertmanager.url or server.notifiers or server.notifier.alertmanager.config or enable Alertmanager in values file" -}}
 {{- end -}}
 {{- if eq .Values.server.datasource.url "" -}}
 {{- fail "server.datasource.url datasource URL must be specified" -}}
@@ -70,6 +70,9 @@ spec:
             {{- with .Values.server.datasource.bearer.tokenFile }}
             - -datasource.bearerTokenFile={{ . }}
             {{- end }}
+            {{- if .Values.server.notifier.alertmanager.config }}
+            - -notifier.config={{ .Values.server.notifier.alertmanager.config }}
+            {{- else }}
             - -notifier.url={{ include "vmalert.alertmanager.urls" . }}
             {{- with (include "vmalert.alertmanager.passwords" .) }}
             - -notifier.basicAuth.password={{ . }}
@@ -82,6 +85,7 @@ spec:
             {{- end }}
             {{- with (include "vmalert.alertmanager.bearerTokenFiles" .) }}
             - -notifier.bearerTokenFile={{ . }}
+            {{- end }}
             {{- end }}
             - -remoteRead.url={{ .Values.server.remote.read.url }}
             {{- if or .Values.server.remote.read.basicAuth.password .Values.server.remote.read.basicAuth.username }}

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -5,7 +5,7 @@
 {{- end -}}
 {{- end -}}
 {{- if and (eq (include "vmalert.alertmanager.urls" . ) "") (eq .Values.server.notifier.config "") -}}
-{{- fail "alert manager URL must be specified. Please fill server.notifier.alertmanager.url or server.notifiers or server.notifier.alertmanager.config or enable Alertmanager in values file" -}}
+{{- fail "alert manager URL must be specified. Please fill server.notifier.alertmanager.url or server.notifiers or server.notifier.config or enable Alertmanager in values file" -}}
 {{- end -}}
 {{- if eq .Values.server.datasource.url "" -}}
 {{- fail "server.datasource.url datasource URL must be specified" -}}

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -4,8 +4,8 @@
 {{- fail "at least one item in `.server.config.alerts.groups` or `.server.extraArgs.rule` must be set " -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq (include "vmalert.alertmanager.urls" . ) "") (eq .Values.server.notifier.config "") -}}
-{{- fail "alert manager URL must be specified. Please fill server.notifier.alertmanager.url or server.notifiers or server.notifier.config or enable Alertmanager in values file" -}}
+{{- if and (eq (include "vmalert.alertmanager.urls" . ) "") (empty .Values.server.notifier.config) (eq .Values.server.notifier.configPath "") -}}
+{{- fail "alert manager URL must be specified. Please fill server.notifier.alertmanager.url or server.notifiers or server.notifier.config or server.notifier.configPath or enable Alertmanager in values file" -}}
 {{- end -}}
 {{- if eq .Values.server.datasource.url "" -}}
 {{- fail "server.datasource.url datasource URL must be specified" -}}
@@ -70,8 +70,10 @@ spec:
             {{- with .Values.server.datasource.bearer.tokenFile }}
             - -datasource.bearerTokenFile={{ . }}
             {{- end }}
-            {{- if .Values.server.notifier.config }}
-            - -notifier.config={{ .Values.server.notifier.config }}
+            {{- if .Values.server.notifier.configPath }}
+            - -notifier.config={{ .Values.server.notifier.configPath }}
+            {{- else if .Values.server.notifier.config }}
+            - -notifier.config=/config/notifier.yaml
             {{- else }}
             - -notifier.url={{ include "vmalert.alertmanager.urls" . }}
             {{- with (include "vmalert.alertmanager.passwords" .) }}
@@ -173,8 +175,14 @@ spec:
     {{- end }}
       volumes:
         - name: alerts-config
-          configMap:
-            name: {{ include "vmalert.server.configname" . }}
+          projected:
+            sources:
+              - configMap:
+                  name: {{ include "vmalert.server.configname" . }}
+              {{- if and .Values.server.notifier.config (eq .Values.server.notifier.configPath "") }}
+              - configMap:
+                  name: {{ include "vmalert.notifier.configname" . }}
+              {{- end }}
         {{- range .Values.server.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -78,6 +78,7 @@ spec:
             - -notifier.config=/config/notifier.yaml
             {{- else }}
             - -notifier.url={{ include "vmalert.alertmanager.urls" . }}
+            {{- end }}
             {{- with (include "vmalert.alertmanager.passwords" .) }}
             - -notifier.basicAuth.password={{ . }}
             {{- end }}
@@ -89,7 +90,6 @@ spec:
             {{- end }}
             {{- with (include "vmalert.alertmanager.bearerTokenFiles" .) }}
             - -notifier.bearerTokenFile={{ . }}
-            {{- end }}
             {{- end }}
             - -remoteRead.url={{ .Values.server.remote.read.url }}
             {{- if or .Values.server.remote.read.basicAuth.password .Values.server.remote.read.basicAuth.username }}

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -4,8 +4,8 @@
 {{- fail "at least one item in `.server.config.alerts.groups` or `.server.extraArgs.rule` must be set " -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq (include "vmalert.alertmanager.urls" . ) "") (empty .Values.server.notifier.config) (eq .Values.server.notifier.configPath "") -}}
-{{- fail "alert manager URL must be specified. Please fill server.notifier.alertmanager.url or server.notifiers or server.notifier.config or server.notifier.configPath or enable Alertmanager in values file" -}}
+{{- if and (eq (include "vmalert.alertmanager.urls" . ) "") (empty .Values.server.notifier.config) (empty .Values.server.notifier.configMap) (empty .Values.server.notifier.existingSecret) -}}
+{{- fail "alert manager URL must be specified. Please fill server.notifier.alertmanager.url or server.notifiers or server.notifier.config or server.notifier.configMap or server.notifier.existingSecret or enable Alertmanager in values file" -}}
 {{- end -}}
 {{- if eq .Values.server.datasource.url "" -}}
 {{- fail "server.datasource.url datasource URL must be specified" -}}
@@ -70,8 +70,10 @@ spec:
             {{- with .Values.server.datasource.bearer.tokenFile }}
             - -datasource.bearerTokenFile={{ . }}
             {{- end }}
-            {{- if .Values.server.notifier.configPath }}
-            - -notifier.config={{ .Values.server.notifier.configPath }}
+            {{- if .Values.server.notifier.existingSecret }}
+            - -notifier.config=/config/{{ .Values.server.notifier.existingSecretKey }}
+            {{- else if .Values.server.notifier.configMap }}
+            - -notifier.config=/config/{{ .Values.server.notifier.configMapKey }}
             {{- else if .Values.server.notifier.config }}
             - -notifier.config=/config/notifier.yaml
             {{- else }}
@@ -179,7 +181,11 @@ spec:
             sources:
               - configMap:
                   name: {{ include "vmalert.server.configname" . }}
-              {{- if and .Values.server.notifier.config (eq .Values.server.notifier.configPath "") }}
+              {{- if and .Values.server.notifier.existingSecret }}
+              - secret:
+                  name: {{ include "vmalert.notifier.configname" . }}
+              {{- end }}
+              {{- if and .Values.server.notifier.configMap (empty .Values.server.notifier.existingSecret) }}
               - configMap:
                   name: {{ include "vmalert.notifier.configname" . }}
               {{- end }}

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -4,7 +4,7 @@
 {{- fail "at least one item in `.server.config.alerts.groups` or `.server.extraArgs.rule` must be set " -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq (include "vmalert.alertmanager.urls" . ) "") (eq .Values.server.notifier.alertmanager.config "") -}}
+{{- if and (eq (include "vmalert.alertmanager.urls" . ) "") (eq .Values.server.notifier.config "") -}}
 {{- fail "alert manager URL must be specified. Please fill server.notifier.alertmanager.url or server.notifiers or server.notifier.alertmanager.config or enable Alertmanager in values file" -}}
 {{- end -}}
 {{- if eq .Values.server.datasource.url "" -}}
@@ -70,8 +70,8 @@ spec:
             {{- with .Values.server.datasource.bearer.tokenFile }}
             - -datasource.bearerTokenFile={{ . }}
             {{- end }}
-            {{- if .Values.server.notifier.alertmanager.config }}
-            - -notifier.config={{ .Values.server.notifier.alertmanager.config }}
+            {{- if .Values.server.notifier.config }}
+            - -notifier.config={{ .Values.server.notifier.config }}
             {{- else }}
             - -notifier.url={{ include "vmalert.alertmanager.urls" . }}
             {{- with (include "vmalert.alertmanager.passwords" .) }}

--- a/charts/victoria-metrics-alert/templates/server-notifier-configmap.yaml
+++ b/charts/victoria-metrics-alert/templates/server-notifier-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.server.notifier.config (eq .Values.server.notifier.configPath "") }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "vmalert.notifier.configname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "vmalert.server.labels" . | nindent 4 }}
+data:
+  notifier.yaml: |
+{{ toYaml .Values.server.notifier.config | indent 4 }}
+{{- end }}

--- a/charts/victoria-metrics-alert/templates/server-notifier-configmap.yaml
+++ b/charts/victoria-metrics-alert/templates/server-notifier-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.server.notifier.config (eq .Values.server.notifier.configPath "") }}
+{{- if and .Values.server.notifier.config (empty .Values.server.notifier.configMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -108,7 +108,6 @@ server:
   # Multiple notifiers can be enabled by using `notifiers` section
   notifier:
     alertmanager:
-      config: ""
       url: ""
       # -- Basic auth for alertmanager
       basicAuth:
@@ -120,6 +119,7 @@ server:
         token: ""
         # -- Token Auth file with Bearer token. You can use one of token or tokenFile
         tokenFile: ""
+    config: ""
 
   # -- Additional notifiers to use for alerts
   notifiers:

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -120,7 +120,10 @@ server:
         # -- Token Auth file with Bearer token. You can use one of token or tokenFile
         tokenFile: ""
     config: {}
-    configPath: ""
+    configMap: ""
+    configMapKey: "notifier.yaml"
+    existingSecret: ""
+    existingSecretKey: "notifier.yaml"
 
   # -- Additional notifiers to use for alerts
   notifiers:

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -108,6 +108,7 @@ server:
   # Multiple notifiers can be enabled by using `notifiers` section
   notifier:
     alertmanager:
+      config: ""
       url: ""
       # -- Basic auth for alertmanager
       basicAuth:

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -119,7 +119,8 @@ server:
         token: ""
         # -- Token Auth file with Bearer token. You can use one of token or tokenFile
         tokenFile: ""
-    config: ""
+    config: {}
+    configPath: ""
 
   # -- Additional notifiers to use for alerts
   notifiers:


### PR DESCRIPTION
Notifier also supports configuration via file specified with flag `-notifier.config`.

But, no way to do that in current Helm chart.

So, how could I place discover notifiers?

*** EDIT ***

I see it can be better with config and configPath.

- config: we can set the config with a map like the alert rules;
- configPath: or we can set a file path from a volume mount if desired.

# Scenarios

### Scenario 1 with `server.notifier.config`
```
helm template --dry-run --validate . -f custom-config.yaml
```
```
server:
  notifier:
    config:
      dns_sd_configs:
        - names:
            - alertmanager-headless.ns.svc.cluster.local
          type: 'A'
          port: 9093
```
```
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: release-name-victoria-metrics-alert-server-notifier-config
  namespace: prometheus
  labels:
    app: server
    app.kubernetes.io/name: victoria-metrics-alert
    app.kubernetes.io/instance: release-name
    helm.sh/chart: victoria-metrics-alert-0.6.4
    app.kubernetes.io/managed-by: Helm
data:
  notifier.yaml: |
    dns_sd_configs:
    - names:
      - alertmanager-headless.ns.svc.cluster.local
      port: 9093
      type: A

---
    ...
    spec:
      containers:
        - name: victoria-metrics-alert-server
          image: "victoriametrics/vmalert:v1.91.3"
          args:
            - -rule=/config/alert-rules.yaml
            - -datasource.url=http://localhost
            - -notifier.config=/config/notifier.yaml
            - -remoteRead.url=
            - -remoteWrite.url=
            - -envflag.enable=true
            - -envflag.prefix=VM_
            - -loggerFormat=json
          volumeMounts:
            - name: alerts-config
              mountPath: /config
      volumes:
        - name: alerts-config
          projected:
            sources:
              - configMap:
                  name: release-name-victoria-metrics-alert-server-alert-rules-config
              - configMap:
                  name: release-name-victoria-metrics-alert-server-notifier-config
```

### Scenario #2 with `server.notifier.configPath`
```
helm template --dry-run --validate . -f custom-configpath.yaml
```
```
server:
  notifier:
    configPath: "/custom-path/random.yaml"
```
```
---
    ...
    spec:
      containers:
        - name: victoria-metrics-alert-server
          image: "victoriametrics/vmalert:v1.91.3"
          args:
            - -rule=/config/alert-rules.yaml
            - -datasource.url=http://localhost
            - -notifier.config=/custom-path/random.yaml
            - -remoteRead.url=
            - -remoteWrite.url=
            - -envflag.enable=true
            - -envflag.prefix=VM_
            - -loggerFormat=json
```

Please, check it out.