### PR TITLE
Remove invalid `scheme` for `tcpSocket` `livenessProbe`s

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -135,11 +135,6 @@ spec:
           livenessProbe:
             tcpSocket:
               port: http
-            {{- if .Values.vminsert.extraArgs.tls }}
-              scheme: HTTPS
-            {{- else }}
-              scheme: HTTP
-            {{- end }}
             initialDelaySeconds: {{ .Values.vminsert.probe.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.vminsert.probe.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.vminsert.probe.liveness.timeoutSeconds }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -101,11 +101,6 @@ spec:
           livenessProbe:
             tcpSocket:
               port: http
-            {{- if .Values.vmselect.extraArgs.tls }}
-              scheme: HTTPS
-            {{- else }}
-              scheme: HTTP
-            {{- end }}
             initialDelaySeconds: {{ .Values.vmselect.probe.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.vmselect.probe.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.vmselect.probe.liveness.timeoutSeconds }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -96,11 +96,6 @@ spec:
           livenessProbe:
             tcpSocket:
               port: http
-            {{- if .Values.vmselect.extraArgs.tls }}
-              scheme: HTTPS
-            {{- else }}
-              scheme: HTTP
-            {{- end }}
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 5


### PR DESCRIPTION
The chart currently fails to deploy for me due to this error.

See - https://github.com/VictoriaMetrics/helm-charts/issues/843