### PR TITLE
feat: allow GrafanaDashboard resources to be deployed in different namespace and/or with additional parameters

### DIFF
--- a/charts/victoria-metrics-k8s-stack/hack/sync_grafana_dashboards.py
+++ b/charts/victoria-metrics-k8s-stack/hack/sync_grafana_dashboards.py
@@ -105,14 +105,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%%s-%%s" (include "victoria-metrics-k8s-stack.fullname" $) "%(name)s" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/alertmanager-overview.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/alertmanager-overview.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-overview" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/backupmanager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/backupmanager.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "backupmanager" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/grafana-overview.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/grafana-overview.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "grafana-overview" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-system-coredns.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-system-coredns.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-system-coredns" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-global.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-global.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-views-global" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-namespaces.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-namespaces.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-views-namespaces" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-pods.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-pods.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-views-pods" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/operator.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/operator.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "operator" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "victoriametrics-cluster" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "victoriametrics" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmagent.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "vmagent" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmalert.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmalert.yaml
@@ -8,14 +8,28 @@ https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metri
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.grafanaOperatorDashboardsFormat.namespace .Release.Namespace }}
   name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "vmalert" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.grafanaOperatorDashboardsFormat.instanceSelector }}
   instanceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: {{ . }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaOperatorDashboardsFormat.datasources }}
+  datasources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- else }}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -82,6 +82,12 @@ experimentalDashboardsEnabled: true
 ## -- Create dashboards as CRDs (reuqires grafana-operator to be installed)
 grafanaOperatorDashboardsFormat:
   enabled: false
+  # annotations:
+  #   argocd.argoproj.io/sync-options: ServerSideApply=true
+  # namespace: "grafana"
+  # allowCrossNamespaceImport: false
+  # datasources: []
+  # folder: "VictoriaMetrics"
   instanceSelector:
     matchLabels:
       dashboards: "grafana"


### PR DESCRIPTION
This allows to deploy the `GrafanaDashboard` CRs in a separate namespace or to enable `allowCrossNamespaceImport` (which one or the other would be needed, if Grafana is deployed in a different namespace than VictoriaMetrics). 

Additionally it's now possible to override the folder in which the Grafana-Operator places the dashboards and with the `datasources` parameter, one could specifically point the datasource variable within the dashboards to a specific datasource.