### PR TITLE
move clean up cr job to operator chart

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -7,6 +7,8 @@
 ![AppVersion: **APP_VERSION**](https://img.shields.io/static/v1?label=AppVersion&message=**APP_VERSION**&color=success&logo=)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
+* Move `cleanupCRD` option to victoria-metrics-operator chart (#593)
+
 - TODO
 
 ## 0.17.5

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -43,14 +43,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Create the name of service account and clusterRole for cleanup-hook
-*/}}
-{{- define "victoria-metrics-k8s-stack.cleanupHookName" -}}
-{{- printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "cleanup-hook" | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-
-{{/*
 Create the name for VMSingle
 */}}
 {{- define "victoria-metrics-k8s-stack.vmsingleName" -}}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -11,6 +11,12 @@ argocdReleaseOverride: ""
 # -- also checkout here possible ENV variables to configure operator behaviour https://docs.victoriametrics.com/operator/vars.html
 victoria-metrics-operator:
   enabled: true
+  # -- Tells helm to clean up vm cr resources when uninstalling 
+  cleanupCRD: true
+  cleanupImage:
+    repository: gcr.io/google_containers/hyperkube
+    tag: v1.18.0
+    pullPolicy: IfNotPresent
 
   createCRD: false # we disable crd creation by operator chart as we create them in this chart
   operator:

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -11,12 +11,6 @@ argocdReleaseOverride: ""
 # -- also checkout here possible ENV variables to configure operator behaviour https://docs.victoriametrics.com/operator/vars.html
 victoria-metrics-operator:
   enabled: true
-  # -- Tells helm to remove CRD after chart remove
-  cleanupCRD: true
-  cleanupImage:
-    repository: gcr.io/google_containers/hyperkube
-    tag: v1.18.0
-    pullPolicy: IfNotPresent
 
   createCRD: false # we disable crd creation by operator chart as we create them in this chart
   operator:

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -8,8 +8,9 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 * Added `topologySpreadConstraints` for the operator + a small refactoring (#611) 
-* fix vm operator appVersion (#589) 
+* Fix vm operator appVersion (#589)
 * Fixes operator doc description
+* Add `cleanupCRD` option to clean up vm cr resources when uninstalling (#593)
 
 ## 0.24.1 
 

--- a/charts/victoria-metrics-operator/templates/_helpers.tpl
+++ b/charts/victoria-metrics-operator/templates/_helpers.tpl
@@ -58,3 +58,10 @@ Create unified labels for vm-operator components
 helm.sh/chart: {{ include "vm-operator.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Create the name of service account and clusterRole for cleanup-hook
+*/}}
+{{- define "vm-operator.cleanupHookName" -}}
+{{- printf "%s-%s" (include "vm-operator.fullname" .) "cleanup-hook" | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
+++ b/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
@@ -3,26 +3,25 @@
 "helm.sh/hook-weight": "-5"
 "helm.sh/hook-delete-policy": hook-succeeded
 {{- end }}
-{{- if (index .Values "victoria-metrics-operator" "enabled") }}
-{{- if (index .Values "victoria-metrics-operator" "cleanupCRD") }}
+{{- if .Values.cleanupCRD }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "victoria-metrics-k8s-stack.cleanupHookName" . }}
+  name: {{ include "vm-operator.cleanupHookName" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "victoria-metrics-k8s-stack.labels" . | nindent 4 }}
+  labels: {{ include "vm-operator.labels" . | nindent 4 }}
   annotations: {{ include "cleanupHookName.annotations" . | nindent 4 }}
 spec:
   template:
     metadata:
       name: "{{ .Release.Name }}"
-      labels: {{ include "victoria-metrics-k8s-stack.labels" . | nindent 8 }}
+      labels: {{ include "vm-operator.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "victoria-metrics-k8s-stack.cleanupHookName" . }}
+      serviceAccountName: {{ include "vm-operator.cleanupHookName" . }}
       containers:
         - name: kubectl
-          image: "{{ (index .Values "victoria-metrics-operator" "cleanupImage" "repository") }}:{{ (index .Values "victoria-metrics-operator" "cleanupImage" "tag") }}"
-          imagePullPolicy: "{{ (index .Values "victoria-metrics-operator" "cleanupImage" "pullPolicy") }}"
+          image: "{{ (index .Values "cleanupImage" "repository") }}:{{ (index .Values "cleanupImage" "tag") }}"
+          imagePullPolicy: "{{ (index .Values "cleanupImage" "pullPolicy") }}"
           resources:
             limits:
               cpu: "500m"
@@ -56,33 +55,33 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "victoria-metrics-k8s-stack.cleanupHookName" . }}
+  name: {{ include "vm-operator.cleanupHookName" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "victoria-metrics-k8s-stack.labels" . | nindent 4 }}
+  labels: {{- include "vm-operator.labels" . | nindent 4 }}
   annotations: {{ include "cleanupHookName.annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "victoria-metrics-k8s-stack.cleanupHookName" . }}
+  name: {{ include "vm-operator.cleanupHookName" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "victoria-metrics-k8s-stack.labels" . | nindent 4 }}
+  labels: {{- include "vm-operator.labels" . | nindent 4 }}
   annotations: {{ include "cleanupHookName.annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "victoria-metrics-k8s-stack.cleanupHookName" . }}
+  name: {{ include "vm-operator.cleanupHookName" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "victoria-metrics-k8s-stack.cleanupHookName" . }}
+    name: {{ include "vm-operator.cleanupHookName" . }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "victoria-metrics-k8s-stack.cleanupHookName" . }}
+  name: {{ include "vm-operator.cleanupHookName" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "victoria-metrics-k8s-stack.labels" . | nindent 4 }}
+  labels: {{- include "vm-operator.labels" . | nindent 4 }}
   annotations: {{ include "cleanupHookName.annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["operator.victoriametrics.com"]
@@ -95,4 +94,4 @@ rules:
     verbs: ["get", "list", "watch","delete"]
 ---
 {{- end }}
-{{- end }}
+

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -13,7 +13,7 @@ image:
 # -- with this option, if you remove this chart, all crd resources will be deleted with it.
 createCRD: true
 
-# -- Tells helm to remove vm resources when release uninstall
+# -- Tells helm to clean up vm cr resources when uninstalling
 cleanupCRD: true
 cleanupImage:
   repository: gcr.io/google_containers/hyperkube

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -13,6 +13,13 @@ image:
 # -- with this option, if you remove this chart, all crd resources will be deleted with it.
 createCRD: true
 
+# -- Tells helm to remove vm resources when release uninstall
+cleanupCRD: true
+cleanupImage:
+  repository: gcr.io/google_containers/hyperkube
+  tag: v1.18.0
+  pullPolicy: IfNotPresent
+
 replicaCount: 1
 
 # -- Secret to pull images
@@ -59,7 +66,7 @@ operator:
   useCustomConfigReloader: false
 
 # By default, the operator will watch all the namespaces
-# If you want to override this behavior, specify the namespace. 
+# If you want to override this behavior, specify the namespace.
 # Operator supports only single namespace for watching.
 watchNamespace: ""
 

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -14,7 +14,7 @@ image:
 createCRD: true
 
 # -- Tells helm to clean up vm cr resources when uninstalling
-cleanupCRD: true
+cleanupCRD: false
 cleanupImage:
   repository: gcr.io/google_containers/hyperkube
   tag: v1.18.0


### PR DESCRIPTION
I think the right way to fix https://github.com/VictoriaMetrics/helm-charts/issues/548 is moving the cleanup job to operator, instead of have a second job in operator.
But there will be version dependency for victoria-metrics-k8s-stack, it will only have cleanup job when having new operator version.