### PR TITLE
Fix Makefile: use spaces instead of tabs in instructions before targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,15 @@ CT?=ct-docker
 CONTAINER ?= docker
 
 ifeq ($(CONTAINER),docker)
-	CONTAINER_USER_OPTION = --user $(shell id -u):$(shell id -g)
-	CONTAINER_VOLUME_OPTION_SUFFIX =
+    CONTAINER_USER_OPTION = --user $(shell id -u):$(shell id -g)
+    CONTAINER_VOLUME_OPTION_SUFFIX =
 else
-	ifeq ($(CONTAINER),podman)
-    	CONTAINER_USER_OPTION =
-    	CONTAINER_VOLUME_OPTION_SUFFIX = :z
-	else
-	    $(error CONTAINER values currently supported are: docker, podman)
-	endif
+    ifeq ($(CONTAINER),podman)
+        CONTAINER_USER_OPTION =
+        CONTAINER_VOLUME_OPTION_SUFFIX = :z
+    else
+        $(error CONTAINER values currently supported are: docker, podman)
+    endif
 endif
 
 helm-docker:


### PR DESCRIPTION
Unfortunately, in the following PR https://github.com/VictoriaMetrics/helm-charts/pull/790 that was already merged into master, there is a syntax error in the Makefile. I didn't use Makefiles for decades so I forgot that tabs are a must in the target definitions, but I never even knew that they must not be used before the targets, in the instructions that are evaluated during parsing of Makefile. So this patch fixes that. The faulty Makefile is OK when CONTAINER variable was either docker or podman, but when something else is used, I got the following output:

```
[peter@sun vm-helm-charts]$ CONTAINER=faulty make sync-dashboards
Makefile:18: *** recipe commences before first target.  Stop.
```

After this patch, the values docker and podman still work as expected, and any other value give correct error message:

```
[peter@sun vm-helm-charts]$ CONTAINER=faulty make sync-dashboards
Makefile:19: *** CONTAINER values currently supported are: docker, podman.  Stop.
```

Sorry for inconvenience.