### PR TITLE
[vmstorage, vminsert] Add topologySpreadConstraints

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -154,6 +154,10 @@ spec:
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.vminsert.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.vminsert.topologySpreadConstraints | indent 8 }}
+      {{- end }}
       {{- with .Values.vminsert.extraVolumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -125,6 +125,10 @@ spec:
       affinity:
 {{ toYaml .Values.vmselect.affinity | indent 8 }}
     {{- end }}
+    {{- if .Values.vmselect.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.vmselect.topologySpreadConstraints | indent 8 }}
+    {{- end }}
       volumes:
       {{- with .Values.vmselect.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -184,6 +184,10 @@ spec:
       affinity:
 {{ toYaml .Values.vmstorage.affinity | indent 8 }}
     {{- end }}
+     {{- if .Values.vmstorage.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.vmstorage.topologySpreadConstraints | indent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.vmstorage.terminationGracePeriodSeconds }}
       volumes:
         {{- with .Values.vmstorage.extraVolumes }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -359,6 +359,8 @@ vminsert:
   nodeSelector: {}
   # -- Pod affinity
   affinity: {}
+  # -- Pod topologySpreadConstraints
+  topologySpreadConstraints: []
   # -- Pod's annotations
   podAnnotations: {}
   # -- Count of vminsert pods
@@ -541,6 +543,9 @@ vmstorage:
 
   # -- Pod affinity
   affinity: {}
+    # -- Pod topologySpreadConstraints
+  topologySpreadConstraints: []
+
 
   ## Use an alternate scheduler, e.g. "stork".
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/


### PR DESCRIPTION
For some reason topologySpreadConstraints field exists in vmselect-deployment, but missing in other templates. For that reason, I'm adding it back, to keep templates consistent.