### PR TITLE
Fix relabelConfigs for operator scrape

### DIFF
--- a/charts/victoria-metrics-operator/templates/service_scrape.yaml
+++ b/charts/victoria-metrics-operator/templates/service_scrape.yaml
@@ -35,7 +35,7 @@ spec:
           {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.serviceMonitor.relabelings }}
-      relabelings:
+      relabelConfigs:
           {{- toYaml . | nindent 8 }}
       {{- end }}
   namespaceSelector:


### PR DESCRIPTION
Fix [option name](https://docs.victoriametrics.com/operator/api.html#endpoint) for victoria-metrics-operator VMServiceScrape 