### PR TITLE
charts/victoria-metrics-cluster: fix indent for vmselect statefulset

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -147,7 +147,7 @@ spec:
         {{- end }}
       spec:
         accessModes:
-        {{ toYaml .Values.vmselect.persistentVolume.accessModes | indent 10 }}
+        {{- toYaml .Values.vmselect.persistentVolume.accessModes | nindent 10 }}
         resources:
           requests:
             storage: "{{ .Values.vmselect.persistentVolume.size }}"


### PR DESCRIPTION
Fixes: https://github.com/VictoriaMetrics/helm-charts/issues/575