### PR TITLE
victoria-metrics-k8s-stack: re-sync dashboards from upstream resources

### DIFF
--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: victoria-metrics-alert
 description: Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.8.3
+version: 0.8.4
 appVersion: v1.95.1
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next release
 
-- Properly use variable from values file for Grafana datasource type [pull request](https://github.com/VictoriaMetrics/helm-charts/pull/769) 
+- Properly use variable from values file for Grafana datasource type [pull request](https://github.com/VictoriaMetrics/helm-charts/pull/769)
+- Update dashboards from upstream sources.
 
 ## 0.18.8
 

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.18.8
+version: 0.18.9
 appVersion: v1.95.1
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
@@ -111,7 +111,7 @@ data:
                         "uid": "$ds"
                     },
                     "enable": true,
-                    "expr": "sum(ALERTS{alertgroup=\"vmcluster\",alertstate=\"firing\",show_at=\"dashboard\"}) by(alertname)",
+                    "expr": "sum(ALERTS{job=~\"$job\", instance=~\"$instance\", alertgroup=\"vmcluster\",alertstate=\"firing\",show_at=\"dashboard\"}) by(alertname)",
                     "iconColor": "red",
                     "name": "alerts",
                     "titleFormat": "{{`{{`}}alertname{{`}}`}}"
@@ -122,11 +122,11 @@ data:
                         "uid": "$ds"
                     },
                     "enable": true,
-                    "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset 20m) by(short_version))",
+                    "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset 20m) by(version))",
                     "hide": true,
                     "iconColor": "dark-blue",
                     "name": "version change",
-                    "textFormat": "{{`{{`}}short_version{{`}}`}}",
+                    "textFormat": "{{`{{`}}version{{`}}`}}",
                     "titleFormat": "Version change"
                 },
                 {
@@ -1173,7 +1173,7 @@ data:
                             "uid": "$ds"
                         },
                         "editorMode": "code",
-                        "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance\", path!~\"/favicon.ico\"}[$__rate_interval])) by (path) > 0",
+                        "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
                         "format": "time_series",
                         "intervalFactor": 1,
                         "legendFormat": "{{`{{`}}path{{`}}`}}",
@@ -1640,7 +1640,7 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Percentage of used memory (resident).\nThe application's performance will significantly degrade when memory usage is close to 100%.",
+                        "description": "Percentage of used RSS memory (resident).\nThe RSS memory shows the amount of memory recently accessed by the application. It includes anonymous memory and data from recently accessed files (aka page cache).\nThe application's performance will significantly degrade when memory usage is close to 100%.\n\nClick on the line and choose Drilldown to show memory usage per instance",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {
@@ -1752,7 +1752,7 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Share for memory allocated by the process itself. When memory usage reaches 100% it will be likely OOM-killed.",
+                        "description": "Share for memory allocated by the process itself. When memory usage reaches 100% it will be likely OOM-killed.\nSafe memory usage % considered to be below 80%\n\nClick on the line and choose Drilldown to show memory usage per instance",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {
@@ -6171,7 +6171,7 @@ data:
                                     "uid": "$ds"
                                 },
                                 "editorMode": "code",
-                                "expr": "sum(rate(vm_http_requests_total{job=~\"$job_select\", instance=~\"$instance\", path!~\"/favicon.ico|/metrics\"}[$__rate_interval])) by (path) > 0",
+                                "expr": "sum(rate(vm_http_requests_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
                                 "format": "time_series",
                                 "intervalFactor": 1,
                                 "legendFormat": "__auto",
@@ -6187,7 +6187,7 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Shows the max number of concurrent selects across instances.\n* `max` - equal to number of CPU * 2 by default. May be configured with `search.maxConcurrentRequests` flag\n* `current` - current number of goroutines busy with processing requests\n\nWhen `current` hits `max` constantly, it means one or more vmselect nodes are overloaded and require more CPU or better load balancing. If CPU panel shows there are free resources - try increasing  `search.maxConcurrentRequests`.",
+                        "description": "Shows the max number of concurrent selects across instances.\n* `max` limit can be configured via `search.maxConcurrentRequests` flag\n* `current` shows the current number of goroutines busy with processing requests\n\nWhen `current` hits `max` constantly, it means one or more vmselect nodes are overloaded with number of requests. If you observe that CPU for vmselects is saturated, consider adding more vmselect replicas or increase CPU resources. If CPU panel shows a plenty of free resources - try increasing `search.maxConcurrentRequests`.",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {
@@ -7278,7 +7278,7 @@ data:
                                     "uid": "$ds"
                                 },
                                 "editorMode": "code",
-                                "expr": "sum(rate(vm_http_requests_total{job=~\"$job_insert\", instance=~\"$instance\", path!~\"/favicon.ico|/metrics\"}[$__rate_interval])) by (path) > 0",
+                                "expr": "sum(rate(vm_http_requests_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
                                 "format": "time_series",
                                 "intervalFactor": 1,
                                 "legendFormat": "__auto",
@@ -8994,8 +8994,8 @@ data:
                     },
                     "definition": "label_values(vm_app_version{job=~\"$job\", version=~\"^vminsert.*\"}, job)",
                     "hide": 2,
