### PR TITLE
vmselect-statefulset breaks when resources are set

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -100,8 +100,8 @@ spec:
             {{- with .Values.vmselect.extraVolumeMounts }}
           {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.vmselect.resources }}
           {{- include "chart.license.mount" . | nindent 12 }}
+          {{- with .Values.vmselect.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
Fixing position of license mount.

When "vmselect.statefulSet.enabled=true" and "vmselect.resources.requests != {}" then the Template fails with 

``` 
error calling include: template: victoria-metrics-cluster/templates/_helpers.tpl:309:18: executing "chart.license.mount" at <.Values.license.secret.name>: nil pointer evaluating interface {}.license
```