### PR TITLE
vm-alert: fix `notifier.url` check, as it is only needed when alertin…

### DIFF
--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fix `notifier.url` check, as it's only needed when alerting rule is used. (#767)
 
 ## 0.8.3
 

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -4,9 +4,6 @@
 {{- fail "at least one item in `.server.config.alerts.groups` or `.server.extraArgs.rule` must be set " -}}
 {{- end -}}
 {{- end -}}
-{{- if (eq (include "vmalert.alertmanager.urls" . ) "") -}}
-{{- fail "alert manager URL must be specified. Please fill server.notifier.alertmanager.url or server.notifiers or enable Alertmanager in values file" -}}
-{{- end -}}
 {{- if eq .Values.server.datasource.url "" -}}
 {{- fail "server.datasource.url datasource URL must be specified" -}}
 {{- end -}}


### PR DESCRIPTION
…g rule is used.
address https://github.com/VictoriaMetrics/helm-charts/issues/766