### PR TITLE
victoria-metrics-k8s-stack: optional allowCrossNamespaceImport in GrafanaDashboard(s)

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Add optional allowCrossNamespaceImport to GrafanaDashboard(s) (#788)
 
 ## 0.18.9
 

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -419,6 +419,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | grafana.sidecar.datasources.jsonData | object | `{}` |  |
 | grafana.vmServiceScrape.enabled | bool | `true` |  |
 | grafana.vmServiceScrape.spec | object | `{}` |  |
+| grafanaOperatorDashboardsFormat.allowCrossNamespaceImport | bool | `false` |  |
 | grafanaOperatorDashboardsFormat.enabled | bool | `false` |  |
 | grafanaOperatorDashboardsFormat.instanceSelector.matchLabels.dashboards | string | `"grafana"` |  |
 | kube-state-metrics.enabled | bool | `true` |  |

--- a/charts/victoria-metrics-k8s-stack/hack/sync_grafana_dashboards.py
+++ b/charts/victoria-metrics-k8s-stack/hack/sync_grafana_dashboards.py
@@ -115,6 +115,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/alertmanager-overview.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/alertmanager-overview.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/backupmanager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/backupmanager.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/grafana-overview.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/grafana-overview.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-system-coredns.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-system-coredns.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-global.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-global.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-namespaces.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-namespaces.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-pods.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-pods.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/operator.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/operator.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmagent.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmalert.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmalert.yaml
@@ -18,6 +18,9 @@ spec:
   instanceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.grafanaOperatorDashboardsFormat.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
 {{- else }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -92,6 +92,7 @@ grafanaOperatorDashboardsFormat:
   instanceSelector:
     matchLabels:
       dashboards: "grafana"
+  allowCrossNamespaceImport: false
 
 # Provide custom recording or alerting rules to be deployed into the cluster.
 additionalVictoriaMetricsMap:


### PR DESCRIPTION
In *victoria-metrics-k8s-stack* Helm Chart, when values define `grafanaOperatorDashboardsFormat.enabled=true`, special `GrafanaDashboard` CRs get rendered that provide dashboards to Grafana Operator (https://grafana-operator.github.io/grafana-operator/). But those CRs don't get imported into Grafana instance when the Grafana Operator is not deployed to the same k8s namespace as the victoria-metrics-k8s-stack chart is, since `GrafanaDashboard` CRs are created in this namespace.
The provided patch allows overriding an additional boolean attribute in the chart values: `grafanaOperatorDashboardsFormat.allowCrossNamespaceImport` which is false by default. When set to true, the created `GrafanaDashboard` CRs will also contain this attribute and Grafana Operator will import them from a namespace that is different than the Grafana Operator's namespace.
