### PR TITLE
fix misused securityContext and podSecurityContext

### DIFF
--- a/charts/victoria-logs-single/templates/server-deployment.yaml
+++ b/charts/victoria-logs-single/templates/server-deployment.yaml
@@ -48,7 +48,7 @@ spec:
       containers:
         - name: {{ template "victoria-logs.name" . }}-{{ .Values.server.name }}
           securityContext:
-            {{- toYaml .Values.server.podSecurityContext | nindent 12 }}
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           {{- if .Values.server.containerWorkingDir }}
@@ -116,9 +116,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.server.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.server.securityContext }}
+    {{- if .Values.server.podSecurityContext }}
       securityContext:
-{{ toYaml .Values.server.securityContext | indent 8 }}
+{{ toYaml .Values.server.podSecurityContext | indent 8 }}
     {{- end }}
     {{- if .Values.server.tolerations }}
       tolerations:

--- a/charts/victoria-logs-single/templates/server-statefulset.yaml
+++ b/charts/victoria-logs-single/templates/server-statefulset.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "victoria-logs.name" . }}-{{ .Values.server.name }}
-          {{- with  .Values.server.podSecurityContext }}
+          {{- with  .Values.server.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
@@ -118,9 +118,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.server.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.server.securityContext }}
+    {{- if .Values.server.podSecurityContext }}
       securityContext:
-{{ toYaml .Values.server.securityContext | indent 8 }}
+{{ toYaml .Values.server.podSecurityContext | indent 8 }}
     {{- end }}
     {{- if .Values.server.tolerations }}
       tolerations:

--- a/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
@@ -35,14 +35,14 @@ spec:
     {{- end }}
       serviceAccountName: {{ template "vmalert.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
-      {{- with .Values.alertmanager.securityContext }}
+      {{- with .Values.alertmanager.podSecurityContext }}
       securityContext:
         {{- toYaml .| nindent 8 }}
       {{- end }}
       containers:
         - name: {{ template "vmalert.name" . }}-alertmanager
           securityContext:
-            {{- toYaml .Values.alertmanager.podSecurityContext | nindent 12 }}
+            {{- toYaml .Values.alertmanager.securityContext | nindent 12 }}
           image: "{{ .Values.alertmanager.image }}:{{ .Values.alertmanager.tag }}"
           args:
             - --config.file=/config/alertmanager.yaml

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -50,12 +50,12 @@ spec:
     {{- end }}
       serviceAccountName: {{ template "vmalert.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.server.securityContext | nindent 8 }}
+        {{- toYaml .Values.server.podSecurityContext | nindent 8 }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
       containers:
         - name: {{ template "vmalert.name" . }}-{{ .Values.server.name }}
           securityContext:
-            {{- toYaml .Values.server.podSecurityContext | nindent 12 }}
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
           image: "{{ .Values.server.image.repository }}:{{ default .Chart.AppVersion .Values.server.image.tag }}"
           args:
             - -rule=/config/alert-rules.yaml

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           workingDir: {{ .Values.vminsert.containerWorkingDir }}
           {{- end }}
           securityContext:
-            {{- toYaml .Values.vminsert.podSecurityContext | nindent 12 }}
+            {{- toYaml .Values.vminsert.securityContext | nindent 12 }}
           args:
           {{- if not .Values.vminsert.suppresStorageFQDNsRender }}
             {{- include "victoria-metrics.vminsert.vmstorage-pod-fqdn" . | nindent 12 }}
@@ -141,7 +141,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.vminsert.securityContext }}
+      {{- with .Values.vminsert.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           workingDir: {{ .Values.vmselect.containerWorkingDir }}
           {{- end }}
           securityContext:
-            {{- toYaml .Values.vmselect.podSecurityContext | nindent 12 }}
+            {{- toYaml .Values.vmselect.securityContext | nindent 12 }}
           args:
             - {{ printf "%s=%s" "--cacheDataPath" .Values.vmselect.cacheMountPath | quote}}
           {{- if not .Values.vmselect.suppresStorageFQDNsRender }}
@@ -118,9 +118,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.vmselect.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.vmselect.securityContext }}
+    {{- if .Values.vmselect.podSecurityContext }}
       securityContext:
-{{ toYaml .Values.vmselect.securityContext | indent 8 }}
+{{ toYaml .Values.vmselect.podSecurityContext | indent 8 }}
     {{- end }}
       serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
     {{- if .Values.vmselect.tolerations }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
           workingDir: {{ .Values.vmselect.containerWorkingDir }}
           {{- end }}
           securityContext:
-            {{- toYaml .Values.vmselect.podSecurityContext | nindent 12 }}
+            {{- toYaml .Values.vmselect.securityContext | nindent 12 }}
           args:
             - {{ printf "%s=%s" "--cacheDataPath" .Values.vmselect.cacheMountPath | quote}}
           {{- if not .Values.vmselect.suppresStorageFQDNsRender }}
@@ -112,9 +112,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.vmselect.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.vmselect.securityContext }}
+    {{- if .Values.vmselect.podSecurityContext }}
       securityContext:
-{{ toYaml .Values.vmselect.securityContext | indent 8 }}
+{{ toYaml .Values.vmselect.podSecurityContext | indent 8 }}
     {{- end }}
       serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
     {{- if .Values.vmselect.tolerations }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -51,7 +51,7 @@ spec:
           workingDir: {{ .Values.vmstorage.containerWorkingDir }}
           {{- end }}
           securityContext:
-            {{- toYaml .Values.vmstorage.podSecurityContext | nindent 12 }}
+            {{- toYaml .Values.vmstorage.securityContext | nindent 12 }}
           args:
             - {{ printf "%s=%s" "--retentionPeriod" (toString .Values.vmstorage.retentionPeriod) | quote}}
             - {{ printf "%s=%s" "--storageDataPath" .Values.vmstorage.persistentVolume.mountPath | quote}}
@@ -106,7 +106,7 @@ spec:
         - name: {{ template "victoria-metrics.name" . }}-vmbackupmanager
           image: "{{ .Values.vmstorage.vmbackupmanager.image.repository }}:{{ .Values.vmstorage.vmbackupmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.vmstorage.image.pullPolicy }}"
-          {{- with .Values.vmstorage.podSecurityContext }}
+          {{- with .Values.vmstorage.securityContext }}
           securityContext:
             {{- toYaml .  | nindent 12 }}
           {{- end }}
@@ -171,9 +171,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.vmstorage.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.vmstorage.securityContext }}
+    {{- if .Values.vmstorage.podSecurityContext }}
       securityContext:
-{{ toYaml .Values.vmstorage.securityContext | indent 8 }}
+{{ toYaml .Values.vmstorage.podSecurityContext | indent 8 }}
     {{- end }}
       serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
     {{- if .Values.vmstorage.tolerations }}

--- a/charts/victoria-metrics-single/templates/_helpers.tpl
+++ b/charts/victoria-metrics-single/templates/_helpers.tpl
@@ -153,7 +153,7 @@ Return if ingress supports pathType.
     {{- range $key, $value := .Values.server.vmbackupmanager.extraArgs }}
     - --{{ $key }}={{ $value }}
     {{- end }}
-  {{- with  .Values.server.podSecurityContext }}
+  {{- with  .Values.server.securityContext }}
   securityContext: {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.server.vmbackupmanager.resources }}