-                    "includeAll": false,
-                    "multi": false,
+                    "includeAll": true,
+                    "multi": true,
                     "name": "job_insert",
                     "options": [
 
@@ -9023,8 +9023,8 @@ data:
                     },
                     "definition": "label_values(vm_app_version{job=~\"$job\", version=~\"^vmselect.*\"}, job)",
                     "hide": 2,
-                    "includeAll": false,
-                    "multi": false,
+                    "includeAll": true,
+                    "multi": true,
                     "name": "job_select",
                     "options": [
 
@@ -9052,8 +9052,8 @@ data:
                     },
                     "definition": "label_values(vm_app_version{job=~\"$job\", version=~\"^vmstorage.*\"}, job)",
                     "hide": 2,
-                    "includeAll": false,
-                    "multi": false,
+                    "includeAll": true,
+                    "multi": true,
                     "name": "job_storage",
                     "options": [
 

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics.yaml
@@ -111,7 +111,7 @@ data:
                         "uid": "$ds"
                     },
                     "enable": true,
-                    "expr": "sum(ALERTS{alertgroup=\"vmsingle\",alertstate=\"firing\",show_at=\"dashboard\"}) by(alertname)",
+                    "expr": "sum(ALERTS{job=~\"$job\", instance=~\"$instance\", alertgroup=\"vmsingle\",alertstate=\"firing\",show_at=\"dashboard\"}) by(alertname)",
                     "iconColor": "red",
                     "name": "alerts",
                     "titleFormat": "{{`{{`}}alertname{{`}}`}}"
@@ -122,11 +122,11 @@ data:
                         "uid": "$ds"
                     },
                     "enable": true,
-                    "expr": "sum(vm_app_version{job=~\"$job\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\"} offset 20m) by(short_version))",
+                    "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset 20m) by(short_versionversion))",
                     "hide": true,
                     "iconColor": "dark-blue",
                     "name": "version",
-                    "textFormat": "{{`{{`}}short_version{{`}}`}}",
+                    "textFormat": "{{`{{`}}version{{`}}`}}",
                     "titleFormat": "Version change"
                 }
             ]
@@ -1081,7 +1081,7 @@ data:
                             "uid": "$ds"
                         },
                         "editorMode": "code",
-                        "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance\", path!~\"/favicon.ico\"}[$__rate_interval])) by (path) > 0",
+                        "expr": "sum(rate(vm_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
                         "format": "time_series",
                         "interval": "",
                         "intervalFactor": 1,
