### PR TITLE
update sync_rules.py to allow disabling individual alerts

### DIFF
--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -62,6 +62,10 @@ defaultRules:
 
   # -- Runbook url prefix for default rules
   runbookUrl: https://runbooks.prometheus-operator.dev/runbooks
+
+  # Disabled VMRules
+  disabled: {}
+
   ## Reduce app namespace alert scope
   appNamespacesTarget: ".*"
 


### PR DESCRIPTION
Hi,
the kube-prometheus-stack chart allows to disable individual alerts that it ships.
This was added to their sync_rules.py almost two years ago and was something i really missed in this chart.

This merge request will adjust the sync_rules.py to also include the conditions to disable individual rules.

I did test this locally by generating the rules with the make file and running helm template to validate that the chart renders correctly.

If you want i can also generate the rules in this MR but i thought that is part of the release process, thats why i did not yet include it. Let me know if i should add the new rules to this MR.

Maybe it would also be a good idea to bring the script in sync with the latest version of the kube-prometheus-stack chart:
https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py