--- a/charts/victoria-metrics-single/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-single/templates/server-deployment.yaml
@@ -49,7 +49,7 @@ spec:
       containers:
         - name: {{ template "victoria-metrics.name" . }}-{{ .Values.server.name }}
           securityContext:
-            {{- toYaml .Values.server.podSecurityContext | nindent 12 }}
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           {{- if .Values.server.containerWorkingDir }}
@@ -203,9 +203,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.server.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.server.securityContext }}
+    {{- if .Values.server.podSecurityContext }}
       securityContext:
-{{ toYaml .Values.server.securityContext | indent 8 }}
+{{ toYaml .Values.server.podSecurityContext | indent 8 }}
     {{- end }}
       serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
     {{- if .Values.server.tolerations }}

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "victoria-metrics.name" . }}-{{ .Values.server.name }}
-          {{- with  .Values.server.podSecurityContext }}
+          {{- with  .Values.server.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
@@ -170,7 +170,7 @@ spec:
           {{- with .Values.server.vmbackupmanager.resources }}
           resources: {{ toYaml . | nindent 12  }}
           {{- end }}
-          {{- with  .Values.server.podSecurityContext }}
+          {{- with  .Values.server.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with $.Values.server.vmbackupmanager.livenessProbe }}
@@ -204,9 +204,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.server.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.server.securityContext }}
+    {{- if .Values.server.podSecurityContext }}
       securityContext:
-{{ toYaml .Values.server.securityContext | indent 8 }}
+{{ toYaml .Values.server.podSecurityContext | indent 8 }}
     {{- end }}
       serviceAccountName: {{ template "victoria-metrics.serviceAccountName" . }}
     {{- if .Values.server.tolerations }}


### PR DESCRIPTION
fix https://github.com/VictoriaMetrics/helm-charts/issues/455
`securityContext` should be used for containers, `podSecurityContext` should be used for pod