@@ -1531,7 +1531,7 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Percentage of used memory (resident).\nThe application's performance will significantly degrade when memory usage is close to 100%.",
+                        "description": "Percentage of used RSS memory (resident).\nThe RSS memory shows the amount of memory recently accessed by the application. It includes anonymous memory and data from recently accessed files (aka page cache).\nThe application's performance will significantly degrade when memory usage is close to 100%.\n\nClick on the line and choose Drilldown to show memory usage per instance",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {
@@ -1793,7 +1793,7 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Share for memory allocated by the process itself. When memory usage reaches 100% it will be likely OOM-killed.\nSafe memory usage % considered to be below 80%",
+                        "description": "Share for memory allocated by the process itself. When memory usage reaches 100% it will be likely OOM-killed.\nSafe memory usage % considered to be below 80%\n\nClick on the line and choose Drilldown to show memory usage per instance",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmagent.yaml
@@ -236,7 +236,7 @@ data:
                             "uid": "$ds"
                         },
                         "editorMode": "code",
-                        "expr": "sum(rate(vm_promscrape_scraped_samples_sum{job=~\"$job\", instance=~\"$instance\", path!~\"/favicon.ico\"}[$__rate_interval]))",
+                        "expr": "sum(rate(vm_promscrape_scraped_samples_sum{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
                         "interval": "",
                         "legendFormat": "__auto",
                         "range": true,
@@ -1660,7 +1660,7 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Percentage of used memory (resident).\nThe application's performance will significantly degrade when memory usage is close to 100%.\n\nClick on the line and choose Drilldown to show Mem usage per instance",
+                        "description": "Percentage of used RSS memory (resident).\nThe RSS memory shows the amount of memory recently accessed by the application. It includes anonymous memory and data from recently accessed files (aka page cache).\nThe application's performance will significantly degrade when memory usage is close to 100%.\n\nClick on the line and choose Drilldown to show memory usage per instance",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {
@@ -3457,7 +3457,7 @@ data:
                                 "refId": "A"
                             }
                         ],
-                        "title": "Scrape targets UP",
+                        "title": "Scrape targets UP(By Type)",
                         "type": "timeseries"
                     },
                     {
@@ -3559,7 +3559,213 @@ data:
                                 "refId": "A"
                             }
                         ],
-                        "title": "Scrape targets DOWN",
+                        "title": "Scrape targets DOWN(By Type)",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "links": [],
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 12,
+                            "x": 0,
+                            "y": 45
+                        },
+                        "id": 132,
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull",
+                                    "max"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true,
+                                "sortBy": "Last *",
+                                "sortDesc": true
+                            },
+                            "tooltip": {
+                                "mode": "multi",
+                                "sort": "desc"
+                            }
+                        },
+                        "pluginVersion": "9.2.6",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "exemplar": true,
+                                "expr": "sum(vm_promscrape_scrape_pool_targets{job=~\"$job\", instance=~\"$instance\", status=\"up\"}) by(job, scrape_job) > 0",
+                                "format": "time_series",
+                                "interval": "",
+                                "legendFormat": "{{`{{`}}job{{`}}`}}: {{`{{`}}scrape_job{{`}}`}}",
+                                "range": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Scrape targets UP(By Job)",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "links": [],
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 12,
+                            "x": 12,
+                            "y": 45
+                        },
+                        "id": 133,
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull",
+                                    "max"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "mode": "multi",
+                                "sort": "desc"
+                            }
+                        },
+                        "pluginVersion": "9.2.6",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "exemplar": true,
+                                "expr": "sum(vm_promscrape_scrape_pool_targets{job=~\"$job\", instance=~\"$instance\", status=\"down\"}) by(job, scrape_job) > 0",
+                                "format": "time_series",
+                                "interval": "",
+                                "legendFormat": "{{`{{`}}job{{`}}`}}: {{`{{`}}scrape_job{{`}}`}}",
+                                "range": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Scrape targets DOWN(By Job)",
                         "type": "timeseries"
                     },
                     {
@@ -4474,7 +4680,7 @@ data:
                                     "uid": "$ds"
                                 },
                                 "exemplar": true,
