### PR TITLE
From pod labels removed dynamic label `helm.sh/chart`

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- From pod labels removed dynamic label `helm.sh/chart` to avoid restarting every time the chart is updated without changing the pods parameters. **Note that this time it will cause the pods to restart** (#695)
 
 ## 0.11.0
 

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.93.5
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.11.0
+version: 0.11.1
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -55,9 +55,18 @@ helm.sh/chart: {{ include "victoria-metrics.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
+{{- define "victoria-metrics.common.podLabels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
 {{- define "victoria-metrics.vmstorage.labels" -}}
 {{ include "victoria-metrics.vmstorage.matchLabels" . }}
 {{ include "victoria-metrics.common.metaLabels" . }}
+{{- end -}}
+
+{{- define "victoria-metrics.vmstorage.podLabels" -}}
+{{ include "victoria-metrics.vmstorage.matchLabels" . }}
+{{ include "victoria-metrics.common.podLabels" . }}
 {{- end -}}
 
 {{- define "victoria-metrics.vmstorage.matchLabels" -}}
@@ -70,6 +79,11 @@ app: {{ .Values.vmstorage.name }}
 {{ include "victoria-metrics.common.metaLabels" . }}
 {{- end -}}
 
+{{- define "victoria-metrics.vmselect.podLabels" -}}
+{{ include "victoria-metrics.vmselect.matchLabels" . }}
+{{ include "victoria-metrics.common.podLabels" . }}
+{{- end -}}
+
 {{- define "victoria-metrics.vmselect.matchLabels" -}}
 app: {{ .Values.vmselect.name }}
 {{ include "victoria-metrics.common.matchLabels" . }}
@@ -78,6 +92,11 @@ app: {{ .Values.vmselect.name }}
 {{- define "victoria-metrics.vminsert.labels" -}}
 {{ include "victoria-metrics.vminsert.matchLabels" . }}
 {{ include "victoria-metrics.common.metaLabels" . }}
+{{- end -}}
+
+{{- define "victoria-metrics.vminsert.podLabels" -}}
+{{ include "victoria-metrics.vminsert.matchLabels" . }}
+{{ include "victoria-metrics.common.podLabels" . }}
 {{- end -}}
 
 {{- define "victoria-metrics.vminsert.matchLabels" -}}

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "victoria-metrics.vminsert.labels" . | nindent 8 }}
+        {{- include "victoria-metrics.vminsert.podLabels" . | nindent 8 }}
         {{- with .Values.vminsert.extraLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -31,7 +31,7 @@ spec:
 {{ toYaml .Values.vmselect.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        {{- include "victoria-metrics.vmselect.labels" . | nindent 8 }}
+        {{- include "victoria-metrics.vmselect.podLabels" . | nindent 8 }}
 {{- with .Values.vmselect.extraLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -27,7 +27,7 @@ spec:
 {{ toYaml .Values.vmselect.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        {{- include "victoria-metrics.vmselect.labels" . | nindent 8 }}
+        {{- include "victoria-metrics.vmselect.podLabels" . | nindent 8 }}
 {{- with .Values.vmselect.extraLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -27,7 +27,7 @@ spec:
 {{ toYaml .Values.vmstorage.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        {{- include "victoria-metrics.vmstorage.labels" . | nindent 8 }}
+        {{- include "victoria-metrics.vmstorage.podLabels" . | nindent 8 }}
 {{- with .Values.vmstorage.extraLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}


### PR DESCRIPTION
From pod labels removed dynamic label `helm.sh/chart` to avoid restarting every time the chart is updated without changing the pods parameters. 

**Note that this time it will lead the pods restart** 

issue: #695