### PR TITLE
chore: bump kube-state-metrics and node-exporter subchart versions

### DIFF
--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -13,11 +13,11 @@ dependencies:
     repository: https://victoriametrics.github.io/helm-charts
     condition: victoria-metrics-operator.enabled
   - name: kube-state-metrics
-    version: "4.24.*"
+    version: "5.10.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-state-metrics.enabled
   - name: prometheus-node-exporter
-    version: "4.7.*"
+    version: "4.22.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-node-exporter.enabled
   - name: grafana


### PR DESCRIPTION
Upstream changelogs don't indicate any breaking changes, so should be fine :)