-                                "expr": "sum(rate(vm_ingestserver_request_errors_total{job=~\"$job\", instance=~\"$instance\", path!~\"/favicon.ico\"}[$__rate_interval])) by(type, net) > 0",
+                                "expr": "sum(rate(vm_ingestserver_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(type, net) > 0",
                                 "interval": "",
                                 "legendFormat": "{{`{{`}} type {{`}}`}} ({{`{{`}}net{{`}}`}})",
                                 "refId": "A"

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmalert.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmalert.yaml
@@ -126,7 +126,7 @@ data:
                 }
             ]
         },
-        "description": "Overview for VictoriaMetrics vmalert v1.83.0 or higher",
+        "description": "Overview for VictoriaMetrics vmalert v1.96.0 or higher",
         "editable": false,
         "fiscalYearStartMonth": 0,
         "graphTooltip": 1,
@@ -318,7 +318,7 @@ data:
                             "uid": "$ds"
                         },
                         "exemplar": false,
-                        "expr": "count(vmalert_alerting_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"})",
+                        "expr": "count(vmalert_alerting_rules_last_evaluation_samples{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -378,7 +378,7 @@ data:
                             "uid": "$ds"
                         },
                         "exemplar": false,
-                        "expr": "count(vmalert_recording_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"})",
+                        "expr": "count(vmalert_recording_rules_last_evaluation_samples{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -442,7 +442,7 @@ data:
                             "uid": "$ds"
                         },
                         "exemplar": false,
-                        "expr": "(sum(vmalert_alerting_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) or vector(0)) + \n(sum(vmalert_recording_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) or vector(0))",
+                        "expr": "(sum(increase(vmalert_alerting_rules_errors_total{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}[$__rate_interval])) or vector(0)) + \n(sum(increase(vmalert_recording_rules_errors_total{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}[$__rate_interval])) or vector(0))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -507,7 +507,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "count(vmalert_recording_rules_last_evaluation_samples < 1) or 0",
+                        "expr": "count(vmalert_recording_rules_last_evaluation_samples{job=~\"$job\", instance=~\"$instance\"} < 1) or 0",
                         "interval": "",
                         "legendFormat": "",
                         "range": true,
@@ -1207,7 +1207,7 @@ data:
                 },
                 "gridPos": {
                     "h": 7,
-                    "w": 24,
+                    "w": 12,
                     "x": 0,
                     "y": 25
                 },
@@ -1276,6 +1276,107 @@ data:
                 "type": "table"
             },
             {
+                "datasource": {
+                    "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
+                    "uid": "$ds"
+                },
+                "description": "Missed evaluation means that group evaluation time takes longer than the configured evaluation interval. \nThis may result in missed alerting notifications or recording rules samples. Try increasing evaluation interval or concurrency for such groups. See https://docs.victoriametrics.com/vmalert.html#groups\n\nIf rule expressions are taking longer than expected, please see https://docs.victoriametrics.com/Troubleshooting.html#slow-queries.\"",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "bars",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "off"
+                            }
+                        },
+                        "mappings": [],
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 80
+                                }
+                            ]
+                        },
+                        "unit": "short"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 12,
+                    "x": 12,
+                    "y": 25
+                },
+                "id": 58,
+                "options": {
+                    "legend": {
+                        "calcs": [
+                            "mean",
+                            "lastNotNull",
+                            "max"
+                        ],
+                        "displayMode": "table",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "pluginVersion": "9.2.6",
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
+                            "uid": "$ds"
+                        },
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(increase(vmalert_iteration_missed_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, group) > 0",
+                        "interval": "1m",
+                        "legendFormat": "__auto",
+                        "range": true,
+                        "refId": "A"
+                    }
+                ],
+                "title": "Missed evaluations ($instance)",
+                "type": "timeseries"
+            },
+            {
                 "collapsed": true,
                 "datasource": {
                     "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
@@ -1337,8 +1438,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -1379,7 +1479,7 @@ data:
                             },
                             "tooltip": {
                                 "mode": "multi",
-                                "sort": "none"
+                                "sort": "desc"
                             }
                         },
                         "pluginVersion": "9.2.6",
