### PR TITLE
vm-operator: add `extraObjects` to allow deploying additional resourc…

### DIFF
--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.18.5
+version: 0.18.6
 appVersion: v1.94.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- Add `extraObjects` to allow deploying additional resources with the chart release.
+- Add `extraObjects` to allow deploying additional resources with the chart release. (#751)
 
 ## 0.27.3
 

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Add `extraObjects` to allow deploying additional resources with the chart release.
 
 ## 0.27.3
 

--- a/charts/victoria-metrics-operator/Chart.yaml
+++ b/charts/victoria-metrics-operator/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/VictoriaMetrics/operator
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
   - https://github.com/VictoriaMetrics/operator
-version: 0.27.3
+version: 0.27.4
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
 kubeVersion: ">=1.23.0-0"
 keywords:

--- a/charts/victoria-metrics-operator/README.md
+++ b/charts/victoria-metrics-operator/README.md
@@ -157,6 +157,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | extraContainers | list | `[]` |  |
 | extraHostPathMounts | list | `[]` | Additional hostPath mounts |
 | extraLabels | object | `{}` | Labels to be added to the all resources |
+| extraObjects | list | `[]` | Add extra specs dynamically to this chart |
 | extraVolumeMounts | list | `[]` | Extra Volume Mounts for the container |
 | extraVolumes | list | `[]` | Extra Volumes for the pod |
 | fullnameOverride | string | `""` | Overrides the full name of server component |

--- a/charts/victoria-metrics-operator/templates/extra-objects.yaml
+++ b/charts/victoria-metrics-operator/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -174,3 +174,6 @@ serviceMonitor:
   extraLabels: {}
   annotations: {}
   relabelings: []
+
+# -- Add extra specs dynamically to this chart
+extraObjects: []


### PR DESCRIPTION
…es with the chart release
And victoria-metrics-k8s-stack [uses](https://github.com/VictoriaMetrics/helm-charts/blob/add-extra-objects-for-operator-chart/charts/victoria-metrics-k8s-stack/Chart.yaml#L35) victoria-metrics-operator as dependency, it will get `extraObjects` as well.