### PR TITLE
Fix kubeVersion in Chart.yaml

### DIFF
--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -5,7 +5,7 @@ name: victoria-metrics-single
 version: 0.9.6
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
-kubeVersion: ">=1.23.0"
+kubeVersion: ">=1.23.0-0"
 keywords:
   - victoriametrics
   - vmsingle


### PR DESCRIPTION
When trying to update the victoria-metrics-single helm chart in our GKE cluster we see the following error:
```
chart requires kubeVersion: >= 1.23.0 which is incompatible with Kubernetes v1.27.3-gke.100
```
This seems to be a known issue and can by fixed by appending a `-0` to the version:
https://github.com/helm/helm/issues/3810#issuecomment-379877753

This is actually already done for all other Victoria Metrics helm charts except for victoria-metrics-single:
https://github.com/search?q=repo%3AVictoriaMetrics%2Fhelm-charts%20%3E%3D1.23.0-0&type=code
