### PR TITLE
fix grafana dashboards so ephemeral_storage does not mess with memory query

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-global.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-global.yaml
@@ -302,7 +302,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_requests{unit=\"byte\"}) / sum(machine_memory_bytes)",
+                        "expr": "sum(kube_pod_container_resource_requests{unit=\"byte\", resource=\"memory\"}) / sum(machine_memory_bytes)",
                         "hide": false,
                         "legendFormat": "Requests",
                         "range": true,
@@ -314,7 +314,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_limits{unit=\"byte\"}) / sum(machine_memory_bytes)",
+                        "expr": "sum(kube_pod_container_resource_limits{unit=\"byte\", resource=\"memory\"}) / sum(machine_memory_bytes)",
                         "hide": false,
                         "legendFormat": "Limits",
                         "range": true,
@@ -847,7 +847,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_requests{unit=\"byte\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{unit=\"byte\", resource=\"memory\"})",
                         "hide": false,
                         "legendFormat": "Requests",
                         "range": true,
@@ -859,7 +859,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_limits{unit=\"byte\"})",
+                        "expr": "sum(kube_pod_container_resource_limits{unit=\"byte\", resource=\"memory\"})",
                         "hide": false,
                         "legendFormat": "Limits",
                         "range": true,


### PR DESCRIPTION
the currently, the dashboards use kube_pod_container_resource_requests metric with a constraint on unit=byte to calculate memory maximums. 

this becomes misleading when also setting the "ephemeral storage" resource, because the unit is also bytes, but the resource is ephemeral_storage, not memory, resulting in incorrect values

 