### PR TITLE
license configuration: remove `secret.key` references for license volumes

### DIFF
--- a/charts/victoria-metrics-agent/templates/_helpers.tpl
+++ b/charts/victoria-metrics-agent/templates/_helpers.tpl
@@ -133,7 +133,6 @@ Return license volume mount
 - name: license-key
   secret:
     secretName: {{ .Values.license.secret.name }}
-    key: {{ .Values.license.secret.key }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/victoria-metrics-alert/templates/_helpers.tpl
+++ b/charts/victoria-metrics-alert/templates/_helpers.tpl
@@ -283,7 +283,6 @@ Return license volume mount
 - name: license-key
   secret:
     secretName: {{ .Values.license.secret.name }}
-    key: {{ .Values.license.secret.key }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/victoria-metrics-anomaly/templates/_helpers.tpl
+++ b/charts/victoria-metrics-anomaly/templates/_helpers.tpl
@@ -73,7 +73,6 @@ Return license volume mount
 - name: license-key
   secret:
     secretName: {{ .Values.license.secret.name }}
-    key: {{ .Values.license.secret.key }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/victoria-metrics-auth/templates/_helpers.tpl
+++ b/charts/victoria-metrics-auth/templates/_helpers.tpl
@@ -117,7 +117,6 @@ Return license volume mount
 - name: license-key
   secret:
     secretName: {{ .Values.license.secret.name }}
-    key: {{ .Values.license.secret.key }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -298,7 +298,6 @@ Return license volume mount
 - name: license-key
   secret:
     secretName: {{ .Values.license.secret.name }}
-    key: {{ .Values.license.secret.key }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/victoria-metrics-gateway/templates/_helpers.tpl
+++ b/charts/victoria-metrics-gateway/templates/_helpers.tpl
@@ -84,7 +84,6 @@ Return license volume mount
 - name: license-key
   secret:
     secretName: {{ .Values.license.secret.name }}
-    key: {{ .Values.license.secret.key }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/victoria-metrics-single/templates/_helpers.tpl
+++ b/charts/victoria-metrics-single/templates/_helpers.tpl
@@ -199,7 +199,6 @@ Return license volume mount
 - name: license-key
   secret:
     secretName: {{ .Values.license.secret.name }}
-    key: {{ .Values.license.secret.key }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Follow-up for https://github.com/VictoriaMetrics/helm-charts/pull/797

Remove `secret.key` reference as it does not actually exist in k8s resource.