### PR TITLE
added endpointslices permissions to operator rbac clusterrole

### DIFF
--- a/charts/victoria-metrics-operator/templates/cluster_role.yaml
+++ b/charts/victoria-metrics-operator/templates/cluster_role.yaml
@@ -496,4 +496,12 @@ rules:
   verbs:
     - get
     - list
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
+    - get
 {{- end -}}


### PR DESCRIPTION
Hello VictoriaMetrics team,

we discovered that the operator chart RBAC misses the following permission after operator itself was modified https://github.com/VictoriaMetrics/operator/pull/763

Thanks