### PR TITLE
Fix: the statefulset pod name length is more than 63

### DIFF
--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -91,13 +91,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "victoria-metrics.vmstorage.fullname" -}}
 {{- if .Values.vmstorage.fullnameOverride -}}
-{{- .Values.vmstorage.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- .Values.vmstorage.fullnameOverride | trunc 60 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.vmstorage.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Values.vmstorage.name | trunc 60 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.vmstorage.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.vmstorage.name | trunc 60 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
If the statefulset name length is 63, the pod name length of the statefulset is more than 63. The Pods' names take the form `<statefulset name>-<ordinal index>`.

So this PR limits the statefulset name max length to 60.