### PR TITLE
vmanomaly: allow changing configuration parameters

### DIFF
--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Add an options to override default `metric_format` for remote write configuration of vmanomaly.
 
 ## 0.4.0
 

--- a/charts/victoria-metrics-anomaly/templates/configmap.yaml
+++ b/charts/victoria-metrics-anomaly/templates/configmap.yaml
@@ -51,8 +51,8 @@ data:
       health_path: {{ . }}
       {{ end -}}
       metric_format:
-        __name__: "$VAR"
-        query: "$QUERY_KEY"
+        __name__: {{ .Values.remote.write.metric_format.name }}
+        query: {{ .Values.remote.write.metric_format.query }}
         model: {{ .Values.model.enabled }}
     {{ if or .Values.monitoring.pull.enabled .Values.monitoring.push.url }}
     monitoring:

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -131,6 +131,9 @@ remote:
     basicAuth:
       username: ""
       password: ""
+    metric_format:
+      name: "$VAR"
+      query: "$QUERY_KEY"
 
 scheduler:
   class: "scheduler.periodic.PeriodicScheduler"


### PR DESCRIPTION
Moves hardcoded configuration values into `.Values` to make it overridable.