### PR TITLE
[victoria-metrics-k8s-stack]:vmalert notifiers and replicas of alertmanager

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -119,8 +119,13 @@ remoteWrite:
 {{- end }}
 remoteRead: {{ include "victoria-metrics-k8s-stack.vmReadEndpoint" . | nindent 2 }}
 datasource: {{ include "victoria-metrics-k8s-stack.vmReadEndpoint" . | nindent 2 }}
+{{- if .Values.alertmanager.enabled }}
+{{- $alertManagerReplicas := .Values.alertmanager.spec.replicaCount | default 1 }}
 notifiers:
-    - url: {{ printf "http://%s-%s.%s.svc:9093" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) .Release.Namespace }}
+    {{- range $n := until (int $alertManagerReplicas) }}
+    - url: {{ printf "http://%s-%s-%d.%s-%s.%s.svc:9093" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" $) $n "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" $) $.Release.Namespace }}
+    {{- end }}
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
If instead of replicas in notifiers add only a service, then alerts are sent to only one alertmanager and this is a problem since alerts in the alertmanager cluster are not synchronized, unlike silence.

