### PR TITLE
{single,cluster}: bump charts version for release

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.94.0
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.11.2
+version: 0.11.3
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.94.0
 description: Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.9.9
+version: 0.9.10
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"


### PR DESCRIPTION
Updates in order to release fix from https://github.com/VictoriaMetrics/helm-charts/pull/712 and address https://github.com/VictoriaMetrics/helm-charts/issues/728