### PR TITLE
charts/victoria-logs-single: fix STS render when using statefulset is disabled

### DIFF
--- a/charts/victoria-logs-single/templates/server-statefulset.yaml
+++ b/charts/victoria-logs-single/templates/server-statefulset.yaml
@@ -107,7 +107,6 @@ spec:
             - name: server-volume
               mountPath: {{ .Values.server.persistentVolume.mountPath }}
               subPath: {{ .Values.server.persistentVolume.subPath }}
-        {{- end }}
       {{- with .Values.server.extraContainers }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -171,4 +170,5 @@ spec:
           matchLabels:
             {{- toYaml . | nindent 12 }}
       {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Due to improper end block location part of manifest was rendered even when STS was set to false.