### PR TITLE
victoria-metrics-cluster: fix vminsert template for extra volumes

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Fix `vminsert` configuration for volumes when using `extraVolumes`. 
 
 ## 0.11.6
 

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.95.1
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.11.6
+version: 0.11.7
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -162,9 +162,11 @@ spec:
       topologySpreadConstraints:
 {{ toYaml .Values.vminsert.topologySpreadConstraints | indent 8 }}
       {{- end }}
-      {{- with .Values.vminsert.extraVolumes }}
+      {{- if or (and .Values.license.secret.name .Values.license.secret.key) .Values.vminsert.extraVolumes }}
       volumes:
+        {{- with .Values.vminsert.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "chart.license.volume" . | nindent 8 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
 Previously, using `extraVolumes` would trigger an error:
```
Error: UPGRADE FAILED: template: templates/vminsert-deployment.yaml:168:12: executing "templates/vminsert-deployment.yaml" at <include "chart.license.volume" .>: error calling include: template: templates/_helpers.tpl:297:18: executing "chart.license.volume" at <.Values.license.secret.name>: can't evaluate field Values in type []interface {}
```
Caused by using `.` from unexpected context from `with` clause.