### PR TITLE
victoria-metrics-alert: fix notifier address if builtin alertmanager …

### DIFF
--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Fix vmalert notifier address if builtin alertmanager is enabled and using baseURLPrefix.
 
 ## 0.7.8
 

--- a/charts/victoria-metrics-alert/templates/_helpers.tpl
+++ b/charts/victoria-metrics-alert/templates/_helpers.tpl
@@ -119,9 +119,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Create base alertmanager url for notifers
+*/}}
 {{- define "vmalert.alertmanager.url" -}}
 {{- if .Values.alertmanager.enabled -}}
-http://{{- include "vmalert.alertmanager.fullname" . -}}:9093
+http://{{- include "vmalert.alertmanager.fullname" . -}}:9093{{ .Values.alertmanager.baseURLPrefix }}
 {{- else -}}
 {{- .Values.server.notifier.alertmanager.url -}}
 {{- end -}}


### PR DESCRIPTION
…is enabled and using baseURLPrefix
