### PR TITLE
charts(victoria-metrics-operator): fix RBAC

### DIFF
--- a/charts/victoria-metrics-operator/templates/cluster_role.yaml
+++ b/charts/victoria-metrics-operator/templates/cluster_role.yaml
@@ -496,4 +496,12 @@ rules:
   verbs:
     - get
     - list
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 {{- end -}}


### PR DESCRIPTION
This will fix errors like

`
victoria-metrics-operator-67f7ff89cd-rnpns victoria-metrics-operator {"level":"error","ts":1696503003.9076064,"msg":"Reconciler error","controller":"vmagent","controllerGroup":"operator.victoriametrics.com","controllerKind":"VMAgent","VMAgent":{"name":"victoriametrics","namespace":"monitoring"},"namespace":"monitoring","name":"victoriametrics","reconcileID":"14bb7466-e5a2-42f2-946c-0c9114d7d58f","error":"cannot create vmagent role and binding for it, err: cannot ensure state of vmagent's cluster role: clusterroles.rbac.authorization.k8s.io \"monitoring:vmagent-cluster-access-victoriametrics\" is forbidden: user \"system:serviceaccount:monitoring:victoria-metrics-operator\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:monitoring\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"discovery.k8s.io\"], Resources:[\"endpointslices\"], Verbs:[\"get\" \"list\" \"watch\"]}","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.13.1/pkg/internal/controller/controller.go:326\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.13.1/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.13.1/pkg/internal/controller/controller.go:234"}
`