@@ -1449,8 +1549,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -1491,7 +1590,7 @@ data:
                             },
                             "tooltip": {
                                 "mode": "multi",
-                                "sort": "none"
+                                "sort": "desc"
                             }
                         },
                         "pluginVersion": "9.2.6",
@@ -1561,8 +1660,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -1675,8 +1773,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -1806,8 +1903,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -1840,7 +1936,7 @@ data:
                             },
                             "tooltip": {
                                 "mode": "multi",
-                                "sort": "none"
+                                "sort": "desc"
                             }
                         },
                         "pluginVersion": "9.2.6",
@@ -1912,8 +2008,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -2190,7 +2285,7 @@ data:
                                 },
                                 "editorMode": "code",
                                 "exemplar": false,
-                                "expr": "sum(vmalert_alerting_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) by(job, group, alertname) > 0",
+                                "expr": "sum(increase(vmalert_alerting_rules_errors_total{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}[$__rate_interval])) by(job, group, alertname) > 0",
                                 "interval": "",
                                 "legendFormat": "{{`{{`}}group{{`}}`}}.{{`{{`}}alertname{{`}}`}} ({{`{{`}}job{{`}}`}})",
                                 "range": true,
@@ -2381,7 +2476,7 @@ data:
                             },
                             "tooltip": {
                                 "mode": "multi",
-                                "sort": "none"
+                                "sort": "desc"
                             }
                         },
                         "pluginVersion": "9.2.6",
@@ -2392,13 +2487,13 @@ data:
                                     "uid": "$ds"
                                 },
                                 "exemplar": false,
-                                "expr": "sum(rate(vmalert_alerts_send_errors_total{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}[$__rate_interval])) by(instance, addr) > 0",
+                                "expr": "sum(rate(vmalert_alerts_send_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(instance, addr) > 0",
                                 "interval": "",
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} => {{`{{`}}addr{{`}}`}}",
                                 "refId": "A"
                             }
                         ],
-                        "title": "Errors rate to Alertmanager ($group)",
+                        "title": "Errors rate to Alertmanager",
                         "type": "timeseries"
                     },
                     {
@@ -2609,7 +2704,7 @@ data:
                             },
                             "tooltip": {
                                 "mode": "multi",
-                                "sort": "none"
+                                "sort": "desc"
                             }
                         },
                         "pluginVersion": "9.2.6",
@@ -2822,7 +2917,7 @@ data:
                                 },
                                 "editorMode": "code",
                                 "exemplar": false,
-                                "expr": "sum(vmalert_recording_rules_error{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}) by(job, group, recording) > 0",
+                                "expr": "sum(increase(vmalert_recording_rules_errors_total{job=~\"$job\", instance=~\"$instance\", group=~\"$group\"}[$__rate_interval])) by(job, group, recording) > 0",
                                 "interval": "",
                                 "legendFormat": "{{`{{`}}group{{`}}`}}.{{`{{`}}recording{{`}}`}} ({{`{{`}}job{{`}}`}})",
                                 "range": true,
@@ -2927,7 +3022,7 @@ data:
                             },
                             "tooltip": {
                                 "mode": "single",
-                                "sort": "none"
+                                "sort": "desc"
                             }
                         },
                         "targets": [
@@ -3019,7 +3114,7 @@ data:
                             },
                             "tooltip": {
                                 "mode": "single",
-                                "sort": "none"
+                                "sort": "desc"
                             }
                         },
                         "targets": [

--- a/charts/victoria-metrics-operator/Chart.yaml
+++ b/charts/victoria-metrics-operator/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/VictoriaMetrics/operator
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
   - https://github.com/VictoriaMetrics/operator
-version: 0.27.6
+version: 0.27.7
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
 kubeVersion: ">=1.23.0-0"
 keywords:


### PR DESCRIPTION
1. re-sync dashboards from upstream resources
2. bump chart version for pr https://github.com/VictoriaMetrics/helm-charts/pull/771 and https://github.com/VictoriaMetrics/helm-charts/pull/767