### PR TITLE
victoria-metrics-k8s-stack&victoria-metrics-operator: update crd yaml…

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Remove unsupported `scheme` field under `livenessProbe.tcpSocket`. See [#844](https://github.com/VictoriaMetrics/helm-charts/pull/844) by @MisguidedEmails.
 
 ## 0.11.11
 

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.97.1
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.11.11
+version: 0.11.12
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Do not store original labels in `vmagent`'s memory by default. This reduces memory usage of `vmagent` but makes `vmagent`'s debugging UI less informative. See [this docs](https://docs.victoriametrics.com/vmagent/#relabel-debug) for details on relabeling debug. 
 - Update dependencies: kube-state-metrics -> 5.16.0, prometheus-node-exporter -> 4.27.0, grafana -> 7.3.0.
 - Update victoriametrics CRD resources yaml.
+- Update builtin dashboards and rules.
 
 ## 0.18.12
 

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Next release
 
 - Do not store original labels in `vmagent`'s memory by default. This reduces memory usage of `vmagent` but makes `vmagent`'s debugging UI less informative. See [this docs](https://docs.victoriametrics.com/vmagent/#relabel-debug) for details on relabeling debug. 
+- Update dependencies: kube-state-metrics -> 5.16.0, prometheus-node-exporter -> 4.27.0, grafana -> 7.3.0.
+- Update victoriametrics CRD resources yaml.
 
 ## 0.18.12
 

--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.27.4
+  version: 0.27.11
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.12.1
+  version: 5.16.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.23.2
+  version: 4.27.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.59.5
+  version: 7.3.0
 - name: crds
   repository: ""
   version: 0.0.0
-digest: sha256:03141592eccb2e6198a1585d938b20ca51e5f21c2c0578cd180ce17bfd740705
-generated: "2023-11-01T17:22:02.335996+01:00"
+digest: sha256:d167f9dcef4c85ec4f1a8ca34cf124fd499f836a45cab3883abaf8e75f7175e1
+generated: "2024-02-05T13:13:05.344406+08:00"

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.18.12
+version: 0.19.0
 appVersion: v1.97.1
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
@@ -37,15 +37,15 @@ dependencies:
     repository: https://victoriametrics.github.io/helm-charts
     condition: victoria-metrics-operator.enabled
   - name: kube-state-metrics
-    version: "5.12.*"
+    version: "5.16.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-state-metrics.enabled
   - name: prometheus-node-exporter
-    version: "4.23.*"
+    version: "4.27.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-node-exporter.enabled
   - name: grafana
-    version: "6.59.*"
+    version: "7.3.*"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
   - name: crds

--- a/charts/victoria-metrics-k8s-stack/charts/crds/crds/crd.yaml
+++ b/charts/victoria-metrics-k8s-stack/charts/crds/crds/crd.yaml
@@ -622,8 +622,6 @@ spec:
                 description: Specifies the DNS parameters of a pod. Parameters specified
                   here will be merged to the generated DNS configuration based on
                   DNSPolicy.
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
                 properties:
                   nameservers:
                     description: A list of DNS name server IP addresses. This will
@@ -656,6 +654,8 @@ spec:
                       type: string
                     type: array
                 type: object
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
               dnsPolicy:
                 description: DNSPolicy set DNS policy for the pod
                 type: string
@@ -932,6 +932,11 @@ spec:
                   for VMServiceScrape, VMPodScrape and other scrapes If interval is
                   higher than defined limit, `maxScrapeInterval` will be used.
                 type: string
+              minReadySeconds:
+                description: MinReadySeconds defines a minim number os seconds to
+                  wait before starting update next pod if previous in healthy state
+                format: int32
+                type: integer
               minScrapeInterval:
                 description: MinScrapeInterval allows limiting minimal scrape interval
                   for VMServiceScrape, VMPodScrape and other scrapes If interval is
@@ -2306,6 +2311,12 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              revisionHistoryLimitCount:
+                description: The number of old ReplicaSets to retain to allow rollback
+                  in deployment or maximum number of revisions that will be maintained
+                  in the StatefulSet's revision history. Defaults to 10.
+                format: int32
+                type: integer
               rollingUpdate:
                 description: RollingUpdate - overrides deployment update params.
                 properties:
@@ -2370,9 +2381,9 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               selectAllByDefault:
                 description: 'SelectAllByDefault changes default behavior for empty
-                  CRD selectors, such ServiceScrapeSelector. with selectAllScrapes:
+                  CRD selectors, such ServiceScrapeSelector. with selectAllByDefault:
                   true and empty serviceScrapeSelector and ServiceScrapeNamespaceSelector
-                  Operator selects all exist serviceScrapes with selectAllScrapes:
+                  Operator selects all exist serviceScrapes with selectAllByDefault:
                   false - selects nothing'
                 type: boolean
               serviceAccountName:
@@ -3451,6 +3462,278 @@ spec:
                 items:
                   description: Receiver defines one or more notification integrations.
                   properties:
+                    discord_configs:
+                      items:
+                        properties:
+                          http_config:
+                            description: HTTP client configuration.
+                            properties:
+                              basic_auth:
+                                description: TODO oAuth2 support BasicAuth for the
+                                  client.
+                                properties:
+                                  password:
+                                    description: The secret in the service scrape
+                                      namespace that contains the password for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  password_file:
+                                    description: PasswordFile defines path to password
+                                      file at disk
+                                    type: string
+                                  username:
+                                    description: The secret in the service scrape
+                                      namespace that contains the username for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              bearer_token_file:
+                                description: BearerTokenFile defines filename for
+                                  bearer token, it must be mounted to pod.
+                                type: string
+                              bearer_token_secret:
+                                description: The secret's key that contains the bearer
+                                  token It must be at them same namespace as CRD
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              proxyURL:
+                                description: Optional proxy URL.
+                                type: string
+                              tls_config:
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Stuct containing the CA cert to use
+                                      for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  caFile:
+                                    description: Path to the CA cert in the container
+                                      to use for the targets.
+                                    type: string
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  certFile:
+                                    description: Path to the client cert file in the
+                                      container for the targets.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keyFile:
+                                    description: Path to the client key file in the
+                                      container for the targets.
+                                    type: string
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          message:
+                            description: The message body template
+                            type: string
+                          send_resolved:
+                            description: SendResolved controls notify about resolved
+                              alerts.
+                            type: boolean
+                          title:
+                            description: The message title template
+                            type: string
+                          webhook_url:
+                            description: The discord webhook URL one of `urlSecret`
+                              and `url` must be defined.
+                            type: string
+                          webhook_url_secret:
+                            description: URLSecret defines secret name and key at
+                              the CRD namespace. It must contain the webhook URL.
+                              one of `urlSecret` and `url` must be defined.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
                     email_configs:
                       description: EmailConfigs defines email notification configurations.
                       items:
@@ -3679,6 +3962,278 @@ spec:
                             type: string
                         type: object
                       type: array
+                    msteams_configs:
+                      items:
+                        properties:
+                          http_config:
+                            description: HTTP client configuration.
+                            properties:
+                              basic_auth:
+                                description: TODO oAuth2 support BasicAuth for the
+                                  client.
+                                properties:
+                                  password:
+                                    description: The secret in the service scrape
+                                      namespace that contains the password for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  password_file:
+                                    description: PasswordFile defines path to password
+                                      file at disk
+                                    type: string
+                                  username:
+                                    description: The secret in the service scrape
+                                      namespace that contains the username for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              bearer_token_file:
+                                description: BearerTokenFile defines filename for
+                                  bearer token, it must be mounted to pod.
+                                type: string
+                              bearer_token_secret:
+                                description: The secret's key that contains the bearer
+                                  token It must be at them same namespace as CRD
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              proxyURL:
+                                description: Optional proxy URL.
+                                type: string
+                              tls_config:
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Stuct containing the CA cert to use
+                                      for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  caFile:
+                                    description: Path to the CA cert in the container
+                                      to use for the targets.
+                                    type: string
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  certFile:
+                                    description: Path to the client cert file in the
+                                      container for the targets.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keyFile:
+                                    description: Path to the client key file in the
+                                      container for the targets.
+                                    type: string
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          send_resolved:
+                            description: SendResolved controls notify about resolved
+                              alerts.
+                            type: boolean
+                          text:
+                            description: The text body of the teams notification.
+                            type: string
+                          title:
+                            description: The title of the teams notification.
+                            type: string
+                          webhook_url:
+                            description: The incoming webhook URL one of `urlSecret`
+                              and `url` must be defined.
+                            type: string
+                          webhook_url_secret:
+                            description: URLSecret defines secret name and key at
+                              the CRD namespace. It must contain the webhook URL.
+                              one of `urlSecret` and `url` must be defined.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
                     name:
                       description: Name of the receiver. Must be unique across all
                         items from the list.
@@ -3691,6 +4246,10 @@ spec:
                         description: OpsGenieConfig configures notifications via OpsGenie.
                           See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
                         properties:
+                          actions:
+                            description: Comma separated list of actions that will
+                              be available for the alert.
+                            type: string
                           api_key:
                             description: The secret's key that contains the OpsGenie
                               API key. It must be at them same namespace as CRD
@@ -3724,6 +4283,10 @@ spec:
                             description: A set of arbitrary key/value pairs that provide
                               further detail about the incident.
                             type: object
+                          entity:
+                            description: Optional field that can be used to specify
+                              which domain alert is related to.
+                            type: string
                           http_config:
                             description: HTTP client configuration.
                             type: object
@@ -3773,6 +4336,12 @@ spec:
                             description: Comma separated list of tags attached to
                               the notifications.
                             type: string
+                          update_alerts:
+                            description: Whether to update message and description
+                              of the alert in OpsGenie if it already exists By default,
+                              the alert is never updated in OpsGenie, the new message
+                              only appears in activity log.
+                            type: boolean
                         type: object
                       type: array
                     pagerduty_configs:
@@ -4140,6 +4709,340 @@ spec:
                             type: string
                         type: object
                       type: array
+                    sns_configs:
+                      items:
+                        properties:
+                          api_url:
+                            description: The api URL
+                            type: string
+                          attributes:
+                            additionalProperties:
+                              type: string
+                            description: SNS message attributes
+                            type: object
+                          http_config:
+                            description: HTTP client configuration.
+                            properties:
+                              basic_auth:
+                                description: TODO oAuth2 support BasicAuth for the
+                                  client.
+                                properties:
+                                  password:
+                                    description: The secret in the service scrape
+                                      namespace that contains the password for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  password_file:
+                                    description: PasswordFile defines path to password
+                                      file at disk
+                                    type: string
+                                  username:
+                                    description: The secret in the service scrape
+                                      namespace that contains the username for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              bearer_token_file:
+                                description: BearerTokenFile defines filename for
+                                  bearer token, it must be mounted to pod.
+                                type: string
+                              bearer_token_secret:
+                                description: The secret's key that contains the bearer
+                                  token It must be at them same namespace as CRD
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              proxyURL:
+                                description: Optional proxy URL.
+                                type: string
+                              tls_config:
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Stuct containing the CA cert to use
+                                      for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  caFile:
+                                    description: Path to the CA cert in the container
+                                      to use for the targets.
+                                    type: string
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  certFile:
+                                    description: Path to the client cert file in the
+                                      container for the targets.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keyFile:
+                                    description: Path to the client key file in the
+                                      container for the targets.
+                                    type: string
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          message:
+                            description: The message content of the SNS notification.
+                            type: string
+                          phone_number:
+                            description: Phone number if message is delivered via
+                              SMS Specify this, topic_arn or target_arn
+                            type: string
+                          send_resolved:
+                            description: SendResolved controls notify about resolved
+                              alerts.
+                            type: boolean
+                          sigv4:
+                            description: Configure the AWS Signature Verification
+                              4 signing process
+                            properties:
+                              access_key:
+                                description: The AWS API keys. Both access_key and
+                                  secret_key must be supplied or both must be blank.
+                                  If blank the environment variables `AWS_ACCESS_KEY_ID`
+                                  and `AWS_SECRET_ACCESS_KEY` are used.
+                                type: string
+                              access_key_selector:
+                                description: secret key selector to get the keys from
+                                  a Kubernetes Secret
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              profile:
+                                description: Named AWS profile used to authenticate
+                                type: string
+                              region:
+                                description: AWS region, if blank the region from
+                                  the default credentials chain is used
+                                type: string
+                              role_arn:
+                                description: AWS Role ARN, an alternative to using
+                                  AWS API keys
+                                type: string
+                              secret_key_selector:
+                                description: secret key selector to get the keys from
+                                  a Kubernetes Secret
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          subject:
+                            description: The subject line if message is delivered
+                              to an email endpoint.
+                            type: string
+                          target_arn:
+                            description: Mobile platform endpoint ARN if message is
+                              delivered via mobile notifications Specify this, topic_arn
+                              or phone_number
+                            type: string
+                          topic_arn:
+                            description: SNS topic ARN, either specify this, phone_number
+                              or target_arn
+                            type: string
+                        type: object
+                      type: array
                     telegram_configs:
                       items:
                         properties:
@@ -4484,6 +5387,258 @@ spec:
                             description: Contains long explanation of the alerted
                               problem.
                             type: string
+                        type: object
+                      type: array
+                    webex_configs:
+                      items:
+                        properties:
+                          api_url:
+                            description: The Webex Teams API URL, i.e. https://webexapis.com/v1/messages
+                            type: string
+                          http_config:
+                            description: HTTP client configuration. You must use this
+                              configuration to supply the bot token as part of the
+                              HTTP `Authorization` header.
+                            properties:
+                              basic_auth:
+                                description: TODO oAuth2 support BasicAuth for the
+                                  client.
+                                properties:
+                                  password:
+                                    description: The secret in the service scrape
+                                      namespace that contains the password for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  password_file:
+                                    description: PasswordFile defines path to password
+                                      file at disk
+                                    type: string
+                                  username:
+                                    description: The secret in the service scrape
+                                      namespace that contains the username for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              bearer_token_file:
+                                description: BearerTokenFile defines filename for
+                                  bearer token, it must be mounted to pod.
+                                type: string
+                              bearer_token_secret:
+                                description: The secret's key that contains the bearer
+                                  token It must be at them same namespace as CRD
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              proxyURL:
+                                description: Optional proxy URL.
+                                type: string
+                              tls_config:
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Stuct containing the CA cert to use
+                                      for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  caFile:
+                                    description: Path to the CA cert in the container
+                                      to use for the targets.
+                                    type: string
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  certFile:
+                                    description: Path to the client cert file in the
+                                      container for the targets.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keyFile:
+                                    description: Path to the client key file in the
+                                      container for the targets.
+                                    type: string
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          message:
+                            description: The message body template
+                            type: string
+                          room_id:
+                            description: The ID of the Webex Teams room where to send
+                              the messages
+                            type: string
+                          send_resolved:
+                            description: SendResolved controls notify about resolved
+                              alerts.
+                            type: boolean
                         type: object
                       type: array
                     webhook_configs:
@@ -5462,8 +6617,6 @@ spec:
                 description: Specifies the DNS parameters of a pod. Parameters specified
                   here will be merged to the generated DNS configuration based on
                   DNSPolicy.
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
                 properties:
                   nameservers:
                     description: A list of DNS name server IP addresses. This will
@@ -5496,6 +6649,8 @@ spec:
                       type: string
                     type: array
                 type: object
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
               dnsPolicy:
                 description: DNSPolicy sets DNS policy for the pod
                 type: string
@@ -5602,6 +6757,11 @@ spec:
               logLevel:
                 description: Log level for VMAlertmanager to be configured with.
                 type: string
+              minReadySeconds:
+                description: MinReadySeconds defines a minim number os seconds to
+                  wait before starting update next pod if previous in healthy state
+                format: int32
+                type: integer
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -5738,6 +6898,12 @@ spec:
                   (milliseconds seconds minutes hours).
                 pattern: '[0-9]+(ms|s|m|h)'
                 type: string
+              revisionHistoryLimitCount:
+                description: The number of old ReplicaSets to retain to allow rollback
+                  in deployment or maximum number of revisions that will be maintained
+                  in the StatefulSet's revision history. Defaults to 10.
+                format: int32
+                type: integer
               rollingUpdateStrategy:
                 description: RollingUpdateStrategy defines strategy for application
                   updates Default is OnDelete, in this case operator handles update
@@ -5771,9 +6937,9 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               selectAllByDefault:
                 description: 'SelectAllByDefault changes default behavior for empty
-                  CRD selectors, such ConfigSelector. with selectAllScrapes: true
+                  CRD selectors, such ConfigSelector. with selectAllByDefault: true
                   and undefined ConfigSelector and ConfigNamespaceSelector Operator
-                  selects all exist alertManagerConfigs with selectAllScrapes: false
+                  selects all exist alertManagerConfigs with selectAllByDefault: false
                   - selects nothing'
                 type: boolean
               serviceAccountName:
@@ -6426,8 +7592,6 @@ spec:
                 description: Datasource Victoria Metrics or VMSelect url. Required
                   parameter. e.g. http://127.0.0.1:8428
                 properties:
-                  OAuth2:
-                    x-kubernetes-preserve-unknown-fields: true
                   basicAuth:
                     description: BasicAuth allow an endpoint to authenticate over
                       basic authentication
@@ -6605,6 +7769,8 @@ spec:
                     description: Victoria Metrics or VMSelect url. Required parameter.
                       E.g. http://127.0.0.1:8428
                     type: string
+                  OAuth2:
+                    x-kubernetes-preserve-unknown-fields: true
                 required:
                 - url
                 type: object
@@ -6612,8 +7778,6 @@ spec:
                 description: Specifies the DNS parameters of a pod. Parameters specified
                   here will be merged to the generated DNS configuration based on
                   DNSPolicy.
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
                 properties:
                   nameservers:
                     description: A list of DNS name server IP addresses. This will
@@ -6646,6 +7810,8 @@ spec:
                       type: string
                     type: array
                 type: object
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
               dnsPolicy:
                 description: DNSPolicy sets DNS policy for the pod
                 type: string
@@ -6800,6 +7966,11 @@ spec:
                 - FATAL
                 - PANIC
                 type: string
+              minReadySeconds:
+                description: MinReadySeconds defines a minim number os seconds to
+                  wait before starting update next pod if previous in healthy state
+                format: int32
+                type: integer
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -6808,13 +7979,12 @@ spec:
                 type: object
               notifier:
                 description: 'Notifier prometheus alertmanager endpoint spec. Required
-                  at least one of  notifier or notifiers. e.g. http://127.0.0.1:9093
-                  If specified both notifier and notifiers, notifier will be added
-                  as last element to notifiers. only one of notifier options could
-                  be chosen: notifierConfigRef or notifiers +  notifier'
+                  at least one of notifier or notifiers when there are alerting rules.
+                  e.g. http://127.0.0.1:9093 If specified both notifier and notifiers,
+                  notifier will be added as last element to notifiers. only one of
+                  notifier options could be chosen: notifierConfigRef or notifiers
+                  +  notifier'
                 properties:
-                  OAuth2:
-                    x-kubernetes-preserve-unknown-fields: true
                   basicAuth:
                     description: BasicAuth allow an endpoint to authenticate over
                       basic authentication
@@ -7060,6 +8230,8 @@ spec:
                   url:
                     description: AlertManager url.  E.g. http://127.0.0.1:9093
                     type: string
+                  OAuth2:
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               notifierConfigRef:
                 description: 'NotifierConfigRef reference for secret with notifier
@@ -7083,16 +8255,15 @@ spec:
                 x-kubernetes-map-type: atomic
               notifiers:
                 description: 'Notifiers prometheus alertmanager endpoints. Required
-                  at least one of  notifier or notifiers. e.g. http://127.0.0.1:9093
-                  If specified both notifier and notifiers, notifier will be added
-                  as last element to notifiers. only one of notifier options could
-                  be chosen: notifierConfigRef or notifiers +  notifier'
+                  at least one of notifier or notifiers when there are alerting rules.
+                  e.g. http://127.0.0.1:9093 If specified both notifier and notifiers,
+                  notifier will be added as last element to notifiers. only one of
+                  notifier options could be chosen: notifierConfigRef or notifiers
+                  +  notifier'
                 items:
                   description: VMAlertNotifierSpec defines the notifier url for sending
                     information about alerts
                   properties:
-                    OAuth2:
-                      x-kubernetes-preserve-unknown-fields: true
                     basicAuth:
                       description: BasicAuth allow an endpoint to authenticate over
                         basic authentication
@@ -7338,6 +8509,8 @@ spec:
                     url:
                       description: AlertManager url.  E.g. http://127.0.0.1:9093
                       type: string
+                    OAuth2:
+                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               podDisruptionBudget:
@@ -7431,8 +8604,6 @@ spec:
                   has been successfully persisted (via RemoteWrite) before. see -remoteRead.url
                   docs in vmalerts for details. E.g. http://127.0.0.1:8428
                 properties:
-                  OAuth2:
-                    x-kubernetes-preserve-unknown-fields: true
                   basicAuth:
                     description: BasicAuth allow an endpoint to authenticate over
                       basic authentication
@@ -7615,6 +8786,8 @@ spec:
                   url:
                     description: URL of the endpoint to send samples to.
                     type: string
+                  OAuth2:
+                    x-kubernetes-preserve-unknown-fields: true
                 required:
                 - url
                 type: object
@@ -7625,8 +8798,6 @@ spec:
                   in the form of time series named ALERTS and ALERTS_FOR_STATE see
                   -remoteWrite.url docs in vmalerts for details. E.g. http://127.0.0.1:8428
                 properties:
-                  OAuth2:
-                    x-kubernetes-preserve-unknown-fields: true
                   basicAuth:
                     description: BasicAuth allow an endpoint to authenticate over
                       basic authentication
@@ -7823,6 +8994,8 @@ spec:
                   url:
                     description: URL of the endpoint to send samples to.
                     type: string
+                  OAuth2:
+                    x-kubernetes-preserve-unknown-fields: true
                 required:
                 - url
                 type: object
@@ -7858,6 +9031,12 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              revisionHistoryLimitCount:
+                description: The number of old ReplicaSets to retain to allow rollback
+                  in deployment or maximum number of revisions that will be maintained
+                  in the StatefulSet's revision history. Defaults to 10.
+                format: int32
+                type: integer
               rollingUpdate:
                 description: RollingUpdate - overrides deployment update params.
                 properties:
@@ -8308,8 +9487,6 @@ spec:
                 description: Specifies the DNS parameters of a pod. Parameters specified
                   here will be merged to the generated DNS configuration based on
                   DNSPolicy.
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
                 properties:
                   nameservers:
                     description: A list of DNS name server IP addresses. This will
@@ -8342,6 +9519,8 @@ spec:
                       type: string
                     type: array
                 type: object
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
               dnsPolicy:
                 description: DNSPolicy sets DNS policy for the pod
                 type: string
@@ -8725,6 +9904,11 @@ spec:
                 - FATAL
                 - PANIC
                 type: string
+              minReadySeconds:
+                description: MinReadySeconds defines a minim number os seconds to
+                  wait before starting update next pod if previous in healthy state
+                format: int32
+                type: integer
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -8847,6 +10031,12 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              revisionHistoryLimitCount:
+                description: The number of old ReplicaSets to retain to allow rollback
+                  in deployment or maximum number of revisions that will be maintained
+                  in the StatefulSet's revision history. Defaults to 10.
+                format: int32
+                type: integer
               runtimeClassName:
                 description: RuntimeClassName - defines runtime class for kubernetes
                   pod. https://kubernetes.io/docs/concepts/containers/runtime-class/
@@ -8994,6 +10184,20 @@ spec:
                   description: VMAuthUnauthorizedPath defines url_map for unauthorized
                     access
                   properties:
+                    drop_src_path_prefix_parts:
+                      description: DropSrcPathPrefixParts is the number of `/`-delimited
+                        request path prefix parts to drop before proxying the request
+                        to backend. See https://docs.victoriametrics.com/vmauth.html#dropping-request-path-prefix
+                        for more details.
+                      type: integer
+                    headers:
+                      description: 'Headers represent additional http headers, that
+                        vmauth uses in form of ["header_key: header_value"] multiple
+                        values for header key: ["header_key: value1,value2"] it''s
+                        available since 1.68.0 version of vmauth'
+                      items:
+                        type: string
+                      type: array
                     ip_filters:
                       description: IPFilters defines filter for src ip address enterprise
                         only
@@ -9007,6 +10211,35 @@ spec:
                             type: string
                           type: array
                       type: object
+                    load_balancing_policy:
+                      description: 'LoadBalancingPolicy defines load balancing policy
+                        to use for backend urls. Supported policies: least_loaded,
+                        first_available. See https://docs.victoriametrics.com/vmauth.html#load-balancing
+                        for more details (default "least_loaded")'
+                      enum:
+                      - least_loaded
+                      - first_available
+                      type: string
+                    response_headers:
+                      description: 'ResponseHeaders represent additional http headers,
+                        that vmauth adds for request response in form of ["header_key:
+                        header_value"] multiple values for header key: ["header_key:
+                        value1,value2"] it''s available since 1.93.0 version of vmauth'
+                      items:
+                        type: string
+                      type: array
+                    retry_status_codes:
+                      description: RetryStatusCodes defines http status codes in numeric
+                        format for request retries e.g. [429,503]
+                      items:
+                        type: integer
+                      type: array
+                    src_hosts:
+                      description: SrcHosts is the list of regular expressions, which
+                        match the request hostname.
+                      items:
+                        type: string
+                      type: array
                     src_paths:
                       description: Paths src request paths
                       items:
@@ -9354,8 +10587,6 @@ spec:
                     description: Specifies the DNS parameters of a pod. Parameters
                       specified here will be merged to the generated DNS configuration
                       based on DNSPolicy.
-                    items:
-                      x-kubernetes-preserve-unknown-fields: true
                     properties:
                       nameservers:
                         description: A list of DNS name server IP addresses. This
@@ -9388,6 +10619,8 @@ spec:
                           type: string
                         type: array
                     type: object
+                    items:
+                      x-kubernetes-preserve-unknown-fields: true
                   dnsPolicy:
                     description: DNSPolicy sets DNS policy for the pod
                     type: string
@@ -9498,6 +10731,12 @@ spec:
                     - FATAL
                     - PANIC
                     type: string
+                  minReadySeconds:
+                    description: MinReadySeconds defines a minim number os seconds
+                      to wait before starting update next pod if previous in healthy
+                      state
+                    format: int32
+                    type: integer
                   name:
                     description: Name is deprecated and will be removed at 0.22.0
                       release
@@ -9625,6 +10864,13 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  revisionHistoryLimitCount:
+                    description: The number of old ReplicaSets to retain to allow
+                      rollback in deployment or maximum number of revisions that will
+                      be maintained in the StatefulSet's revision history. Defaults
+                      to 10.
+                    format: int32
+                    type: integer
                   rollingUpdate:
                     description: RollingUpdate - overrides deployment update params.
                     properties:
@@ -10194,8 +11440,6 @@ spec:
                     description: Specifies the DNS parameters of a pod. Parameters
                       specified here will be merged to the generated DNS configuration
                       based on DNSPolicy.
-                    items:
-                      x-kubernetes-preserve-unknown-fields: true
                     properties:
                       nameservers:
                         description: A list of DNS name server IP addresses. This
@@ -10228,6 +11472,8 @@ spec:
                           type: string
                         type: array
                     type: object
+                    items:
+                      x-kubernetes-preserve-unknown-fields: true
                   dnsPolicy:
                     description: DNSPolicy sets DNS policy for the pod
                     type: string
@@ -10323,6 +11569,12 @@ spec:
                     - FATAL
                     - PANIC
                     type: string
+                  minReadySeconds:
+                    description: MinReadySeconds defines a minim number os seconds
+                      to wait before starting update next pod if previous in healthy
+                      state
+                    format: int32
+                    type: integer
                   name:
                     description: Name is deprecated and will be removed at 0.22.0
                       release
@@ -10491,6 +11743,13 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  revisionHistoryLimitCount:
+                    description: The number of old ReplicaSets to retain to allow
+                      rollback in deployment or maximum number of revisions that will
+                      be maintained in the StatefulSet's revision history. Defaults
+                      to 10.
+                    format: int32
+                    type: integer
                   rollingUpdateStrategy:
                     description: RollingUpdateStrategy defines strategy for application
                       updates Default is OnDelete, in this case operator handles update
@@ -11379,8 +12638,6 @@ spec:
                     description: Specifies the DNS parameters of a pod. Parameters
                       specified here will be merged to the generated DNS configuration
                       based on DNSPolicy.
-                    items:
-                      x-kubernetes-preserve-unknown-fields: true
                     properties:
                       nameservers:
                         description: A list of DNS name server IP addresses. This
@@ -11413,6 +12670,8 @@ spec:
                           type: string
                         type: array
                     type: object
+                    items:
+                      x-kubernetes-preserve-unknown-fields: true
                   dnsPolicy:
                     description: DNSPolicy sets DNS policy for the pod
                     type: string
@@ -11521,6 +12780,12 @@ spec:
                       format: int32
                       type: integer
                     type: array
+                  minReadySeconds:
+                    description: MinReadySeconds defines a minim number os seconds
+                      to wait before starting update next pod if previous in healthy
+                      state
+                    format: int32
+                    type: integer
                   name:
                     description: Name is deprecated and will be removed at 0.22.0
                       release
@@ -11648,6 +12913,13 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  revisionHistoryLimitCount:
+                    description: The number of old ReplicaSets to retain to allow
+                      rollback in deployment or maximum number of revisions that will
+                      be maintained in the StatefulSet's revision history. Defaults
+                      to 10.
+                    format: int32
+                    type: integer
                   rollingUpdateStrategy:
                     description: RollingUpdateStrategy defines strategy for application
                       updates Default is OnDelete, in this case operator handles update
@@ -16103,8 +17375,6 @@ spec:
                 description: Specifies the DNS parameters of a pod. Parameters specified
                   here will be merged to the generated DNS configuration based on
                   DNSPolicy.
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
                 properties:
                   nameservers:
                     description: A list of DNS name server IP addresses. This will
@@ -16137,6 +17407,8 @@ spec:
                       type: string
                     type: array
                 type: object
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
               dnsPolicy:
                 description: DNSPolicy sets DNS policy for the pod
                 type: string
@@ -16413,6 +17685,12 @@ spec:
                   at indexdb rotates once at the half of configured retention period
                   https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#retention
                 type: string
+              revisionHistoryLimitCount:
+                description: The number of old ReplicaSets to retain to allow rollback
+                  in deployment or maximum number of revisions that will be maintained
+                  in the StatefulSet's revision history. Defaults to 10.
+                format: int32
+                type: integer
               runtimeClassName:
                 description: RuntimeClassName - defines runtime class for kubernetes
                   pod. https://kubernetes.io/docs/concepts/containers/runtime-class/
@@ -18283,6 +19561,12 @@ spec:
                 description: DisableSecretCreation skips related secret creation for
                   vmuser
                 type: boolean
+              drop_src_path_prefix_parts:
+                description: DropSrcPathPrefixParts is the number of `/`-delimited
+                  request path prefix parts to drop before proxying the request to
+                  backend. See https://docs.victoriametrics.com/vmauth.html#dropping-request-path-prefix
+                  for more details.
+                type: integer
               generatePassword:
                 description: GeneratePassword instructs operator to generate password
                   for user if spec.password if empty.
@@ -18308,10 +19592,25 @@ spec:
                       type: string
                     type: array
                 type: object
+              load_balancing_policy:
+                description: 'LoadBalancingPolicy defines load balancing policy to
+                  use for backend urls. Supported policies: least_loaded, first_available.
+                  See https://docs.victoriametrics.com/vmauth.html#load-balancing
+                  for more details (default "least_loaded")'
+                enum:
+                - least_loaded
+                - first_available
+                type: string
               max_concurrent_requests:
                 description: MaxConcurrentRequests defines max concurrent requests
                   per user 300 is default value for vmauth
                 type: integer
+              metric_labels:
+                additionalProperties:
+                  type: string
+                description: MetricLabels - additional labels for metrics exported
+                  by vmauth for given user.
+                type: object
               name:
                 description: Name of the VMUser object.
                 type: string
@@ -18378,6 +19677,12 @@ spec:
                       - name
                       - namespace
                       type: object
+                    drop_src_path_prefix_parts:
+                      description: DropSrcPathPrefixParts is the number of `/`-delimited
+                        request path prefix parts to drop before proxying the request
+                        to backend. See https://docs.victoriametrics.com/vmauth.html#dropping-request-path-prefix
+                        for more details.
+                      type: integer
                     headers:
                       description: 'Headers represent additional http headers, that
                         vmauth uses in form of ["header_key: header_value"] multiple
@@ -18386,6 +19691,19 @@ spec:
                       items:
                         type: string
                       type: array
+                    hosts:
+                      items:
+                        type: string
+                      type: array
+                    load_balancing_policy:
+                      description: 'LoadBalancingPolicy defines load balancing policy
+                        to use for backend urls. Supported policies: least_loaded,
+                        first_available. See https://docs.victoriametrics.com/vmauth.html#load-balancing
+                        for more details (default "least_loaded")'
+                      enum:
+                      - least_loaded
+                      - first_available
+                      type: string
                     paths:
                       description: Paths - matched path to route.
                       items:
@@ -18428,6 +19746,10 @@ spec:
                       type: string
                   type: object
                 type: array
+              tls_insecure_skip_verify:
+                description: TLSInsecureSkipVerify - whether to skip TLS verification
+                  when connecting to backend over HTTPS. See https://docs.victoriametrics.com/vmauth.html#backend-tls-setup
+                type: boolean
               tokenRef:
                 description: TokenRef allows fetching token from user-created secrets
                   by its name and key.

--- a/charts/victoria-metrics-k8s-stack/hack/sync_grafana_dashboards.py
+++ b/charts/victoria-metrics-k8s-stack/hack/sync_grafana_dashboards.py
@@ -106,7 +106,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%%s-%%s" (include "victoria-metrics-k8s-stack.fullname" $) "%(name)s" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%%s-%%s" (include "victoria-metrics-k8s-stack.fullname" $) "%(name)s" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}

--- a/charts/victoria-metrics-k8s-stack/hack/sync_rules.py
+++ b/charts/victoria-metrics-k8s-stack/hack/sync_rules.py
@@ -155,7 +155,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%%s-%%s" (include "victoria-metrics-k8s-stack.fullname" .) "%(name)s" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%%s-%%s" (include "victoria-metrics-k8s-stack.fullname" .) "%(name)s" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/alertmanager-overview.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/alertmanager-overview.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-overview" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-overview" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/backupmanager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/backupmanager.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "backupmanager" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "backupmanager" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/grafana-overview.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/grafana-overview.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "grafana-overview" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "grafana-overview" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-system-coredns.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-system-coredns.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-system-coredns" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-system-coredns" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
@@ -169,9 +169,10 @@ data:
                         "fields": "",
                         "values": false
                     },
-                    "textMode": "value_and_name"
+                    "textMode": "value_and_name",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.0.1",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -179,7 +180,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "up{job=\"coredns\", instance=~\"$instance\"}",
+                        "expr": "up{job=~\"$job\", instance=~\"$instance\", cluster=~\"$cluster\"}",
                         "interval": "",
                         "legendFormat": "{{`{{`}} instance {{`}}`}}",
                         "refId": "A"
@@ -199,6 +200,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -212,6 +214,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -274,7 +277,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "rate(process_cpu_seconds_total{job=\"coredns\", instance=~\"$instance\"}[$__rate_interval])",
+                        "expr": "rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\", cluster=~\"$cluster\"}[$__rate_interval])",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} instance {{`}}`}}",
                         "refId": "A"
@@ -294,6 +297,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -307,6 +311,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -368,7 +373,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "process_resident_memory_bytes{job=\"coredns\", instance=~\"$instance\"}",
+                        "expr": "process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\", cluster=~\"$cluster\"}",
                         "interval": "",
                         "legendFormat": "{{`{{`}} instance {{`}}`}}",
                         "refId": "A"
@@ -388,6 +393,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -401,6 +407,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -462,7 +469,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(coredns_dns_requests_total{instance=~\"$instance\",proto=\"$protocol\"}[$__rate_interval]))",
+                        "expr": "sum(rate(coredns_dns_requests_total{instance=~\"$instance\",proto=\"$protocol\", cluster=~\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "total $protocol requests",
                         "refId": "A"
@@ -482,6 +489,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -495,6 +503,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -556,7 +565,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(coredns_dns_request_size_bytes_sum{instance=~\"$instance\",proto=\"$protocol\"}[$__rate_interval])) by (proto) / sum(rate(coredns_dns_request_size_bytes_count{instance=~\"$instance\",proto=\"$protocol\"}[$__rate_interval])) by (proto)",
+                        "expr": "sum(rate(coredns_dns_request_size_bytes_sum{instance=~\"$instance\",proto=\"$protocol\", cluster=~\"$cluster\"}[$__rate_interval])) by (proto) / sum(rate(coredns_dns_request_size_bytes_count{instance=~\"$instance\",proto=\"$protocol\", cluster=~\"$cluster\"}[$__rate_interval])) by (proto)",
                         "interval": "$resolution",
                         "legendFormat": "average $protocol packet size",
                         "refId": "A"
@@ -576,6 +585,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -589,6 +599,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -650,7 +661,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(coredns_dns_requests_total{instance=~\"$instance\"}[$__rate_interval])) by (type)",
+                        "expr": "sum(rate(coredns_dns_requests_total{instance=~\"$instance\", cluster=~\"$cluster\"}[$__rate_interval])) by (type)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} type {{`}}`}}",
                         "refId": "A"
@@ -670,6 +681,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -683,6 +695,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -744,7 +757,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(coredns_dns_responses_total{instance=~\"$instance\"}[$__rate_interval])) by (rcode)",
+                        "expr": "sum(rate(coredns_dns_responses_total{instance=~\"$instance\", cluster=~\"$cluster\"}[$__rate_interval])) by (rcode)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} rcode {{`}}`}}",
                         "refId": "A"
@@ -764,6 +777,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -777,6 +791,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -838,7 +853,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(coredns_forward_requests_total[$__rate_interval]))",
+                        "expr": "sum(rate(coredns_forward_requests_total{cluster=~\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "total forward requests",
                         "refId": "A"
@@ -858,6 +873,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -871,6 +887,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -932,7 +949,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(coredns_forward_responses_total{rcode=~\"SERVFAIL|REFUSED\"}[$__rate_interval])) by (rcode)",
+                        "expr": "sum(rate(coredns_forward_responses_total{rcode=~\"SERVFAIL|REFUSED\", cluster=~\"$cluster\"}[$__rate_interval])) by (rcode)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} rcode {{`}}`}}",
                         "refId": "A"
@@ -952,6 +969,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -965,6 +983,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1026,7 +1045,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(coredns_cache_hits_total{instance=~\"$instance\"}[$__rate_interval])) by (type)",
+                        "expr": "sum(rate(coredns_cache_hits_total{instance=~\"$instance\", cluster=~\"$cluster\"}[$__rate_interval])) by (type)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} type {{`}}`}}",
                         "refId": "A"
@@ -1037,7 +1056,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(coredns_cache_misses_total{instance=~\"$instance\"}[$__rate_interval])) by (type)",
+                        "expr": "sum(rate(coredns_cache_misses_total{instance=~\"$instance\", cluster=~\"$cluster\"}[$__rate_interval])) by (type)",
                         "interval": "$resolution",
                         "legendFormat": "misses",
                         "refId": "B"
@@ -1057,6 +1076,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1070,6 +1090,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1131,7 +1152,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(coredns_cache_entries) by (type)",
+                        "expr": "sum(coredns_cache_entries{cluster=~\"$cluster\"}) by (type)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} type {{`}}`}}",
                         "refId": "A"
@@ -1201,7 +1222,7 @@ data:
                         "unit": "s"
                     }
                 },
-                "pluginVersion": "10.0.1",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -1209,7 +1230,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(increase(coredns_dns_request_duration_seconds_bucket{instance=~\"$instance\"}[$__rate_interval])) by (le)",
+                        "expr": "sum(increase(coredns_dns_request_duration_seconds_bucket{instance=~\"$instance\", cluster=~\"$cluster\"}[$__rate_interval])) by (le)",
                         "format": "heatmap",
                         "legendFormat": "{{`{{`}}le{{`}}`}}",
                         "range": true,
@@ -1280,7 +1301,7 @@ data:
                         "unit": "s"
                     }
                 },
-                "pluginVersion": "10.0.1",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -1288,7 +1309,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(increase(coredns_forward_request_duration_seconds_bucket{instance=~\"$instance\"}[$__rate_interval])) by (le)",
+                        "expr": "sum(increase(coredns_forward_request_duration_seconds_bucket{instance=~\"$instance\", cluster=~\"$cluster\"}[$__rate_interval])) by (le)",
                         "format": "heatmap",
                         "legendFormat": "{{`{{`}}le{{`}}`}}",
                         "range": true,
@@ -1359,7 +1380,7 @@ data:
                         "unit": "decbytes"
                     }
                 },
-                "pluginVersion": "10.0.1",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -1367,7 +1388,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(increase(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\", le!=\"0\"}[$__rate_interval])) by (le)",
+                        "expr": "sum(increase(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\", le!=\"0\", cluster=~\"$cluster\"}[$__rate_interval])) by (le)",
                         "format": "heatmap",
                         "legendFormat": "{{`{{`}}le{{`}}`}}",
                         "range": true,
@@ -1438,7 +1459,7 @@ data:
                         "unit": "decbytes"
                     }
                 },
-                "pluginVersion": "10.0.1",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -1446,7 +1467,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(increase(coredns_dns_response_size_bytes_bucket{instance=~\"$instance\", le!=\"0\"}[$__rate_interval])) by (le)",
+                        "expr": "sum(increase(coredns_dns_response_size_bytes_bucket{instance=~\"$instance\", le!=\"0\", cluster=~\"$cluster\"}[$__rate_interval])) by (le)",
                         "format": "heatmap",
                         "legendFormat": "{{`{{`}}le{{`}}`}}",
                         "range": true,
@@ -1459,7 +1480,6 @@ data:
         ],
         "refresh": "30s",
         "schemaVersion": 38,
-        "style": "dark",
         "tags": [
             "Kubernetes",
             "Prometheus",
@@ -1489,6 +1509,36 @@ data:
                 },
                 {
                     "current": {
+                        "isNone": true,
+                        "selected": false,
+                        "text": "None",
+                        "value": ""
+                    },
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "definition": "label_values(kube_node_info,cluster)",
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "includeAll": false,
+                    "multi": false,
+                    "name": "cluster",
+                    "options": [
+
+                    ],
+                    "query": {
+                        "qryType": 1,
+                        "query": "label_values(kube_node_info,cluster)",
+                        "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                    },
+                    "refresh": 1,
+                    "regex": "",
+                    "skipUrlSync": false,
+                    "sort": 1,
+                    "type": "query"
+                },
+                {
+                    "current": {
                         "selected": false,
                         "text": "All",
                         "value": "$__all"
@@ -1497,7 +1547,7 @@ data:
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
-                    "definition": "label_values(up{job=\"coredns\"}, instance)",
+                    "definition": "label_values(up{job=\"$job\", cluster=\"$cluster\"},instance)",
                     "hide": 0,
                     "includeAll": true,
                     "label": "",
@@ -1507,8 +1557,9 @@ data:
 
                     ],
                     "query": {
-                        "query": "label_values(up{job=\"coredns\"}, instance)",
-                        "refId": "StandardVariableQuery"
+                        "qryType": 1,
+                        "query": "label_values(up{job=\"$job\", cluster=\"$cluster\"},instance)",
+                        "refId": "PrometheusVariableQueryEditor-VariableQuery"
                     },
                     "refresh": 1,
                     "regex": "",
@@ -1530,7 +1581,7 @@ data:
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
-                    "definition": "label_values(coredns_dns_requests_total, proto)",
+                    "definition": "label_values(coredns_dns_requests_total{cluster=\"$cluster\"}, proto)",
                     "hide": 0,
                     "includeAll": false,
                     "label": "",
@@ -1540,7 +1591,7 @@ data:
 
                     ],
                     "query": {
-                        "query": "label_values(coredns_dns_requests_total, proto)",
+                        "query": "label_values(coredns_dns_requests_total{cluster=\"$cluster\"}, proto)",
                         "refId": "StandardVariableQuery"
                     },
                     "refresh": 1,
@@ -1598,6 +1649,35 @@ data:
                     "queryValue": "",
                     "skipUrlSync": false,
                     "type": "custom"
+                },
+                {
+                    "current": {
+                        "selected": true,
+                        "text": [
+                            "coredns"
+                        ],
+                        "value": [
+                            "coredns"
+                        ]
+                    },
+                    "definition": "label_values(coredns_build_info{cluster=\"$cluster\"},job)",
+                    "hide": 0,
+                    "includeAll": false,
+                    "multi": true,
+                    "name": "job",
+                    "options": [
+
+                    ],
+                    "query": {
+                        "qryType": 1,
+                        "query": "label_values(coredns_build_info{cluster=\"$cluster\"},job)",
+                        "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                    },
+                    "refresh": 1,
+                    "regex": "",
+                    "skipUrlSync": false,
+                    "sort": 1,
+                    "type": "query"
                 }
             ]
         },
@@ -1611,7 +1691,7 @@ data:
         "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / System / CoreDNS",
         "uid": "k8s_system_coredns",
-        "version": 13,
+        "version": 17,
         "weekStart": ""
     }
 {{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-global.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-global.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-views-global" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-views-global" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
@@ -124,7 +124,7 @@ data:
                 "collapsed": false,
                 "datasource": {
                     "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
-                    "uid": "prometheus"
+                    "uid": "${datasource}"
                 },
                 "gridPos": {
                     "h": 1,
@@ -178,6 +178,7 @@ data:
                     "displayMode": "lcd",
                     "minVizHeight": 10,
                     "minVizWidth": 0,
+                    "namePlacement": "auto",
                     "orientation": "horizontal",
                     "reduceOptions": {
                         "calcs": [
@@ -189,7 +190,7 @@ data:
                     "showUnfilled": true,
                     "valueMode": "color"
                 },
-                "pluginVersion": "10.0.3",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -198,7 +199,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "avg(1-rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))",
+                        "expr": "avg(sum by (instance, cpu) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\", cluster=\"$cluster\"}[$__rate_interval])))",
                         "interval": "",
                         "legendFormat": "Real",
                         "range": true,
@@ -210,7 +211,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"}) / sum(machine_cpu_cores)",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", cluster=\"$cluster\"}) / sum(machine_cpu_cores{cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Requests",
                         "range": true,
@@ -222,7 +223,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"}) / sum(machine_cpu_cores)",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", cluster=\"$cluster\"}) / sum(machine_cpu_cores{cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Limits",
                         "range": true,
@@ -274,6 +275,7 @@ data:
                     "displayMode": "lcd",
                     "minVizHeight": 10,
                     "minVizWidth": 0,
+                    "namePlacement": "auto",
                     "orientation": "horizontal",
                     "reduceOptions": {
                         "calcs": [
@@ -286,7 +288,7 @@ data:
                     "text": {},
                     "valueMode": "color"
                 },
-                "pluginVersion": "10.0.3",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -295,7 +297,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes)",
+                        "expr": "sum(node_memory_MemTotal_bytes{cluster=\"$cluster\"} - node_memory_MemAvailable_bytes{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Real",
                         "range": true,
@@ -307,7 +309,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"}) / sum(machine_memory_bytes)",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", cluster=\"$cluster\"}) / sum(machine_memory_bytes{cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Requests",
                         "range": true,
@@ -319,7 +321,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"}) / sum(machine_memory_bytes)",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", cluster=\"$cluster\"}) / sum(machine_memory_bytes{cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Limits",
                         "range": true,
@@ -370,9 +372,10 @@ data:
                         "values": false
                     },
                     "text": {},
-                    "textMode": "value"
+                    "textMode": "value",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.0.3",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -380,7 +383,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "count(count by (node) (kube_node_info))",
+                        "expr": "count(count by (node) (kube_node_info{cluster=\"$cluster\"}))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -400,6 +403,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -413,6 +417,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -480,7 +485,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_namespace_labels)",
+                        "expr": "sum(kube_namespace_labels{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Namespaces",
                         "refId": "A"
@@ -490,7 +495,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_pod_container_status_running)",
+                        "expr": "sum(kube_pod_container_status_running{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Running Containers",
                         "refId": "B"
@@ -500,7 +505,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_pod_status_phase{phase=\"Running\"})",
+                        "expr": "sum(kube_pod_status_phase{phase=\"Running\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Running Pods",
                         "refId": "O"
@@ -510,7 +515,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_service_info)",
+                        "expr": "sum(kube_service_info{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Services",
                         "refId": "C"
@@ -520,7 +525,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_endpoint_info)",
+                        "expr": "sum(kube_endpoint_info{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Endpoints",
                         "refId": "D"
@@ -530,7 +535,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_ingress_info)",
+                        "expr": "sum(kube_ingress_info{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Ingresses",
                         "refId": "E"
@@ -540,7 +545,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_deployment_labels)",
+                        "expr": "sum(kube_deployment_labels{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Deployments",
                         "refId": "F"
@@ -550,7 +555,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_statefulset_labels)",
+                        "expr": "sum(kube_statefulset_labels{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Statefulsets",
                         "refId": "G"
@@ -560,7 +565,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_daemonset_labels)",
+                        "expr": "sum(kube_daemonset_labels{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Daemonsets",
                         "refId": "H"
@@ -570,7 +575,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_persistentvolumeclaim_info)",
+                        "expr": "sum(kube_persistentvolumeclaim_info{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Persistent Volume Claims",
                         "refId": "I"
@@ -580,7 +585,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_hpa_labels)",
+                        "expr": "sum(kube_hpa_labels{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Horizontal Pod Autoscalers",
                         "refId": "J"
@@ -590,7 +595,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_configmap_info)",
+                        "expr": "sum(kube_configmap_info{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Configmaps",
                         "refId": "K"
@@ -600,7 +605,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_secret_info)",
+                        "expr": "sum(kube_secret_info{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Secrets",
                         "refId": "L"
@@ -610,7 +615,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_networkpolicy_labels)",
+                        "expr": "sum(kube_networkpolicy_labels{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Network Policies",
                         "refId": "M"
@@ -621,7 +626,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "count(count by (node) (kube_node_info))",
+                        "expr": "count(count by (node) (kube_node_info{cluster=\"$cluster\"}))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "Nodes",
@@ -672,16 +677,17 @@ data:
                         "values": false
                     },
                     "text": {},
-                    "textMode": "value"
+                    "textMode": "value",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.0.3",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "count(kube_namespace_created)",
+                        "expr": "count(kube_namespace_created{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -726,15 +732,16 @@ data:
                     "orientation": "auto",
                     "reduceOptions": {
                         "calcs": [
-                            "mean"
+                            "lastNotNull"
                         ],
                         "fields": "",
                         "values": false
                     },
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.0.3",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -743,7 +750,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(1-rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))",
+                        "expr": "sum(rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\", cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "",
                         "legendFormat": "Real",
                         "range": true,
@@ -755,7 +762,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Requests",
                         "range": true,
@@ -767,7 +774,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"})",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Limits",
                         "range": true,
@@ -779,7 +786,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(machine_cpu_cores)",
+                        "expr": "sum(machine_cpu_cores{cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Total",
                         "range": true,
@@ -825,15 +832,16 @@ data:
                     "orientation": "auto",
                     "reduceOptions": {
                         "calcs": [
-                            "mean"
+                            "lastNotNull"
                         ],
                         "fields": "",
                         "values": false
                     },
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.0.3",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -842,7 +850,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes)",
+                        "expr": "sum(node_memory_MemTotal_bytes{cluster=\"$cluster\"} - node_memory_MemAvailable_bytes{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Real",
                         "range": true,
@@ -854,7 +862,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Requests",
                         "range": true,
@@ -866,7 +874,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"})",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Limits",
                         "range": true,
@@ -878,7 +886,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(machine_memory_bytes)",
+                        "expr": "sum(machine_memory_bytes{cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Total",
                         "range": true,
@@ -929,16 +937,17 @@ data:
                         "values": false
                     },
                     "text": {},
-                    "textMode": "value"
+                    "textMode": "value",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.0.3",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_pod_status_phase{phase=\"Running\"})",
+                        "expr": "sum(kube_pod_status_phase{phase=\"Running\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -951,7 +960,7 @@ data:
                 "collapsed": false,
                 "datasource": {
                     "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
-                    "uid": "prometheus"
+                    "uid": "${datasource}"
                 },
                 "gridPos": {
                     "h": 1,
@@ -976,6 +985,7 @@ data:
                             "seriesBy": "last"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "CPU %",
@@ -989,6 +999,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineStyle": {
                                 "fill": "solid"
@@ -1058,7 +1069,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "avg(1-rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))",
+                        "expr": "avg(sum by (instance, cpu) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\", cluster=\"$cluster\"}[$__rate_interval])))",
                         "interval": "$resolution",
                         "legendFormat": "CPU usage in %",
                         "refId": "A"
@@ -1078,6 +1089,7 @@ data:
                             "mode": "continuous-GrYlRd"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "MEMORY",
@@ -1091,6 +1103,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1162,7 +1175,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes)",
+                        "expr": "sum(node_memory_MemTotal_bytes{cluster=\"$cluster\"} - node_memory_MemAvailable_bytes{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{cluster=\"$cluster\"})",
                         "interval": "$resolution",
                         "legendFormat": "Memory usage in %",
                         "range": true,
@@ -1183,6 +1196,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "CPU CORES",
@@ -1196,6 +1210,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineStyle": {
                                 "fill": "solid"
@@ -1267,7 +1282,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\"}[$__rate_interval])) by (namespace)",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (namespace)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} namespace {{`}}`}}",
                         "refId": "A"
@@ -1287,6 +1302,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1300,6 +1316,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1367,7 +1384,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{image!=\"\"}) by (namespace)",
+                        "expr": "sum(container_memory_working_set_bytes{image!=\"\", cluster=\"$cluster\"}) by (namespace)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} namespace {{`}}`}}",
                         "refId": "A"
@@ -1422,8 +1439,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1468,7 +1484,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "avg(1-rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval])) by (instance)",
+                        "expr": "avg(sum by (instance, cpu) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\", cluster=\"$cluster\"}[$__rate_interval]))) by (instance)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} node {{`}}`}}",
                         "refId": "A"
@@ -1522,8 +1538,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1569,7 +1584,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) by (instance)",
+                        "expr": "sum(node_memory_MemTotal_bytes{cluster=\"$cluster\"} - node_memory_MemAvailable_bytes{cluster=\"$cluster\"}) by (instance)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} node{{`}}`}}",
                         "range": true,
@@ -1629,8 +1644,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1676,7 +1690,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{image!=\"\"}[$__rate_interval])) by (namespace) > 0",
+                        "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{image!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (namespace) > 0",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} namespace {{`}}`}}",
                         "range": true,
@@ -1736,8 +1750,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1783,7 +1796,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(node_cpu_core_throttles_total[$__rate_interval])) by (instance)",
+                        "expr": "sum(rate(node_cpu_core_throttles_total{cluster=\"$cluster\"}[$__rate_interval])) by (instance)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} instance {{`}}`}}",
                         "range": true,
@@ -1851,8 +1864,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1898,7 +1910,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(kube_pod_status_qos_class) by (qos_class)",
+                        "expr": "sum(kube_pod_status_qos_class{cluster=\"$cluster\"}) by (qos_class)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} qos_class {{`}}`}} pods",
                         "range": true,
@@ -1910,7 +1922,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_info)",
+                        "expr": "sum(kube_pod_info{cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Total pods",
                         "range": true,
@@ -1965,8 +1977,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2012,7 +2023,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(kube_pod_status_reason) by (reason)",
+                        "expr": "sum(kube_pod_status_reason{cluster=\"$cluster\"}) by (reason)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} reason {{`}}`}}",
                         "range": true,
@@ -2068,8 +2079,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2115,7 +2125,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(increase(container_oom_events_total[$__rate_interval])) by (namespace) > 0",
+                        "expr": "sum(increase(container_oom_events_total{cluster=\"$cluster\"}[$__rate_interval])) by (namespace) > 0",
                         "interval": "",
                         "legendFormat": "{{`{{`}} namespace {{`}}`}}",
                         "range": true,
@@ -2171,8 +2181,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2218,7 +2227,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(increase(kube_pod_container_status_restarts_total[$__rate_interval])) by (namespace) > 0",
+                        "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=\"$cluster\"}[$__rate_interval])) by (namespace) > 0",
                         "interval": "",
                         "legendFormat": "{{`{{`}} namespace {{`}}`}}",
                         "range": true,
@@ -2232,7 +2241,7 @@ data:
                 "collapsed": false,
                 "datasource": {
                     "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
-                    "uid": "prometheus"
+                    "uid": "${datasource}"
                 },
                 "gridPos": {
                     "h": 1,
@@ -2291,8 +2300,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2332,7 +2340,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lxc.*|veth.*\"}[$__rate_interval])) by (device)",
+                        "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lxc.*|veth.*\", cluster=\"$cluster\"}[$__rate_interval])) by (device)",
                         "interval": "$resolution",
                         "legendFormat": "Received : {{`{{`}} device {{`}}`}}",
                         "range": true,
@@ -2345,7 +2353,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "- sum(rate(node_network_transmit_bytes_total{device!~\"lxc.*|veth.*\"}[$__rate_interval]))  by (device)",
+                        "expr": "- sum(rate(node_network_transmit_bytes_total{device!~\"lxc.*|veth.*\", cluster=\"$cluster\"}[$__rate_interval]))  by (device)",
                         "interval": "$resolution",
                         "legendFormat": "Transmitted : {{`{{`}} device {{`}}`}}",
                         "range": true,
@@ -2400,8 +2408,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2441,7 +2448,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(node_network_receive_drop_total[$__rate_interval]))",
+                        "expr": "sum(rate(node_network_receive_drop_total{cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "Packets dropped (receive)",
                         "range": true,
@@ -2454,7 +2461,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "- sum(rate(node_network_transmit_drop_total[$__rate_interval]))",
+                        "expr": "- sum(rate(node_network_transmit_drop_total{cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "Packets dropped (transmit)",
                         "range": true,
@@ -2509,8 +2516,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2550,7 +2556,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(container_network_receive_bytes_total[$__rate_interval])) by (namespace)",
+                        "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\"}[$__rate_interval])) by (namespace)",
                         "interval": "$resolution",
                         "legendFormat": "Received : {{`{{`}} namespace {{`}}`}}",
                         "range": true,
@@ -2562,7 +2568,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "- sum(rate(container_network_transmit_bytes_total[$__rate_interval])) by (namespace)",
+                        "expr": "- sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\"}[$__rate_interval])) by (namespace)",
                         "hide": false,
                         "interval": "$resolution",
                         "legendFormat": "Transmitted : {{`{{`}} namespace {{`}}`}}",
@@ -2618,8 +2624,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2659,7 +2664,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(node_network_receive_bytes_total[$__rate_interval])) by (instance)",
+                        "expr": "sum(rate(node_network_receive_bytes_total{cluster=\"$cluster\"}[$__rate_interval])) by (instance)",
                         "interval": "$resolution",
                         "legendFormat": "Received bytes in {{`{{`}} instance {{`}}`}}",
                         "range": true,
@@ -2671,7 +2676,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "- sum(rate(node_network_transmit_bytes_total[$__rate_interval])) by (instance)",
+                        "expr": "- sum(rate(node_network_transmit_bytes_total{cluster=\"$cluster\"}[$__rate_interval])) by (instance)",
                         "hide": false,
                         "interval": "$resolution",
                         "legendFormat": "Transmitted bytes in {{`{{`}} instance {{`}}`}}",
@@ -2728,8 +2733,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2769,7 +2773,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lxc.*|veth.*|lo\"}[$__rate_interval])) by (instance)",
+                        "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lxc.*|veth.*|lo\", cluster=\"$cluster\"}[$__rate_interval])) by (instance)",
                         "interval": "$resolution",
                         "legendFormat": "Received bytes in {{`{{`}} instance {{`}}`}}",
                         "range": true,
@@ -2781,7 +2785,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "- sum(rate(node_network_transmit_bytes_total{device!~\"lxc.*|veth.*|lo\"}[$__rate_interval])) by (instance)",
+                        "expr": "- sum(rate(node_network_transmit_bytes_total{device!~\"lxc.*|veth.*|lo\", cluster=\"$cluster\"}[$__rate_interval])) by (instance)",
                         "hide": false,
                         "interval": "$resolution",
                         "legendFormat": "Transmitted bytes in {{`{{`}} instance {{`}}`}}",
@@ -2838,8 +2842,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2879,7 +2882,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(node_network_receive_bytes_total{device=\"lo\"}[$__rate_interval])) by (instance)",
+                        "expr": "sum(rate(node_network_receive_bytes_total{device=\"lo\", cluster=\"$cluster\"}[$__rate_interval])) by (instance)",
                         "interval": "$resolution",
                         "legendFormat": "Received bytes in {{`{{`}} instance {{`}}`}}",
                         "range": true,
@@ -2891,7 +2894,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "- sum(rate(node_network_transmit_bytes_total{device=\"lo\"}[$__rate_interval])) by (instance)",
+                        "expr": "- sum(rate(node_network_transmit_bytes_total{device=\"lo\", cluster=\"$cluster\"}[$__rate_interval])) by (instance)",
                         "hide": false,
                         "interval": "$resolution",
                         "legendFormat": "Transmitted bytes in {{`{{`}} instance {{`}}`}}",
@@ -2905,7 +2908,6 @@ data:
         ],
         "refresh": "30s",
         "schemaVersion": 38,
-        "style": "dark",
         "tags": [
             "Kubernetes",
             "Prometheus",
@@ -2916,8 +2918,8 @@ data:
                 {
                     "current": {
                         "selected": false,
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "",
+                        "value": ""
                     },
                     "hide": 0,
                     "includeAll": false,
@@ -2935,7 +2937,37 @@ data:
                 },
                 {
                     "current": {
-                        "selected": true,
+                        "isNone": true,
+                        "selected": false,
+                        "text": "None",
+                        "value": ""
+                    },
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "definition": "label_values(kube_node_info,cluster)",
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "includeAll": false,
+                    "multi": false,
+                    "name": "cluster",
+                    "options": [
+
+                    ],
+                    "query": {
+                        "qryType": 1,
+                        "query": "label_values(kube_node_info,cluster)",
+                        "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                    },
+                    "refresh": 1,
+                    "regex": "",
+                    "skipUrlSync": false,
+                    "sort": 1,
+                    "type": "query"
+                },
+                {
+                    "current": {
+                        "selected": false,
                         "text": "30s",
                         "value": "30s"
                     },
@@ -2992,7 +3024,7 @@ data:
         "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Views / Global",
         "uid": "k8s_views_global",
-        "version": 31,
+        "version": 36,
         "weekStart": ""
     }
 {{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-namespaces.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-namespaces.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-views-namespaces" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-views-namespaces" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
@@ -171,10 +171,12 @@ data:
                 },
                 "id": 46,
                 "options": {
+                    "minVizHeight": 75,
+                    "minVizWidth": 75,
                     "orientation": "auto",
                     "reduceOptions": {
                         "calcs": [
-                            "mean"
+                            "lastNotNull"
                         ],
                         "fields": "",
                         "values": false
@@ -183,7 +185,7 @@ data:
                     "showThresholdMarkers": true,
                     "text": {}
                 },
-                "pluginVersion": "10.0.3",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -192,7 +194,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", image!=\"\"}[$__rate_interval])) / sum(machine_cpu_cores)",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", image!=\"\", cluster=\"$cluster\"}[$__rate_interval])) / sum(machine_cpu_cores{cluster=\"$cluster\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -243,6 +245,8 @@ data:
                 },
                 "id": 48,
                 "options": {
+                    "minVizHeight": 75,
+                    "minVizWidth": 75,
                     "orientation": "auto",
                     "reduceOptions": {
                         "calcs": [
@@ -255,7 +259,7 @@ data:
                     "showThresholdMarkers": true,
                     "text": {}
                 },
-                "pluginVersion": "10.0.3",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -263,7 +267,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\", image!=\"\"}) / sum(machine_memory_bytes)",
+                        "expr": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\", image!=\"\", cluster=\"$cluster\"}) / sum(machine_memory_bytes{cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -283,6 +287,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -296,6 +301,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -362,7 +368,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_pod_container_status_running{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_pod_info{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Running Pods",
                         "refId": "A"
@@ -372,7 +378,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_service_info{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_service_info{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Services",
                         "refId": "B"
@@ -382,7 +388,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_ingress_info{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_ingress_info{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Ingresses",
                         "refId": "C"
@@ -392,7 +398,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_deployment_labels{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_deployment_labels{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Deployments",
                         "refId": "D"
@@ -402,7 +408,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_statefulset_labels{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_statefulset_labels{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Statefulsets",
                         "refId": "E"
@@ -412,7 +418,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_daemonset_labels{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_daemonset_labels{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Daemonsets",
                         "refId": "F"
@@ -422,7 +428,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_persistentvolumeclaim_info{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_persistentvolumeclaim_info{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Persistent Volume Claims",
                         "refId": "G"
@@ -432,7 +438,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_hpa_labels{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_hpa_labels{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Horizontal Pod Autoscalers",
                         "refId": "H"
@@ -442,7 +448,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_configmap_info{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_configmap_info{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Configmaps",
                         "refId": "I"
@@ -452,7 +458,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_secret_info{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_secret_info{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Secrets",
                         "refId": "J"
@@ -462,7 +468,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_networkpolicy_labels{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_networkpolicy_labels{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Network Policies",
                         "refId": "K"
@@ -507,15 +513,16 @@ data:
                     "orientation": "auto",
                     "reduceOptions": {
                         "calcs": [
-                            "mean"
+                            "lastNotNull"
                         ],
                         "fields": "",
                         "values": false
                     },
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.0.3",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -524,7 +531,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", image!=\"\"}[$__rate_interval]))",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", image!=\"\", cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "",
                         "legendFormat": "Real",
                         "range": true,
@@ -536,7 +543,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"cpu\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"cpu\", cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Requests",
                         "range": true,
@@ -548,7 +555,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"cpu\"})",
+                        "expr": "sum(kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"cpu\", cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Limits",
                         "range": true,
@@ -560,7 +567,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(machine_cpu_cores)",
+                        "expr": "sum(machine_cpu_cores{cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Cluster Total",
                         "range": true,
@@ -606,15 +613,16 @@ data:
                     "orientation": "auto",
                     "reduceOptions": {
                         "calcs": [
-                            "mean"
+                            "lastNotNull"
                         ],
                         "fields": "",
                         "values": false
                     },
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.0.3",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -623,7 +631,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\", image!=\"\"})",
+                        "expr": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\", image!=\"\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Real",
                         "range": true,
@@ -635,7 +643,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"memory\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"memory\", cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Requests",
                         "range": true,
@@ -647,7 +655,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"memory\"})",
+                        "expr": "sum(kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"memory\", cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Limits",
                         "range": true,
@@ -659,7 +667,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(machine_memory_bytes)",
+                        "expr": "sum(machine_memory_bytes{cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Cluster Total",
                         "range": true,
@@ -697,6 +705,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "CPU CORES",
@@ -710,6 +719,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -772,7 +782,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", image!=\"\", pod=~\"${created_by}.*\"}[$__rate_interval])) by (pod)",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", image!=\"\", pod=~\"${created_by}.*\", cluster=\"$cluster\"}[$__rate_interval])) by (pod)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} pod {{`}}`}}",
                         "range": true,
@@ -793,6 +803,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -806,6 +817,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -868,7 +880,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\", image!=\"\", pod=~\"${created_by}.*\"}) by (pod)",
+                        "expr": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\", image!=\"\", pod=~\"${created_by}.*\", cluster=\"$cluster\"}) by (pod)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} pod {{`}}`}}",
                         "range": true,
@@ -890,6 +902,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "SECONDS",
@@ -903,6 +916,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineStyle": {
                                 "fill": "solid"
@@ -975,7 +989,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{namespace=~\"$namespace\", image!=\"\", pod=~\"${created_by}.*\"}[$__rate_interval])) by (pod) > 0",
+                        "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{namespace=~\"$namespace\", image!=\"\", pod=~\"${created_by}.*\", cluster=\"$cluster\"}[$__rate_interval])) by (pod) > 0",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} pod {{`}}`}}",
                         "range": true,
@@ -1009,6 +1023,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1022,6 +1037,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1043,8 +1059,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1090,7 +1105,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(kube_pod_status_qos_class{namespace=~\"$namespace\"}) by (qos_class)",
+                        "expr": "sum(kube_pod_status_qos_class{namespace=~\"$namespace\", cluster=\"$cluster\"}) by (qos_class)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} qos_class {{`}}`}} pods",
                         "range": true,
@@ -1102,7 +1117,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_info{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_pod_info{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "hide": false,
                         "legendFormat": "Total pods",
                         "range": true,
@@ -1123,6 +1138,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1136,6 +1152,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1157,8 +1174,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1204,7 +1220,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(kube_pod_status_reason) by (reason)",
+                        "expr": "sum(kube_pod_status_reason{cluster=\"$cluster\"}) by (reason)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} reason {{`}}`}}",
                         "range": true,
@@ -1226,6 +1242,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1239,6 +1256,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1260,8 +1278,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1307,7 +1324,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(increase(container_oom_events_total{namespace=~\"${namespace}\"}[$__rate_interval])) by (namespace, pod) > 0",
+                        "expr": "sum(increase(container_oom_events_total{namespace=~\"${namespace}\", cluster=\"$cluster\"}[$__rate_interval])) by (namespace, pod) > 0",
                         "interval": "",
                         "legendFormat": "namespace: {{`{{`}} namespace {{`}}`}} - pod: {{`{{`}} pod {{`}}`}}",
                         "range": true,
@@ -1329,6 +1346,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1342,6 +1360,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1363,8 +1382,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1410,7 +1428,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"${namespace}\"}[$__rate_interval])) by (namespace, pod) > 0",
+                        "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"${namespace}\", cluster=\"$cluster\"}[$__rate_interval])) by (namespace, pod) > 0",
                         "interval": "",
                         "legendFormat": "namespace: {{`{{`}} namespace {{`}}`}} - pod: {{`{{`}} pod {{`}}`}}",
                         "range": true,
@@ -1431,6 +1449,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1444,6 +1463,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1466,8 +1486,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1506,7 +1525,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_status_ready{namespace=~\"$namespace\", pod=~\"${created_by}.*\"})",
+                        "expr": "sum(kube_pod_container_status_ready{namespace=~\"$namespace\", pod=~\"${created_by}.*\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Ready",
                         "range": true,
@@ -1518,7 +1537,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_status_running{namespace=~\"$namespace\", pod=~\"${created_by}.*\"})",
+                        "expr": "sum(kube_pod_container_status_running{namespace=~\"$namespace\", pod=~\"${created_by}.*\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Running",
                         "range": true,
@@ -1529,7 +1548,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_pod_container_status_waiting{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_pod_container_status_waiting{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Waiting",
                         "refId": "C"
@@ -1539,7 +1558,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_pod_container_status_restarts_total{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Restarts Total",
                         "refId": "D"
@@ -1549,7 +1568,7 @@ data:
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
-                        "expr": "sum(kube_pod_container_status_terminated{namespace=~\"$namespace\"})",
+                        "expr": "sum(kube_pod_container_status_terminated{namespace=~\"$namespace\", cluster=\"$cluster\"})",
                         "interval": "",
                         "legendFormat": "Terminated",
                         "refId": "E"
@@ -1569,6 +1588,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1582,6 +1602,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1604,8 +1625,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1644,7 +1664,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_pod_container_info{namespace=~\"$namespace\", pod=~\"${created_by}.*\"}) by (pod)",
+                        "expr": "sum(kube_pod_container_info{namespace=~\"$namespace\", pod=~\"${created_by}.*\", cluster=\"$cluster\"}) by (pod)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} pod {{`}}`}}",
                         "range": true,
@@ -1665,6 +1685,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1678,6 +1699,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1699,8 +1721,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1740,7 +1761,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) by (deployment)",
+                        "expr": "sum(kube_deployment_status_replicas_available{namespace=~\"$namespace\", cluster=\"$cluster\"}) by (deployment)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} deployment {{`}}`}}",
                         "range": true,
@@ -1761,6 +1782,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1774,6 +1796,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1795,8 +1818,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1835,7 +1857,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(kube_deployment_status_replicas_unavailable{namespace=~\"$namespace\", pod=~\"${created_by}.*\"}) by (deployment)",
+                        "expr": "sum(kube_deployment_status_replicas_unavailable{namespace=~\"$namespace\", pod=~\"${created_by}.*\", cluster=\"$cluster\"}) by (deployment)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} deployment {{`}}`}}",
                         "range": true,
@@ -1873,6 +1895,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1886,6 +1909,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -1908,8 +1932,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1948,7 +1971,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kubelet_volume_stats_used_bytes{namespace=~\"$namespace\"}) by (persistentvolumeclaim) / sum(kubelet_volume_stats_capacity_bytes{namespace=~\"$namespace\"}) by (persistentvolumeclaim)",
+                        "expr": "sum(kubelet_volume_stats_used_bytes{namespace=~\"$namespace\", cluster=\"$cluster\"}) by (persistentvolumeclaim) / sum(kubelet_volume_stats_capacity_bytes{namespace=~\"$namespace\", cluster=\"$cluster\"}) by (persistentvolumeclaim)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} persistentvolumeclaim {{`}}`}}",
                         "refId": "A"
@@ -1968,6 +1991,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1981,6 +2005,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -2003,8 +2028,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2043,7 +2067,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kubelet_volume_stats_used_bytes{namespace=~\"$namespace\"}) by (persistentvolumeclaim)",
+                        "expr": "sum(kubelet_volume_stats_used_bytes{namespace=~\"$namespace\", cluster=\"$cluster\"}) by (persistentvolumeclaim)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} persistentvolumeclaim {{`}}`}} - Used",
                         "refId": "A"
@@ -2054,7 +2078,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=~\"$namespace\"}) by (persistentvolumeclaim)",
+                        "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=~\"$namespace\", cluster=\"$cluster\"}) by (persistentvolumeclaim)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "{{`{{`}} persistentvolumeclaim {{`}}`}} - Capacity",
@@ -2075,6 +2099,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -2088,6 +2113,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "smooth",
                             "lineWidth": 2,
                             "pointSize": 5,
@@ -2110,8 +2136,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2150,7 +2175,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "1 - sum(kubelet_volume_stats_inodes_used{namespace=~\"$namespace\"}) by (persistentvolumeclaim) / sum(kubelet_volume_stats_inodes{namespace=~\"$namespace\"}) by (persistentvolumeclaim)",
+                        "expr": "1 - sum(kubelet_volume_stats_inodes_used{namespace=~\"$namespace\", cluster=\"$cluster\"}) by (persistentvolumeclaim) / sum(kubelet_volume_stats_inodes{namespace=~\"$namespace\", cluster=\"$cluster\"}) by (persistentvolumeclaim)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} persistentvolumeclaim {{`}}`}}",
                         "refId": "A"
@@ -2162,7 +2187,6 @@ data:
         ],
         "refresh": "30s",
         "schemaVersion": 38,
-        "style": "dark",
         "tags": [
             "Kubernetes",
             "Prometheus",
@@ -2173,8 +2197,8 @@ data:
                 {
                     "current": {
                         "selected": false,
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "",
+                        "value": ""
                     },
                     "hide": 0,
                     "includeAll": false,
@@ -2192,6 +2216,36 @@ data:
                 },
                 {
                     "current": {
+                        "isNone": true,
+                        "selected": false,
+                        "text": "None",
+                        "value": ""
+                    },
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "definition": "label_values(kube_node_info,cluster)",
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "includeAll": false,
+                    "multi": false,
+                    "name": "cluster",
+                    "options": [
+
+                    ],
+                    "query": {
+                        "qryType": 1,
+                        "query": "label_values(kube_node_info,cluster)",
+                        "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                    },
+                    "refresh": 1,
+                    "regex": "",
+                    "skipUrlSync": false,
+                    "sort": 1,
+                    "type": "query"
+                },
+                {
+                    "current": {
                         "selected": true,
                         "text": [
                             "monitoring"
@@ -2204,7 +2258,7 @@ data:
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
-                    "definition": "label_values(kube_pod_info, namespace)",
+                    "definition": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
                     "hide": 0,
                     "includeAll": true,
                     "multi": true,
@@ -2213,7 +2267,7 @@ data:
 
                     ],
                     "query": {
-                        "query": "label_values(kube_pod_info, namespace)",
+                        "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
                         "refId": "StandardVariableQuery"
                     },
                     "refresh": 1,
@@ -2227,7 +2281,7 @@ data:
                 },
                 {
                     "current": {
-                        "selected": true,
+                        "selected": false,
                         "text": "30s",
                         "value": "30s"
                     },
@@ -2282,7 +2336,7 @@ data:
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
-                    "definition": "label_values(kube_pod_info{namespace=~\"$namespace\", container!=\"\"},created_by_name)",
+                    "definition": "label_values(kube_pod_info{namespace=~\"$namespace\", container!=\"\", cluster=\"$cluster\"},created_by_name)",
                     "description": "Can be used to filter on a specific deployment, statefulset or deamonset (only relevant panels).",
                     "hide": 0,
                     "includeAll": true,
@@ -2292,7 +2346,7 @@ data:
 
                     ],
                     "query": {
-                        "query": "label_values(kube_pod_info{namespace=~\"$namespace\", container!=\"\"},created_by_name)",
+                        "query": "label_values(kube_pod_info{namespace=~\"$namespace\", container!=\"\", cluster=\"$cluster\"},created_by_name)",
                         "refId": "PrometheusVariableQueryEditor-VariableQuery"
                     },
                     "refresh": 1,
@@ -2313,7 +2367,7 @@ data:
         "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Views / Namespaces",
         "uid": "k8s_views_ns",
-        "version": 27,
+        "version": 32,
         "weekStart": ""
     }
 {{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-pods.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/k8s-views-pods.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-views-pods" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "k8s-views-pods" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
@@ -192,17 +192,19 @@ data:
                         "fields": "",
                         "values": false
                     },
-                    "textMode": "name"
+                    "textMode": "name",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
+                        "editorMode": "code",
                         "exemplar": false,
-                        "expr": "kube_pod_info{namespace=\"$namespace\", pod=\"$pod\"}",
+                        "expr": "kube_pod_info{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "{{`{{`}} created_by_kind {{`}}`}}: {{`{{`}} created_by_name {{`}}`}}",
@@ -258,17 +260,19 @@ data:
                         "fields": "",
                         "values": false
                     },
-                    "textMode": "name"
+                    "textMode": "name",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
+                        "editorMode": "code",
                         "exemplar": false,
-                        "expr": "kube_pod_info{namespace=\"$namespace\", pod=\"$pod\"}",
+                        "expr": "kube_pod_info{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "{{`{{`}} node {{`}}`}}",
@@ -318,17 +322,19 @@ data:
                         "fields": "",
                         "values": false
                     },
-                    "textMode": "name"
+                    "textMode": "name",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
+                        "editorMode": "code",
                         "exemplar": false,
-                        "expr": "kube_pod_info{namespace=\"$namespace\", pod=\"$pod\"}",
+                        "expr": "kube_pod_info{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "{{`{{`}} pod_ip {{`}}`}}",
@@ -378,9 +384,10 @@ data:
                         "fields": "",
                         "values": false
                     },
-                    "textMode": "name"
+                    "textMode": "name",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -389,7 +396,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "kube_pod_info{namespace=\"$namespace\", pod=\"$pod\", priority_class!=\"\"}",
+                        "expr": "kube_pod_info{namespace=\"$namespace\", pod=\"$pod\", priority_class!=\"\", cluster=\"$cluster\"}",
                         "format": "time_series",
                         "instant": true,
                         "interval": "",
@@ -473,9 +480,10 @@ data:
                         "fields": "",
                         "values": false
                     },
-                    "textMode": "name"
+                    "textMode": "name",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -484,7 +492,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "kube_pod_status_qos_class{namespace=\"$namespace\", pod=\"$pod\"} > 0",
+                        "expr": "kube_pod_status_qos_class{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"} > 0",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "{{`{{`}} qos_class {{`}}`}}",
@@ -536,9 +544,10 @@ data:
                         "fields": "",
                         "values": false
                     },
-                    "textMode": "name"
+                    "textMode": "name",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -547,7 +556,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "kube_pod_container_status_last_terminated_reason{namespace=\"$namespace\", pod=\"$pod\"}",
+                        "expr": "kube_pod_container_status_last_terminated_reason{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "{{`{{`}} reason {{`}}`}}",
@@ -603,9 +612,10 @@ data:
                         "fields": "",
                         "values": true
                     },
-                    "textMode": "value"
+                    "textMode": "value",
+                    "wideLayout": true
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -614,7 +624,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "kube_pod_container_status_last_terminated_exitcode{namespace=\"$namespace\", pod=\"$pod\"}",
+                        "expr": "kube_pod_container_status_last_terminated_exitcode{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "__auto",
@@ -695,6 +705,8 @@ data:
                 },
                 "id": 39,
                 "options": {
+                    "minVizHeight": 75,
+                    "minVizWidth": 75,
                     "orientation": "auto",
                     "reduceOptions": {
                         "calcs": [
@@ -706,7 +718,7 @@ data:
                     "showThresholdLabels": false,
                     "showThresholdMarkers": true
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -715,7 +727,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}[$__rate_interval])) / sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"})",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", cluster=\"$cluster\"}[$__rate_interval])) / sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\", job=~\"$job\", cluster=\"$cluster\"})",
                         "instant": true,
                         "interval": "$resolution",
                         "legendFormat": "Requests",
@@ -765,6 +777,8 @@ data:
                 },
                 "id": 48,
                 "options": {
+                    "minVizHeight": 75,
+                    "minVizWidth": 75,
                     "orientation": "auto",
                     "reduceOptions": {
                         "calcs": [
@@ -776,7 +790,7 @@ data:
                     "showThresholdLabels": false,
                     "showThresholdMarkers": true
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -785,7 +799,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}[$__rate_interval])) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"})",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", cluster=\"$cluster\"}[$__rate_interval])) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\", job=~\"$job\", cluster=\"$cluster\"})",
                         "instant": true,
                         "interval": "$resolution",
                         "legendFormat": "Limits",
@@ -839,6 +853,8 @@ data:
                 },
                 "id": 40,
                 "options": {
+                    "minVizHeight": 75,
+                    "minVizWidth": 75,
                     "orientation": "auto",
                     "reduceOptions": {
                         "calcs": [
@@ -850,15 +866,16 @@ data:
                     "showThresholdLabels": false,
                     "showThresholdMarkers": true
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
+                        "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) / sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"})",
+                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", cluster=\"$cluster\"}) / sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\", job=~\"$job\", cluster=\"$cluster\"})",
                         "instant": true,
                         "interval": "$resolution",
                         "legendFormat": "Requests",
@@ -908,6 +925,8 @@ data:
                 },
                 "id": 49,
                 "options": {
+                    "minVizHeight": 75,
+                    "minVizWidth": 75,
                     "orientation": "auto",
                     "reduceOptions": {
                         "calcs": [
@@ -919,15 +938,16 @@ data:
                     "showThresholdLabels": false,
                     "showThresholdMarkers": true
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "${datasource}"
                         },
+                        "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}) ",
+                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", cluster=\"$cluster\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\", job=~\"$job\", cluster=\"$cluster\"}) ",
                         "instant": true,
                         "interval": "$resolution",
                         "legendFormat": "Limits",
@@ -1037,7 +1057,7 @@ data:
                     "showHeader": true,
                     "sortBy": []
                 },
-                "pluginVersion": "10.1.0",
+                "pluginVersion": "10.2.2",
                 "targets": [
                     {
                         "datasource": {
@@ -1046,7 +1066,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}) by (container)",
+                        "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\", job=~\"$job\", cluster=\"$cluster\"}) by (container)",
                         "format": "table",
                         "instant": true,
                         "interval": "",
@@ -1061,7 +1081,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}) by (container)",
+                        "expr": "sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\", job=~\"$job\", cluster=\"$cluster\"}) by (container)",
                         "format": "table",
                         "instant": true,
                         "interval": "",
@@ -1076,7 +1096,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}) by (container)",
+                        "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\", job=~\"$job\", cluster=\"$cluster\"}) by (container)",
                         "format": "table",
                         "instant": true,
                         "interval": "",
@@ -1090,7 +1110,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}) by (container)",
+                        "expr": "sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\", job=~\"$job\", cluster=\"$cluster\"}) by (container)",
                         "format": "table",
                         "instant": true,
                         "interval": "",
@@ -1104,7 +1124,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", container!=\"\"}[$__rate_interval])) by (container)",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", container!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -1119,7 +1139,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", container!=\"\"}) by (container)",
+                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", container!=\"\", cluster=\"$cluster\"}) by (container)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -1230,6 +1250,7 @@ data:
                             "mode": "thresholds"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "Percent",
@@ -1320,7 +1341,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}[$__rate_interval])) by (container) / sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}) by (container)",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container) / sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\", job=~\"$job\", cluster=\"$cluster\"}) by (container)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} container {{`}}`}}  REQUESTS",
                         "range": true,
@@ -1332,7 +1353,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}[$__rate_interval])) by (container) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}) by (container)",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\", job=~\"$job\", cluster=\"$cluster\"}) by (container)",
                         "hide": false,
                         "legendFormat": "{{`{{`}} container {{`}}`}}  LIMITS",
                         "range": true,
@@ -1354,6 +1375,7 @@ data:
                             "mode": "thresholds"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "Percent",
@@ -1447,7 +1469,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) by (container) / sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}) by (container)",
+                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", cluster=\"$cluster\"}) by (container) / sum(kube_pod_container_resource_requests{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\", job=~\"$job\", cluster=\"$cluster\"}) by (container)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} container {{`}}`}} REQUESTS",
                         "range": true,
@@ -1459,7 +1481,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "editorMode": "code",
-                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) by (container) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}) by (container)",
+                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", cluster=\"$cluster\"}) by (container) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\", job=~\"$job\", cluster=\"$cluster\"}) by (container)",
                         "hide": false,
                         "legendFormat": "{{`{{`}} container {{`}}`}} LIMITS",
                         "range": true,
@@ -1480,6 +1502,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "CPU Cores",
@@ -1581,7 +1604,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", container!=\"\"}[$__rate_interval])) by (container)",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", container!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} container {{`}}`}}",
                         "range": true,
@@ -1602,6 +1625,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "Bytes",
@@ -1686,7 +1710,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", container!=\"\"}) by (container)",
+                        "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", image!=\"\", container!=\"\", cluster=\"$cluster\"}) by (container)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} container {{`}}`}}",
                         "range": true,
@@ -1708,6 +1732,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "SECONDS",
@@ -1747,8 +1772,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1794,7 +1818,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{namespace=~\"$namespace\", pod=\"$pod\", image!=\"\", container!=\"\"}[$__rate_interval])) by (container)",
+                        "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{namespace=~\"$namespace\", pod=\"$pod\", image!=\"\", container!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container)",
                         "interval": "$resolution",
                         "legendFormat": "{{`{{`}} container {{`}}`}}",
                         "range": true,
@@ -1829,6 +1853,7 @@ data:
                             "mode": "thresholds"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "Percent",
@@ -1869,8 +1894,7 @@ data:
                             "mode": "percentage",
                             "steps": [
                                 {
-                                    "color": "red",
-                                    "value": null
+                                    "color": "red"
                                 },
                                 {
                                     "color": "yellow",
@@ -1922,7 +1946,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(increase(container_oom_events_total{namespace=\"${namespace}\", pod=\"${pod}\", container!=\"\"}[$__rate_interval])) by (container)",
+                        "expr": "sum(increase(container_oom_events_total{namespace=\"${namespace}\", pod=\"${pod}\", container!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} container {{`}}`}}",
                         "range": true,
@@ -1944,6 +1968,7 @@ data:
                             "mode": "thresholds"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "Percent",
@@ -1984,8 +2009,7 @@ data:
                             "mode": "percentage",
                             "steps": [
                                 {
-                                    "color": "red",
-                                    "value": null
+                                    "color": "red"
                                 },
                                 {
                                     "color": "yellow",
@@ -2037,7 +2061,7 @@ data:
                         },
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"${namespace}\", pod=\"${pod}\", container!=\"\"}[$__rate_interval])) by (container)",
+                        "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"${namespace}\", pod=\"${pod}\", container!=\"\", job=~\"$job\", cluster=\"$cluster\"}[$__rate_interval])) by (container)",
                         "interval": "",
                         "legendFormat": "{{`{{`}} container {{`}}`}}",
                         "range": true,
@@ -2084,6 +2108,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -2119,8 +2144,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2159,7 +2183,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                        "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "Received",
                         "refId": "A"
@@ -2170,7 +2194,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "- sum(rate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                        "expr": "- sum(rate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "Transmitted",
                         "refId": "B"
@@ -2190,6 +2214,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -2225,8 +2250,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -2265,7 +2289,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_network_receive_packets_total{namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                        "expr": "sum(rate(container_network_receive_packets_total{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "Received",
                         "refId": "A"
@@ -2276,7 +2300,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "- sum(rate(container_network_transmit_packets_total{namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                        "expr": "- sum(rate(container_network_transmit_packets_total{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "Transmitted",
                         "refId": "B"
@@ -2296,6 +2320,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -2370,7 +2395,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_network_receive_packets_dropped_total{namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                        "expr": "sum(rate(container_network_receive_packets_dropped_total{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "Received",
                         "refId": "A"
@@ -2381,7 +2406,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "- sum(rate(container_network_transmit_packets_dropped_total{namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                        "expr": "- sum(rate(container_network_transmit_packets_dropped_total{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "Transmitted",
                         "refId": "B"
@@ -2401,6 +2426,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -2475,7 +2501,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                        "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "Received",
                         "refId": "A"
@@ -2486,7 +2512,7 @@ data:
                             "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "- sum(rate(container_network_transmit_errors_total{namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                        "expr": "- sum(rate(container_network_transmit_errors_total{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}[$__rate_interval]))",
                         "interval": "$resolution",
                         "legendFormat": "Transmitted",
                         "refId": "B"
@@ -2498,7 +2524,6 @@ data:
         ],
         "refresh": "30s",
         "schemaVersion": 38,
-        "style": "dark",
         "tags": [
             "Kubernetes",
             "Prometheus",
@@ -2509,8 +2534,8 @@ data:
                 {
                     "current": {
                         "selected": false,
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "",
+                        "value": ""
                     },
                     "hide": 0,
                     "includeAll": false,
@@ -2528,6 +2553,36 @@ data:
                 },
                 {
                     "current": {
+                        "isNone": true,
+                        "selected": false,
+                        "text": "None",
+                        "value": ""
+                    },
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "definition": "label_values(kube_node_info,cluster)",
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "includeAll": false,
+                    "multi": false,
+                    "name": "cluster",
+                    "options": [
+
+                    ],
+                    "query": {
+                        "qryType": 1,
+                        "query": "label_values(kube_node_info,cluster)",
+                        "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                    },
+                    "refresh": 1,
+                    "regex": "",
+                    "skipUrlSync": false,
+                    "sort": 1,
+                    "type": "query"
+                },
+                {
+                    "current": {
                         "selected": false,
                         "text": "monitoring",
                         "value": "monitoring"
@@ -2536,7 +2591,7 @@ data:
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
-                    "definition": "label_values(kube_pod_info, namespace)",
+                    "definition": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
                     "hide": 0,
                     "includeAll": false,
                     "multi": false,
@@ -2545,7 +2600,7 @@ data:
 
                     ],
                     "query": {
-                        "query": "label_values(kube_pod_info, namespace)",
+                        "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
                         "refId": "Prometheus-namespace-Variable-Query"
                     },
                     "refresh": 1,
@@ -2567,7 +2622,7 @@ data:
                         "type": "prometheus",
                         "uid": "${datasource}"
                     },
-                    "definition": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
+                    "definition": "label_values(kube_pod_info{namespace=\"$namespace\", cluster=\"$cluster\"}, pod)",
                     "hide": 0,
                     "includeAll": false,
                     "multi": false,
@@ -2576,7 +2631,7 @@ data:
 
                     ],
                     "query": {
-                        "query": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
+                        "query": "label_values(kube_pod_info{namespace=\"$namespace\", cluster=\"$cluster\"}, pod)",
                         "refId": "Prometheus-pod-Variable-Query"
                     },
                     "refresh": 2,
@@ -2590,7 +2645,7 @@ data:
                 },
                 {
                     "current": {
-                        "selected": true,
+                        "selected": false,
                         "text": "30s",
                         "value": "30s"
                     },
@@ -2634,6 +2689,35 @@ data:
                     "queryValue": "",
                     "skipUrlSync": false,
                     "type": "custom"
+                },
+                {
+                    "current": {
+                        "selected": false,
+                        "text": "kube-state-metrics",
+                        "value": "kube-state-metrics"
+                    },
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "definition": "label_values(kube_pod_info,job)",
+                    "hide": 0,
+                    "includeAll": false,
+                    "multi": true,
+                    "name": "job",
+                    "options": [
+
+                    ],
+                    "query": {
+                        "qryType": 1,
+                        "query": "label_values(kube_pod_info,job)",
+                        "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                    },
+                    "refresh": 1,
+                    "regex": "",
+                    "skipUrlSync": false,
+                    "sort": 1,
+                    "type": "query"
                 }
             ]
         },
@@ -2647,7 +2731,7 @@ data:
         "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Views / Pods",
         "uid": "k8s_views_pods",
-        "version": 22,
+        "version": 26,
         "weekStart": ""
     }
 {{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/operator.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/operator.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "operator" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "operator" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics-cluster.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "victoriametrics-cluster" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "victoriametrics-cluster" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
@@ -55,7 +55,7 @@ data:
                 "type": "grafana",
                 "id": "grafana",
                 "name": "Grafana",
-                "version": "9.2.7"
+                "version": "10.3.1"
             },
             {
                 "type": "datasource",
@@ -217,7 +217,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -242,10 +243,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -286,7 +289,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -311,10 +315,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -357,7 +363,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "req/s"
+                        "unit": "req/s",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -382,10 +389,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -427,7 +436,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -452,10 +462,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -497,7 +509,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -522,10 +535,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -567,7 +582,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "bytes"
+                        "unit": "bytes",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -592,10 +608,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -637,7 +655,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "bytes"
+                        "unit": "bytes",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -662,10 +681,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -706,7 +727,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "bytes"
+                        "unit": "bytes",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -731,10 +753,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -767,7 +791,9 @@ data:
                         },
                         "custom": {
                             "align": "auto",
-                            "displayMode": "auto",
+                            "cellOptions": {
+                                "type": "auto"
+                            },
                             "inspect": false,
                             "minWidth": 50
                         },
@@ -784,7 +810,8 @@ data:
                                     "value": 80
                                 }
                             ]
-                        }
+                        },
+                        "unitScale": true
                     },
                     "overrides": [
                         {
@@ -821,7 +848,9 @@ data:
                 },
                 "id": 149,
                 "options": {
+                    "cellHeight": "sm",
                     "footer": {
+                        "countRows": false,
                         "fields": "",
                         "reducer": [
                             "sum"
@@ -836,7 +865,7 @@ data:
                         }
                     ]
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -865,6 +894,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -879,6 +909,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "stepAfter",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -911,7 +942,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "none"
+                        "unit": "none",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -985,6 +1017,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -998,6 +1031,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineStyle": {
                                 "fill": "solid"
@@ -1033,7 +1067,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1093,6 +1128,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1106,6 +1142,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1138,7 +1175,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1199,6 +1237,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1212,6 +1251,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1244,7 +1284,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1309,6 +1350,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1322,6 +1364,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1354,7 +1397,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "s"
+                        "unit": "s",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1415,6 +1459,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1428,6 +1473,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1451,8 +1497,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1460,7 +1505,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1521,6 +1567,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1534,6 +1581,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1563,8 +1611,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1572,7 +1619,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1650,6 +1698,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1663,6 +1712,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1701,7 +1751,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1709,7 +1760,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 38
+                            "y": 3
                         },
                         "id": 66,
                         "links": [],
@@ -1762,6 +1813,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1775,6 +1827,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1813,7 +1866,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1821,7 +1875,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 38
+                            "y": 3
                         },
                         "id": 138,
                         "links": [],
@@ -1873,6 +1927,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1886,6 +1941,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1924,7 +1980,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1932,7 +1989,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 46
+                            "y": 11
                         },
                         "id": 64,
                         "links": [],
@@ -1987,6 +2044,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2000,6 +2058,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2031,7 +2090,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "Bps"
+                                "unit": "Bps",
+                                "unitScale": true
                             },
                             "overrides": [
                                 {
@@ -2052,7 +2112,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 46
+                            "y": 11
                         },
                         "id": 122,
                         "links": [],
@@ -2123,6 +2183,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2136,6 +2197,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2169,7 +2231,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": [
                                 {
@@ -2193,7 +2256,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 54
+                            "y": 19
                         },
                         "id": 117,
                         "links": [],
@@ -2248,6 +2311,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2261,6 +2325,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2292,7 +2357,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": [
                                 {
@@ -2313,7 +2379,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 54
+                            "y": 19
                         },
                         "id": 204,
                         "links": [],
@@ -2383,6 +2449,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2396,6 +2463,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2429,7 +2497,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2437,7 +2506,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 62
+                            "y": 27
                         },
                         "id": 68,
                         "links": [],
@@ -2491,6 +2560,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2504,6 +2574,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2534,7 +2605,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2542,7 +2614,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 62
+                            "y": 27
                         },
                         "id": 119,
                         "options": {
@@ -2593,6 +2665,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2606,6 +2679,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2639,7 +2713,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2647,7 +2722,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 70
+                            "y": 35
                         },
                         "id": 70,
                         "links": [],
@@ -2701,6 +2776,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2714,6 +2790,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2744,7 +2821,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2752,7 +2830,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 70
+                            "y": 35
                         },
                         "id": 120,
                         "options": {
@@ -2790,6 +2868,115 @@ data:
                             }
                         ],
                         "title": "TCP connections rate ($instance)",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the percent of CPU spent on garbage collection.\n\nIf % is high, then CPU usage can be decreased by changing GOGC to higher values. Increasing GOGC value will increase memory usage, and decrease CPU usage.\n\nTry searching for keyword `GOGC` at https://docs.victoriametrics.com/troubleshooting/ ",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "decimals": 0,
+                                "links": [],
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "percentunit",
+                                "unitScale": true
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 43
+                        },
+                        "id": 210,
+                        "links": [],
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull",
+                                    "max"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "mode": "multi",
+                                "sort": "desc"
+                            }
+                        },
+                        "pluginVersion": "9.2.6",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(job)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "__auto",
+                                "range": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "CPU spent on GC ($instance)",
                         "type": "timeseries"
                     }
                 ],
@@ -2891,7 +3078,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 31
+                            "y": 23
                         },
                         "id": 102,
                         "options": {
@@ -3005,7 +3192,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 31
+                            "y": 23
                         },
                         "id": 108,
                         "options": {
@@ -3106,7 +3293,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 39
+                            "y": 31
                         },
                         "id": 142,
                         "links": [
@@ -3158,7 +3345,7 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Slow queries according to `search.logSlowQueryDuration` flag, which is `5s` by default.",
+                        "description": "Shows % of slow queries according to `search.logSlowQueryDuration` flag, which is `5s` by default.\n\nThe less value is better.",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {
@@ -3169,6 +3356,7 @@ data:
                                     "axisColorMode": "text",
                                     "axisLabel": "",
                                     "axisPlacement": "auto",
+                                    "axisSoftMin": 0,
                                     "barAlignment": 0,
                                     "drawStyle": "line",
                                     "fillOpacity": 10,
@@ -3209,7 +3397,7 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "percentunit"
                             },
                             "overrides": []
                         },
@@ -3217,7 +3405,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 39
+                            "y": 31
                         },
                         "id": 107,
                         "options": {
@@ -3243,13 +3431,15 @@ data:
                                     "type": "prometheus",
                                     "uid": "$ds"
                                 },
-                                "expr": "sum(rate(vm_slow_queries_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval]))",
+                                "editorMode": "code",
+                                "expr": "sum(rate(vm_slow_queries_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval]))\n/\nsum(rate(vm_http_requests_total{job=~\"$job_select\", instance=~\"$instance\", path=~\"/select/.*\"}[$__rate_interval]))",
                                 "interval": "",
-                                "legendFormat": "slow queries rate",
+                                "legendFormat": "slow queries %",
+                                "range": true,
                                 "refId": "A"
                             }
                         ],
-                        "title": "Slow queries rate ($instance)",
+                        "title": "Slow queries % ($instance)",
                         "type": "timeseries"
                     },
                     {
@@ -3316,7 +3506,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 47
+                            "y": 39
                         },
                         "id": 170,
                         "links": [],
@@ -3362,7 +3552,7 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "VictoriaMetrics limits the number of labels per each metric with `-maxLabelsPerTimeseries` command-line flag.\n\nThis prevents from ingesting metrics with too many labels. The value of `maxLabelsPerTimeseries` must be adjusted for your workload.\n\nWhen limit is exceeded (graph is > 0) - extra labels are dropped, which could result in unexpected identical time series.",
+                        "description": "VictoriaMetrics limits the number of labels per each metric with `-maxLabelsPerTimeseries` command-line flag.\n\nThis prevents from ingesting metrics with too many labels. The value of `maxLabelsPerTimeseries` must be adjusted for your workload.\n\nWhen limit is exceeded (graph is > 0) - extra labels are dropped, which could result in unexpected identical time series. See more details about dropped labels in vminsert logs.",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {
@@ -3422,7 +3612,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 47
+                            "y": 39
                         },
                         "id": 116,
                         "links": [],
@@ -3524,7 +3714,7 @@ data:
                             "h": 9,
                             "w": 12,
                             "x": 0,
-                            "y": 55
+                            "y": 47
                         },
                         "id": 144,
                         "options": {
@@ -3627,7 +3817,7 @@ data:
                             "h": 9,
                             "w": 12,
                             "x": 12,
-                            "y": 55
+                            "y": 47
                         },
                         "id": 58,
                         "links": [],
@@ -3683,7 +3873,9 @@ data:
                                 },
                                 "custom": {
                                     "align": "auto",
-                                    "displayMode": "auto",
+                                    "cellOptions": {
+                                        "type": "auto"
+                                    },
                                     "inspect": false
                                 },
                                 "mappings": [],
@@ -3728,10 +3920,10 @@ data:
                             ]
                         },
                         "gridPos": {
-                            "h": 7,
+                            "h": 6,
                             "w": 24,
                             "x": 0,
-                            "y": 64
+                            "y": 56
                         },
                         "id": 183,
                         "options": {
@@ -3750,7 +3942,7 @@ data:
                                 }
                             ]
                         },
-                        "pluginVersion": "9.1.0",
+                        "pluginVersion": "9.2.7",
                         "targets": [
                             {
                                 "datasource": {
@@ -3796,6 +3988,108 @@ data:
                             }
                         ],
                         "type": "table"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows how many rows were ignored on insertion due to corrupted or out of retention timestamps.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 62
+                        },
+                        "id": 135,
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull",
+                                    "max"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true,
+                                "sortBy": "Last *",
+                                "sortDesc": true
+                            },
+                            "tooltip": {
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "pluginVersion": "9.1.0",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "exemplar": true,
+                                "expr": "sum(increase(vm_rows_ignored_total{job=~\"$job_storage\", instance=~\"$instance\"}[1h])) by (reason)",
+                                "interval": "",
+                                "legendFormat": "__auto",
+                                "range": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Rows ignored for last 1h ($instance)",
+                        "type": "timeseries"
                     }
                 ],
                 "title": "Troubleshooting",
@@ -3879,7 +4173,7 @@ data:
                             "h": 9,
                             "w": 12,
                             "x": 0,
-                            "y": 21
+                            "y": 37
                         },
                         "id": 76,
                         "links": [],
@@ -3995,7 +4289,7 @@ data:
                             "h": 9,
                             "w": 12,
                             "x": 12,
-                            "y": 21
+                            "y": 37
                         },
                         "id": 86,
                         "links": [],
@@ -4120,7 +4414,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 30
+                            "y": 46
                         },
                         "id": 80,
                         "links": [],
@@ -4225,7 +4519,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 30
+                            "y": 46
                         },
                         "id": 78,
                         "links": [],
@@ -4341,7 +4635,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 38
+                            "y": 54
                         },
                         "id": 82,
                         "options": {
@@ -4448,7 +4742,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 38
+                            "y": 54
                         },
                         "id": 74,
                         "options": {
@@ -4566,7 +4860,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 6
+                            "y": 14
                         },
                         "id": 100,
                         "links": [],
@@ -4677,7 +4971,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 6
+                            "y": 14
                         },
                         "id": 113,
                         "links": [],
@@ -4789,7 +5083,7 @@ data:
                             "h": 7,
                             "w": 12,
                             "x": 0,
-                            "y": 14
+                            "y": 22
                         },
                         "id": 151,
                         "links": [],
@@ -4934,7 +5228,7 @@ data:
                             "h": 7,
                             "w": 12,
                             "x": 12,
-                            "y": 14
+                            "y": 22
                         },
                         "id": 167,
                         "links": [],
@@ -5071,7 +5365,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 21
+                            "y": 29
                         },
                         "id": 141,
                         "links": [
@@ -5190,7 +5484,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 21
+                            "y": 29
                         },
                         "id": 133,
                         "links": [
@@ -5316,7 +5610,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 29
+                            "y": 37
                         },
                         "id": 54,
                         "options": {
@@ -5419,7 +5713,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 29
+                            "y": 37
                         },
                         "id": 55,
                         "options": {
@@ -5527,7 +5821,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 37
+                            "y": 45
                         },
                         "id": 20,
                         "links": [],
@@ -5660,7 +5954,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 37
+                            "y": 45
                         },
                         "id": 22,
                         "links": [],
@@ -5768,7 +6062,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 45
+                            "y": 53
                         },
                         "id": 202,
                         "links": [],
@@ -5904,7 +6198,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 45
+                            "y": 53
                         },
                         "id": 14,
                         "links": [],
@@ -5965,7 +6259,7 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "Shows how many rows were ignored on insertion due to corrupted or out of retention timestamps.",
+                        "description": "Shows network usage by vmstorage services.\n* Writes show traffic sent to vmselects.\n* Reads show traffic received from vminserts.",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {
@@ -6001,6 +6295,7 @@ data:
                                         "mode": "off"
                                     }
                                 },
+                                "links": [],
                                 "mappings": [],
                                 "thresholds": {
                                     "mode": "absolute",
@@ -6014,23 +6309,36 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "bps"
                             },
-                            "overrides": []
+                            "overrides": [
+                                {
+                                    "matcher": {
+                                        "id": "byRegexp",
+                                        "options": "/read.*/"
+                                    },
+                                    "properties": [
+                                        {
+                                            "id": "custom.transform",
+                                            "value": "negative-Y"
+                                        }
+                                    ]
+                                }
+                            ]
                         },
                         "gridPos": {
                             "h": 8,
-                            "w": 12,
+                            "w": 24,
                             "x": 0,
-                            "y": 53
+                            "y": 61
                         },
-                        "id": 135,
+                        "id": 206,
+                        "links": [],
                         "options": {
                             "legend": {
                                 "calcs": [
                                     "mean",
-                                    "lastNotNull",
-                                    "max"
+                                    "lastNotNull"
                                 ],
                                 "displayMode": "table",
                                 "placement": "bottom",
@@ -6040,7 +6348,7 @@ data:
                             },
                             "tooltip": {
                                 "mode": "multi",
-                                "sort": "none"
+                                "sort": "desc"
                             }
                         },
                         "pluginVersion": "9.1.0",
@@ -6051,15 +6359,29 @@ data:
                                     "uid": "$ds"
                                 },
                                 "editorMode": "code",
-                                "exemplar": true,
-                                "expr": "sum(increase(vm_rows_ignored_total{job=~\"$job_storage\", instance=~\"$instance\"}[1h])) by (reason)",
-                                "interval": "",
-                                "legendFormat": "__auto",
+                                "expr": "sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) * 8 > 0",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "read",
                                 "range": true,
                                 "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "sum(rate(vm_tcplistener_written_bytes_total{job=~\"$job_storage\", instance=~\"$instance\"}[$__rate_interval])) * 8 > 0",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 1,
+                                "legendFormat": "write ",
+                                "range": true,
+                                "refId": "B"
                             }
                         ],
-                        "title": "Rows ignored for last 1h ($instance)",
+                        "title": "Network usage ($instance)",
                         "type": "timeseries"
                     }
                 ],
@@ -6144,7 +6466,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 98
+                            "y": 50
                         },
                         "id": 92,
                         "links": [],
@@ -6270,7 +6592,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 98
+                            "y": 50
                         },
                         "id": 95,
                         "links": [],
@@ -6392,7 +6714,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 106
+                            "y": 58
                         },
                         "id": 163,
                         "links": [],
@@ -6536,7 +6858,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 106
+                            "y": 58
                         },
                         "id": 165,
                         "links": [],
@@ -6676,7 +6998,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 114
+                            "y": 66
                         },
                         "id": 178,
                         "links": [],
@@ -6783,7 +7105,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 114
+                            "y": 66
                         },
                         "id": 180,
                         "links": [],
@@ -6890,7 +7212,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 122
+                            "y": 74
                         },
                         "id": 179,
                         "links": [],
@@ -6997,7 +7319,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 122
+                            "y": 74
                         },
                         "id": 181,
                         "links": [],
@@ -7044,7 +7366,7 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "",
+                        "description": "Shows network usage between vmselects and clients, such as vmalert, Grafana, vmui, etc.",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {
@@ -7113,9 +7435,9 @@ data:
                         },
                         "gridPos": {
                             "h": 8,
-                            "w": 24,
+                            "w": 12,
                             "x": 0,
-                            "y": 130
+                            "y": 82
                         },
                         "id": 93,
                         "links": [],
@@ -7166,7 +7488,137 @@ data:
                                 "refId": "B"
                             }
                         ],
-                        "title": "Network usage ($instance)",
+                        "title": "Network usage: clients ($instance)",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows network usage between vmselects and vmstorages.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "links": [],
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "bps"
+                            },
+                            "overrides": [
+                                {
+                                    "matcher": {
+                                        "id": "byRegexp",
+                                        "options": "/read.*/"
+                                    },
+                                    "properties": [
+                                        {
+                                            "id": "custom.transform",
+                                            "value": "negative-Y"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 82
+                        },
+                        "id": 207,
+                        "links": [],
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true,
+                                "sortBy": "Last *",
+                                "sortDesc": true
+                            },
+                            "tooltip": {
+                                "mode": "multi",
+                                "sort": "desc"
+                            }
+                        },
+                        "pluginVersion": "9.1.0",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "sum(rate(vm_tcpdialer_read_bytes_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) * 8 > 0",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "read",
+                                "range": true,
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "sum(rate(vm_tcpdialer_written_bytes_total{job=~\"$job_select\", instance=~\"$instance\"}[$__rate_interval])) * 8 > 0",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 1,
+                                "legendFormat": "write ",
+                                "range": true,
+                                "refId": "B"
+                            }
+                        ],
+                        "title": "Network usage: vmstorage ($instance)",
                         "type": "timeseries"
                     }
                 ],
@@ -7251,7 +7703,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 24
+                            "y": 51
                         },
                         "id": 97,
                         "links": [],
@@ -7377,7 +7829,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 24
+                            "y": 51
                         },
                         "id": 99,
                         "links": [],
@@ -7501,7 +7953,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 32
+                            "y": 59
                         },
                         "id": 185,
                         "links": [],
@@ -7645,7 +8097,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 32
+                            "y": 59
                         },
                         "id": 187,
                         "links": [],
@@ -7725,219 +8177,6 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "",
-                        "fieldConfig": {
-                            "defaults": {
-                                "color": {
-                                    "mode": "palette-classic"
-                                },
-                                "custom": {
-                                    "axisCenteredZero": false,
-                                    "axisColorMode": "text",
-                                    "axisLabel": "",
-                                    "axisPlacement": "auto",
-                                    "barAlignment": 0,
-                                    "drawStyle": "line",
-                                    "fillOpacity": 0,
-                                    "gradientMode": "none",
-                                    "hideFrom": {
-                                        "legend": false,
-                                        "tooltip": false,
-                                        "viz": false
-                                    },
-                                    "lineInterpolation": "linear",
-                                    "lineWidth": 1,
-                                    "pointSize": 5,
-                                    "scaleDistribution": {
-                                        "type": "linear"
-                                    },
-                                    "showPoints": "never",
-                                    "spanNulls": false,
-                                    "stacking": {
-                                        "group": "A",
-                                        "mode": "normal"
-                                    },
-                                    "thresholdsStyle": {
-                                        "mode": "off"
-                                    }
-                                },
-                                "links": [],
-                                "mappings": [],
-                                "thresholds": {
-                                    "mode": "absolute",
-                                    "steps": [
-                                        {
-                                            "color": "green"
-                                        },
-                                        {
-                                            "color": "red",
-                                            "value": 80
-                                        }
-                                    ]
-                                },
-                                "unit": "bps"
-                            },
-                            "overrides": []
-                        },
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 0,
-                            "y": 40
-                        },
-                        "id": 90,
-                        "links": [],
-                        "options": {
-                            "legend": {
-                                "calcs": [
-                                    "mean",
-                                    "lastNotNull",
-                                    "max"
-                                ],
-                                "displayMode": "table",
-                                "placement": "bottom",
-                                "showLegend": true,
-                                "sortBy": "Last *",
-                                "sortDesc": true
-                            },
-                            "tooltip": {
-                                "mode": "multi",
-                                "sort": "desc"
-                            }
-                        },
-                        "pluginVersion": "9.1.0",
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "type": "prometheus",
-                                    "uid": "$ds"
-                                },
-                                "editorMode": "code",
-                                "exemplar": true,
-                                "expr": "sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval])) * 8 > 0",
-                                "format": "time_series",
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "read",
-                                "range": true,
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Network usage ($instance)",
-                        "type": "timeseries"
-                    },
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "$ds"
-                        },
-                        "description": "",
-                        "fieldConfig": {
-                            "defaults": {
-                                "color": {
-                                    "mode": "palette-classic"
-                                },
-                                "custom": {
-                                    "axisCenteredZero": false,
-                                    "axisColorMode": "text",
-                                    "axisLabel": "",
-                                    "axisPlacement": "auto",
-                                    "barAlignment": 0,
-                                    "drawStyle": "line",
-                                    "fillOpacity": 0,
-                                    "gradientMode": "none",
-                                    "hideFrom": {
-                                        "legend": false,
-                                        "tooltip": false,
-                                        "viz": false
-                                    },
-                                    "lineInterpolation": "linear",
-                                    "lineWidth": 1,
-                                    "pointSize": 5,
-                                    "scaleDistribution": {
-                                        "type": "linear"
-                                    },
-                                    "showPoints": "never",
-                                    "spanNulls": false,
-                                    "stacking": {
-                                        "group": "A",
-                                        "mode": "none"
-                                    },
-                                    "thresholdsStyle": {
-                                        "mode": "off"
-                                    }
-                                },
-                                "decimals": 2,
-                                "links": [],
-                                "mappings": [],
-                                "min": 0,
-                                "thresholds": {
-                                    "mode": "absolute",
-                                    "steps": [
-                                        {
-                                            "color": "green"
-                                        },
-                                        {
-                                            "color": "red",
-                                            "value": 80
-                                        }
-                                    ]
-                                },
-                                "unit": "short"
-                            },
-                            "overrides": []
-                        },
-                        "gridPos": {
-                            "h": 8,
-                            "w": 12,
-                            "x": 12,
-                            "y": 40
-                        },
-                        "id": 88,
-                        "links": [],
-                        "options": {
-                            "legend": {
-                                "calcs": [
-                                    "mean",
-                                    "lastNotNull",
-                                    "max"
-                                ],
-                                "displayMode": "table",
-                                "placement": "bottom",
-                                "showLegend": true,
-                                "sortBy": "Last *",
-                                "sortDesc": true
-                            },
-                            "tooltip": {
-                                "mode": "multi",
-                                "sort": "desc"
-                            }
-                        },
-                        "pluginVersion": "9.1.0",
-                        "targets": [
-                            {
-                                "datasource": {
-                                    "type": "prometheus",
-                                    "uid": "$ds"
-                                },
-                                "editorMode": "code",
-                                "expr": "max(histogram_quantile(0.99, sum(increase(vm_rows_per_insert_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange)))",
-                                "format": "time_series",
-                                "interval": "",
-                                "intervalFactor": 1,
-                                "legendFormat": "max",
-                                "range": true,
-                                "refId": "A"
-                            }
-                        ],
-                        "title": "Rows per insert ($instance)",
-                        "type": "timeseries"
-                    },
-                    {
-                        "datasource": {
-                            "type": "prometheus",
-                            "uid": "$ds"
-                        },
                         "description": "Shows the saturation level of connection between vminsert and vmstorage components. If the threshold of 0.9sec is reached, then the connection is saturated by more than 90% and vminsert won't be able to keep up. This usually means that more vminsert or vmstorage nodes must be added to the cluster in order to increase the total number of vminsert -> vmstorage links.\n",
                         "fieldConfig": {
                             "defaults": {
@@ -7998,7 +8237,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 48
+                            "y": 67
                         },
                         "id": 139,
                         "links": [],
@@ -8105,7 +8344,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 48
+                            "y": 67
                         },
                         "id": 114,
                         "links": [],
@@ -8143,6 +8382,373 @@ data:
                         ],
                         "title": "Storage reachability ($instance)",
                         "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows network usage between vminserts and clients, such as vmagent, Prometheus, or any other client pushing metrics to vminsert.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "links": [],
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "bps"
+                            },
+                            "overrides": [
+                                {
+                                    "matcher": {
+                                        "id": "byRegexp",
+                                        "options": "/read.*/"
+                                    },
+                                    "properties": [
+                                        {
+                                            "id": "custom.transform",
+                                            "value": "negative-Y"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 75
+                        },
+                        "id": 208,
+                        "links": [],
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true,
+                                "sortBy": "Last *",
+                                "sortDesc": true
+                            },
+                            "tooltip": {
+                                "mode": "multi",
+                                "sort": "desc"
+                            }
+                        },
+                        "pluginVersion": "9.1.0",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval])) * 8 > 0",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "read",
+                                "range": true,
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "sum(rate(vm_tcplistener_written_bytes_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval])) * 8 > 0",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 1,
+                                "legendFormat": "write ",
+                                "range": true,
+                                "refId": "B"
+                            }
+                        ],
+                        "title": "Network usage: clients ($instance)",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows network usage between vminserts and vmstorages.",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "links": [],
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "bps"
+                            },
+                            "overrides": [
+                                {
+                                    "matcher": {
+                                        "id": "byRegexp",
+                                        "options": "/read.*/"
+                                    },
+                                    "properties": [
+                                        {
+                                            "id": "custom.transform",
+                                            "value": "negative-Y"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 75
+                        },
+                        "id": 209,
+                        "links": [],
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true,
+                                "sortBy": "Last *",
+                                "sortDesc": true
+                            },
+                            "tooltip": {
+                                "mode": "multi",
+                                "sort": "desc"
+                            }
+                        },
+                        "pluginVersion": "9.1.0",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "sum(rate(vm_tcpdialer_read_bytes_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval])) * 8 > 0",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "read",
+                                "range": true,
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "sum(rate(vm_tcpdialer_written_bytes_total{job=~\"$job_insert\", instance=~\"$instance\"}[$__rate_interval])) * 8 > 0",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 1,
+                                "legendFormat": "write ",
+                                "range": true,
+                                "refId": "B"
+                            }
+                        ],
+                        "title": "Network usage: vmstorage ($instance)",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "decimals": 2,
+                                "links": [],
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 12,
+                            "y": 83
+                        },
+                        "id": 88,
+                        "links": [],
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull",
+                                    "max"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true,
+                                "sortBy": "Last *",
+                                "sortDesc": true
+                            },
+                            "tooltip": {
+                                "mode": "multi",
+                                "sort": "desc"
+                            }
+                        },
+                        "pluginVersion": "9.1.0",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "max(histogram_quantile(0.99, sum(increase(vm_rows_per_insert_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, vmrange)))",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 1,
+                                "legendFormat": "max",
+                                "range": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Rows per insert ($instance)",
+                        "type": "timeseries"
                     }
                 ],
                 "title": "vminsert ($instance)",
@@ -8167,7 +8773,7 @@ data:
                             "h": 2,
                             "w": 24,
                             "x": 0,
-                            "y": 84
+                            "y": 100
                         },
                         "id": 198,
                         "options": {
@@ -8231,8 +8837,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         }
                                     ]
                                 },
@@ -8244,7 +8849,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 86
+                            "y": 102
                         },
                         "id": 189,
                         "links": [],
@@ -8333,8 +8938,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         }
                                     ]
                                 },
@@ -8346,7 +8950,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 86
+                            "y": 102
                         },
                         "id": 190,
                         "links": [],
@@ -8435,8 +9039,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         }
                                     ]
                                 },
@@ -8448,7 +9051,7 @@ data:
                             "h": 7,
                             "w": 12,
                             "x": 0,
-                            "y": 94
+                            "y": 110
                         },
                         "id": 192,
                         "links": [],
@@ -8539,8 +9142,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -8556,7 +9158,7 @@ data:
                             "h": 7,
                             "w": 12,
                             "x": 12,
-                            "y": 94
+                            "y": 110
                         },
                         "id": 196,
                         "links": [],
@@ -8646,8 +9248,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         }
                                     ]
                                 },
@@ -8659,7 +9260,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 101
+                            "y": 117
                         },
                         "id": 200,
                         "links": [],
@@ -8748,8 +9349,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         }
                                     ]
                                 },
@@ -8761,7 +9361,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 101
+                            "y": 117
                         },
                         "id": 201,
                         "links": [],
@@ -8864,8 +9464,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -8881,7 +9480,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 109
+                            "y": 125
                         },
                         "id": 203,
                         "links": [],
@@ -8930,9 +9529,8 @@ data:
                 "type": "row"
             }
         ],
-        "refresh": false,
-        "schemaVersion": 37,
-        "style": "dark",
+        "refresh": "",
+        "schemaVersion": 39,
         "tags": [
             "vm-k8s-stack"
         ],
@@ -8940,9 +9538,9 @@ data:
             "list": [
                 {
                     "current": {
-                        "selected": true,
-                        "text": "VictoriaMetrics",
-                        "value": "VictoriaMetrics"
+                        "selected": false,
+                        "text": "VictoriaMetrics - cluster",
+                        "value": "PAF93674D0B4E9963"
                     },
                     "hide": 0,
                     "includeAll": false,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/victoriametrics.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "victoriametrics" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "victoriametrics" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
@@ -55,7 +55,7 @@ data:
                 "type": "grafana",
                 "id": "grafana",
                 "name": "Grafana",
-                "version": "9.2.7"
+                "version": "10.3.1"
             },
             {
                 "type": "datasource",
@@ -125,7 +125,7 @@ data:
                         "uid": "$ds"
                     },
                     "enable": true,
-                    "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset 20m) by(short_versionversion))",
+                    "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset 20m) by(version))",
                     "hide": true,
                     "iconColor": "dark-blue",
                     "name": "version",
@@ -134,7 +134,7 @@ data:
                 }
             ]
         },
-        "description": "Overview for single node VictoriaMetrics v1.83.0 or higher",
+        "description": "Overview for single-node VictoriaMetrics v1.83.0 or higher",
         "editable": false,
         "fiscalYearStartMonth": 0,
         "gnetId": 10229,
@@ -217,7 +217,7 @@ data:
                     "content": "<div style=\"text-align: center;\">$version</div>",
                     "mode": "markdown"
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -251,7 +251,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -276,10 +277,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -320,7 +323,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -345,10 +349,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -390,7 +396,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -415,10 +422,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -464,7 +473,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -489,10 +499,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -536,7 +548,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "s"
+                        "unit": "s",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -559,10 +572,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -602,7 +617,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -627,10 +643,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -671,7 +689,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "bytes"
+                        "unit": "bytes",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -696,10 +715,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -741,7 +762,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "bytes"
+                        "unit": "bytes",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -766,10 +788,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -811,7 +835,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "bytes"
+                        "unit": "bytes",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -836,10 +861,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -896,6 +923,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -909,6 +937,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -941,7 +970,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1001,6 +1031,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1014,6 +1045,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1046,7 +1078,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1108,6 +1141,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1121,6 +1155,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1153,7 +1188,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1216,6 +1252,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1229,6 +1266,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1261,7 +1299,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "s"
+                        "unit": "s",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1358,8 +1397,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1461,8 +1499,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1541,6 +1578,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1554,6 +1592,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1586,7 +1625,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1594,7 +1634,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 31
+                            "y": 3
                         },
                         "id": 112,
                         "links": [],
@@ -1647,6 +1687,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1660,6 +1701,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1692,7 +1734,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "bytes"
+                                "unit": "bytes",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1700,7 +1743,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 31
+                            "y": 3
                         },
                         "id": 44,
                         "links": [],
@@ -1803,6 +1846,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1816,6 +1860,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1848,7 +1893,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1856,7 +1902,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 39
+                            "y": 11
                         },
                         "id": 123,
                         "links": [],
@@ -1908,6 +1954,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1921,6 +1968,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1953,7 +2001,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1961,7 +2010,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 39
+                            "y": 11
                         },
                         "id": 114,
                         "links": [],
@@ -2016,6 +2065,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2029,6 +2079,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2062,7 +2113,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": [
                                 {
@@ -2086,7 +2138,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 47
+                            "y": 19
                         },
                         "id": 75,
                         "links": [],
@@ -2141,6 +2193,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2154,6 +2207,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2186,7 +2240,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": [
                                 {
@@ -2210,7 +2265,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 47
+                            "y": 19
                         },
                         "id": 57,
                         "links": [],
@@ -2275,6 +2330,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2288,6 +2344,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2321,7 +2378,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2329,7 +2387,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 55
+                            "y": 27
                         },
                         "id": 47,
                         "links": [],
@@ -2382,6 +2440,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2395,6 +2454,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2426,7 +2486,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "bytes"
+                                "unit": "bytes",
+                                "unitScale": true
                             },
                             "overrides": [
                                 {
@@ -2447,7 +2508,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 55
+                            "y": 27
                         },
                         "id": 76,
                         "links": [],
@@ -2512,6 +2573,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2525,6 +2587,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2558,7 +2621,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2566,7 +2630,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 63
+                            "y": 35
                         },
                         "id": 48,
                         "links": [],
@@ -2619,6 +2683,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2632,6 +2697,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2663,7 +2729,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": [
                                 {
@@ -2684,7 +2751,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 63
+                            "y": 35
                         },
                         "id": 124,
                         "links": [],
@@ -2754,6 +2821,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2767,6 +2835,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2799,7 +2868,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2807,7 +2877,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 71
+                            "y": 43
                         },
                         "id": 49,
                         "links": [],
@@ -2861,6 +2931,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2874,6 +2945,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2906,7 +2978,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2914,7 +2987,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 71
+                            "y": 43
                         },
                         "id": 37,
                         "links": [],
@@ -2954,6 +3027,115 @@ data:
                             }
                         ],
                         "title": "TCP connections ($instance)",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the percent of CPU spent on garbage collection.\n\nIf % is high, then CPU usage can be decreased by changing GOGC to higher values. Increasing GOGC value will increase memory usage, and decrease CPU usage.\n\nTry searching for keyword `GOGC` at https://docs.victoriametrics.com/troubleshooting/ ",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "decimals": 0,
+                                "links": [],
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "percentunit",
+                                "unitScale": true
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 51
+                        },
+                        "id": 125,
+                        "links": [],
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull",
+                                    "max"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "mode": "multi",
+                                "sort": "desc"
+                            }
+                        },
+                        "pluginVersion": "9.2.6",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(instance)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "__auto",
+                                "range": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "CPU spent on GC ($instance)",
                         "type": "timeseries"
                     }
                 ],
@@ -3047,7 +3229,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 8
+                            "y": 16
                         },
                         "id": 66,
                         "options": {
@@ -3159,7 +3341,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 8
+                            "y": 16
                         },
                         "id": 68,
                         "links": [],
@@ -3266,7 +3448,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 16
+                            "y": 24
                         },
                         "id": 116,
                         "links": [],
@@ -3371,7 +3553,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 16
+                            "y": 24
                         },
                         "id": 60,
                         "links": [],
@@ -3473,7 +3655,7 @@ data:
                             "h": 9,
                             "w": 12,
                             "x": 0,
-                            "y": 24
+                            "y": 32
                         },
                         "id": 90,
                         "options": {
@@ -3578,7 +3760,7 @@ data:
                             "h": 9,
                             "w": 12,
                             "x": 12,
-                            "y": 24
+                            "y": 32
                         },
                         "id": 118,
                         "links": [],
@@ -3634,7 +3816,9 @@ data:
                                 },
                                 "custom": {
                                     "align": "auto",
-                                    "displayMode": "auto",
+                                    "cellOptions": {
+                                        "type": "auto"
+                                    },
                                     "inspect": false
                                 },
                                 "mappings": [],
@@ -3682,7 +3866,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 33
+                            "y": 41
                         },
                         "id": 120,
                         "options": {
@@ -3749,7 +3933,7 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
-                        "description": "VictoriaMetrics limits the number of labels per each metric with `-maxLabelsPerTimeseries` command-line flag.\n\nThis prevents from ingesting metrics with too many labels. The value of `maxLabelsPerTimeseries` must be adjusted for your workload.\n\nWhen limit is exceeded (graph is > 0) - extra labels are dropped, which could result in unexpected identical time series.",
+                        "description": "VictoriaMetrics limits the number of labels per each metric with `-maxLabelsPerTimeseries` command-line flag.\n\nThis prevents from ingesting metrics with too many labels. The value of `maxLabelsPerTimeseries` must be adjusted for your workload.\n\nWhen limit is exceeded (graph is > 0) - extra labels are dropped, which could result in unexpected identical time series. See more details about dropped labels in logs.",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {
@@ -3809,7 +3993,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 33
+                            "y": 41
                         },
                         "id": 74,
                         "links": [],
@@ -3924,8 +4108,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -3941,7 +4124,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 33
+                            "y": 41
                         },
                         "id": 10,
                         "links": [],
@@ -4031,8 +4214,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -4048,7 +4230,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 33
+                            "y": 41
                         },
                         "id": 73,
                         "links": [],
@@ -4139,8 +4321,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -4156,7 +4337,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 41
+                            "y": 49
                         },
                         "id": 53,
                         "links": [],
@@ -4273,8 +4454,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -4307,7 +4487,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 41
+                            "y": 49
                         },
                         "id": 34,
                         "links": [],
@@ -4407,8 +4587,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -4441,7 +4620,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 49
+                            "y": 57
                         },
                         "id": 30,
                         "links": [],
@@ -4542,8 +4721,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -4559,7 +4737,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 49
+                            "y": 57
                         },
                         "id": 36,
                         "links": [],
@@ -4646,8 +4824,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -4663,7 +4840,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 57
+                            "y": 65
                         },
                         "id": 58,
                         "links": [],
@@ -4754,8 +4931,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -4771,7 +4947,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 57
+                            "y": 65
                         },
                         "id": 62,
                         "options": {
@@ -4854,8 +5030,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -4887,7 +5062,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 65
+                            "y": 73
                         },
                         "id": 59,
                         "links": [],
@@ -4986,8 +5161,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -5003,7 +5177,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 65
+                            "y": 73
                         },
                         "id": 64,
                         "options": {
@@ -5088,8 +5262,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -5105,7 +5278,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 73
+                            "y": 81
                         },
                         "id": 99,
                         "links": [],
@@ -5196,8 +5369,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -5213,7 +5385,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 73
+                            "y": 81
                         },
                         "id": 103,
                         "links": [],
@@ -5304,8 +5476,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -5321,7 +5492,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 81
+                            "y": 89
                         },
                         "id": 122,
                         "links": [],
@@ -5412,8 +5583,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -5429,7 +5599,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 81
+                            "y": 89
                         },
                         "id": 105,
                         "links": [],
@@ -5485,9 +5655,8 @@ data:
                 "type": "row"
             }
         ],
-        "refresh": false,
-        "schemaVersion": 37,
-        "style": "dark",
+        "refresh": "",
+        "schemaVersion": 39,
         "tags": [
             "victoriametrics",
             "vmsingle",
@@ -5499,7 +5668,7 @@ data:
                     "current": {
                         "selected": false,
                         "text": "VictoriaMetrics",
-                        "value": "VictoriaMetrics"
+                        "value": "P4169E866C3094E38"
                     },
                     "hide": 0,
                     "includeAll": false,
@@ -5618,7 +5787,7 @@ data:
             ]
         },
         "time": {
-            "from": "now-30m",
+            "from": "now-3h",
             "to": "now"
         },
         "timepicker": {
@@ -5646,7 +5815,7 @@ data:
             ]
         },
         "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
-        "title": "VictoriaMetrics",
+        "title": "VictoriaMetrics - single-node",
         "uid": "wNf0q_kZk",
         "version": 1,
         "weekStart": ""

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmagent.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "vmagent" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "vmagent" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
@@ -55,7 +55,7 @@ data:
                 "type": "grafana",
                 "id": "grafana",
                 "name": "Grafana",
-                "version": "9.2.7"
+                "version": "10.3.1"
             },
             {
                 "type": "datasource",
@@ -199,7 +199,8 @@ data:
                                     "value": null
                                 }
                             ]
-                        }
+                        },
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -228,10 +229,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -266,7 +269,8 @@ data:
                                     "value": null
                                 }
                             ]
-                        }
+                        },
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -295,10 +299,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -321,9 +327,10 @@ data:
                     "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                     "uid": "$ds"
                 },
-                "description": "Shows total number of all configured scrape targets in state \"up\".\n\nSee `http://vmagent-host:8429/targets` to get list of all targets. \n",
+                "description": "Shows the number of targets scraped per second.",
                 "fieldConfig": {
                     "defaults": {
+                        "decimals": 1,
                         "mappings": [],
                         "thresholds": {
                             "mode": "absolute",
@@ -333,7 +340,8 @@ data:
                                     "value": null
                                 }
                             ]
-                        }
+                        },
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -343,10 +351,11 @@ data:
                     "x": 8,
                     "y": 1
                 },
-                "id": 9,
+                "id": 134,
+                "links": [],
                 "options": {
                     "colorMode": "value",
-                    "graphMode": "area",
+                    "graphMode": "none",
                     "justifyMode": "auto",
                     "orientation": "auto",
                     "reduceOptions": {
@@ -356,23 +365,27 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "$ds"
                         },
-                        "expr": "sum(vm_promscrape_targets{job=~\"$job\", instance=~\"$instance\", status=\"up\"})",
+                        "editorMode": "code",
+                        "expr": "sum(rate(vm_promscrape_scrapes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) ",
                         "interval": "",
-                        "legendFormat": "up",
+                        "legendFormat": "__auto",
+                        "range": true,
                         "refId": "A"
                     }
                 ],
-                "title": "Scrape targets up",
+                "title": "Targets scraped/s",
                 "type": "stat"
             },
             {
@@ -380,7 +393,7 @@ data:
                     "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                     "uid": "$ds"
                 },
-                "description": "Shows total number of all configured scrape targets in state \"down\".\n\nSee `http://vmagent-host:8429/targets` to get list of all targets. \n",
+                "description": "Shows total number of all configured scrape targets in state `up` or `down`.\n\nSee `http://vmagent-host:8429/targets` to get list of all targets. \n",
                 "fieldConfig": {
                     "defaults": {
                         "mappings": [],
@@ -390,15 +403,37 @@ data:
                                 {
                                     "color": "green",
                                     "value": null
-                                },
+                                }
+                            ]
+                        },
+                        "unitScale": true
+                    },
+                    "overrides": [
+                        {
+                            "matcher": {
+                                "id": "byName",
+                                "options": "down"
+                            },
+                            "properties": [
                                 {
-                                    "color": "red",
-                                    "value": 1
+                                    "id": "thresholds",
+                                    "value": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "color": "green",
+                                                "value": null
+                                            },
+                                            {
+                                                "color": "red",
+                                                "value": 1
+                                            }
+                                        ]
+                                    }
                                 }
                             ]
                         }
-                    },
-                    "overrides": []
+                    ]
                 },
                 "gridPos": {
                     "h": 3,
@@ -425,23 +460,40 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
                             "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
                             "uid": "$ds"
                         },
-                        "expr": "sum(vm_promscrape_targets{job=~\"$job\", instance=~\"$instance\", status=\"down\"})",
+                        "editorMode": "code",
+                        "expr": "sum(vm_promscrape_targets{job=~\"$job\", instance=~\"$instance\", status=\"up\"})",
                         "interval": "",
                         "legendFormat": "up",
+                        "range": true,
                         "refId": "A"
+                    },
+                    {
+                        "datasource": {
+                            "type": "{{ default "prometheus" .Values.grafana.defaultDatasourceType }}",
+                            "uid": "$ds"
+                        },
+                        "editorMode": "code",
+                        "expr": "sum(vm_promscrape_targets{job=~\"$job\", instance=~\"$instance\", status=\"down\"})",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "down",
+                        "range": true,
+                        "refId": "B"
                     }
                 ],
-                "title": "Scrape targets down",
+                "title": "Scrape targets",
                 "type": "stat"
             },
             {
@@ -467,7 +519,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -497,10 +550,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -538,7 +593,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "bytes"
+                        "unit": "bytes",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -561,10 +617,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -592,7 +650,9 @@ data:
                         },
                         "custom": {
                             "align": "auto",
-                            "displayMode": "auto",
+                            "cellOptions": {
+                                "type": "auto"
+                            },
                             "inspect": false,
                             "minWidth": 50
                         },
@@ -609,7 +669,8 @@ data:
                                     "value": 80
                                 }
                             ]
-                        }
+                        },
+                        "unitScale": true
                     },
                     "overrides": [
                         {
@@ -646,7 +707,9 @@ data:
                 },
                 "id": 101,
                 "options": {
+                    "cellHeight": "sm",
                     "footer": {
+                        "countRows": false,
                         "fields": "",
                         "reducer": [
                             "sum"
@@ -655,7 +718,7 @@ data:
                     },
                     "showHeader": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -684,6 +747,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -697,6 +761,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "stepAfter",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -730,7 +795,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -814,6 +880,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -827,6 +894,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -863,7 +931,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": [
                         {
@@ -948,6 +1017,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -961,6 +1031,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -999,7 +1070,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "bytes"
+                        "unit": "bytes",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1065,6 +1137,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1078,6 +1151,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1110,7 +1184,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1174,6 +1249,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1187,6 +1263,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1219,7 +1296,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "decbytes"
+                        "unit": "decbytes",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1283,6 +1361,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1296,6 +1375,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1328,7 +1408,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1386,6 +1467,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1399,6 +1481,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1431,7 +1514,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1557,6 +1641,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1570,6 +1655,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1599,7 +1685,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -1607,7 +1694,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1615,7 +1703,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 11
+                            "y": 3
                         },
                         "id": 109,
                         "links": [],
@@ -1670,6 +1758,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1683,6 +1772,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1712,7 +1802,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -1720,7 +1811,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1728,7 +1820,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 11
+                            "y": 3
                         },
                         "id": 111,
                         "links": [],
@@ -1781,6 +1873,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1794,6 +1887,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1822,7 +1916,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -1830,7 +1925,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "bytes"
+                                "unit": "bytes",
+                                "unitScale": true
                             },
                             "overrides": [
                                 {
@@ -1851,7 +1947,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 19
+                            "y": 11
                         },
                         "id": 81,
                         "links": [],
@@ -1921,6 +2017,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1934,6 +2031,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1956,7 +2054,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -1964,7 +2063,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "bps"
+                                "unit": "bps",
+                                "unitScale": true
                             },
                             "overrides": [
                                 {
@@ -1985,7 +2085,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 19
+                            "y": 11
                         },
                         "id": 7,
                         "options": {
@@ -2048,6 +2148,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2061,6 +2162,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2085,7 +2187,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -2093,7 +2196,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2101,7 +2205,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 27
+                            "y": 19
                         },
                         "id": 83,
                         "links": [],
@@ -2152,6 +2256,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2165,6 +2270,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2189,7 +2295,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -2197,7 +2304,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2205,7 +2313,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 27
+                            "y": 19
                         },
                         "id": 39,
                         "links": [],
@@ -2250,12 +2358,14 @@ data:
                             "type": "prometheus",
                             "uid": "$ds"
                         },
+                        "description": "Shows the percent of CPU spent on garbage collection.\n\nIf % is high, then CPU usage can be decreased by changing GOGC to higher values. Increasing GOGC value will increase memory usage, and decrease CPU usage.\n\nTry searching for keyword `GOGC` at https://docs.victoriametrics.com/troubleshooting/ ",
                         "fieldConfig": {
                             "defaults": {
                                 "color": {
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -2269,6 +2379,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2293,7 +2404,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -2301,7 +2413,116 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "percentunit",
+                                "unitScale": true
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 27
+                        },
+                        "id": 135,
+                        "links": [],
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull",
+                                    "max"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "mode": "multi",
+                                "sort": "desc"
+                            }
+                        },
+                        "pluginVersion": "9.2.6",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(job)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "__auto",
+                                "range": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "CPU spent on GC ($instance)",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "decimals": 0,
+                                "links": [],
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2309,7 +2530,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 35
+                            "y": 27
                         },
                         "id": 41,
                         "links": [],
@@ -3221,7 +3442,9 @@ data:
                                 },
                                 "custom": {
                                     "align": "auto",
-                                    "displayMode": "auto",
+                                    "cellOptions": {
+                                        "type": "auto"
+                                    },
                                     "inspect": false
                                 },
                                 "mappings": [],
@@ -3370,6 +3593,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -3383,6 +3607,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -3406,7 +3631,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -3414,7 +3640,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -3422,7 +3649,7 @@ data:
                             "h": 7,
                             "w": 12,
                             "x": 0,
-                            "y": 45
+                            "y": 37
                         },
                         "id": 48,
                         "options": {
@@ -3474,6 +3701,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -3487,6 +3715,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -3510,7 +3739,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -3518,7 +3748,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -3526,7 +3757,7 @@ data:
                             "h": 7,
                             "w": 12,
                             "x": 12,
-                            "y": 45
+                            "y": 37
                         },
                         "id": 76,
                         "options": {
@@ -3576,6 +3807,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -3589,6 +3821,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -3612,7 +3845,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -3620,7 +3854,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -3628,7 +3863,7 @@ data:
                             "h": 7,
                             "w": 12,
                             "x": 0,
-                            "y": 45
+                            "y": 44
                         },
                         "id": 132,
                         "options": {
@@ -3680,6 +3915,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -3693,6 +3929,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -3716,7 +3953,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -3724,7 +3962,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -3732,7 +3971,7 @@ data:
                             "h": 7,
                             "w": 12,
                             "x": 12,
-                            "y": 45
+                            "y": 44
                         },
                         "id": 133,
                         "options": {
@@ -3783,6 +4022,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -3796,6 +4036,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -3819,7 +4060,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -3827,7 +4069,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -3835,7 +4078,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 52
+                            "y": 51
                         },
                         "id": 20,
                         "options": {
@@ -3885,6 +4128,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -3898,6 +4142,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -3921,7 +4166,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -3929,7 +4175,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -3937,7 +4184,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 52
+                            "y": 51
                         },
                         "id": 126,
                         "options": {
@@ -3986,6 +4233,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -3999,6 +4247,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -4022,7 +4271,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -4030,7 +4280,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "bytes"
+                                "unit": "bytes",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -4038,7 +4289,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 60
+                            "y": 59
                         },
                         "id": 46,
                         "options": {
@@ -4087,6 +4338,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -4100,6 +4352,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -4123,7 +4376,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -4131,7 +4385,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -4139,7 +4394,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 60
+                            "y": 59
                         },
                         "id": 31,
                         "options": {
@@ -4300,8 +4555,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -4417,8 +4671,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -4521,8 +4774,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -4638,8 +4890,7 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green",
-                                            "value": null
+                                            "color": "green"
                                         },
                                         {
                                             "color": "red",
@@ -6063,8 +6314,7 @@ data:
             }
         ],
         "refresh": "",
-        "schemaVersion": 37,
-        "style": "dark",
+        "schemaVersion": 39,
         "tags": [
             "vmagent",
             "victoriametrics",
@@ -6074,9 +6324,9 @@ data:
             "list": [
                 {
                     "current": {
-                        "selected": true,
+                        "selected": false,
                         "text": "VictoriaMetrics",
-                        "value": "VictoriaMetrics"
+                        "value": "P4169E866C3094E38"
                     },
                     "hide": 0,
                     "includeAll": false,

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmalert.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboards/vmalert.yaml
@@ -9,7 +9,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "vmalert" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "vmalert" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}-grafana
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
@@ -55,7 +55,7 @@ data:
                 "type": "grafana",
                 "id": "grafana",
                 "name": "Grafana",
-                "version": "9.2.7"
+                "version": "10.3.1"
             },
             {
                 "type": "datasource",
@@ -227,7 +227,8 @@ data:
                                     "value": null
                                 }
                             ]
-                        }
+                        },
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -250,10 +251,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -287,7 +290,8 @@ data:
                                     "value": null
                                 }
                             ]
-                        }
+                        },
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -310,10 +314,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -347,7 +353,8 @@ data:
                                     "value": null
                                 }
                             ]
-                        }
+                        },
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -370,10 +377,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -411,7 +420,8 @@ data:
                                     "value": 1
                                 }
                             ]
-                        }
+                        },
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -434,10 +444,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -475,7 +487,8 @@ data:
                                     "value": 1
                                 }
                             ]
-                        }
+                        },
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -498,10 +511,12 @@ data:
                         "fields": "",
                         "values": false
                     },
+                    "showPercentChange": false,
                     "text": {},
-                    "textMode": "auto"
+                    "textMode": "auto",
+                    "wideLayout": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -532,7 +547,9 @@ data:
                         },
                         "custom": {
                             "align": "auto",
-                            "displayMode": "auto",
+                            "cellOptions": {
+                                "type": "auto"
+                            },
                             "inspect": false,
                             "minWidth": 50
                         },
@@ -549,7 +566,8 @@ data:
                                     "value": 80
                                 }
                             ]
-                        }
+                        },
+                        "unitScale": true
                     },
                     "overrides": [
                         {
@@ -586,7 +604,9 @@ data:
                 },
                 "id": 45,
                 "options": {
+                    "cellHeight": "sm",
                     "footer": {
+                        "countRows": false,
                         "fields": "",
                         "reducer": [
                             "sum"
@@ -595,7 +615,7 @@ data:
                     },
                     "showHeader": true
                 },
-                "pluginVersion": "9.2.7",
+                "pluginVersion": "10.3.1",
                 "targets": [
                     {
                         "datasource": {
@@ -624,6 +644,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -637,6 +658,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "stepAfter",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -670,7 +692,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -755,6 +778,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -768,6 +792,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -798,7 +823,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -858,6 +884,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -871,6 +898,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -901,7 +929,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "s"
+                        "unit": "s",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -961,6 +990,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -974,6 +1004,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1004,7 +1035,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1062,6 +1094,7 @@ data:
                             "mode": "palette-classic"
                         },
                         "custom": {
+                            "axisBorderShow": false,
                             "axisCenteredZero": false,
                             "axisColorMode": "text",
                             "axisLabel": "",
@@ -1075,6 +1108,7 @@ data:
                                 "tooltip": false,
                                 "viz": false
                             },
+                            "insertNulls": false,
                             "lineInterpolation": "linear",
                             "lineWidth": 1,
                             "pointSize": 5,
@@ -1105,7 +1139,8 @@ data:
                                 }
                             ]
                         },
-                        "unit": "short"
+                        "unit": "short",
+                        "unitScale": true
                     },
                     "overrides": []
                 },
@@ -1163,7 +1198,9 @@ data:
                         },
                         "custom": {
                             "align": "auto",
-                            "displayMode": "auto",
+                            "cellOptions": {
+                                "type": "auto"
+                            },
                             "inspect": false
                         },
                         "mappings": [],
@@ -1171,8 +1208,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1324,8 +1360,7 @@ data:
                             "mode": "absolute",
                             "steps": [
                                 {
-                                    "color": "green",
-                                    "value": null
+                                    "color": "green"
                                 },
                                 {
                                     "color": "red",
@@ -1405,6 +1440,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1418,6 +1454,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1441,7 +1478,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -1449,7 +1487,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1457,7 +1496,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 33
+                            "y": 3
                         },
                         "id": 37,
                         "links": [
@@ -1516,6 +1555,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1529,6 +1569,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1552,7 +1593,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -1560,7 +1602,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "bytes"
+                                "unit": "bytes",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1568,7 +1611,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 33
+                            "y": 3
                         },
                         "id": 57,
                         "links": [
@@ -1627,6 +1670,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1640,6 +1684,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1663,7 +1708,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -1671,7 +1717,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1679,7 +1726,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 41
+                            "y": 11
                         },
                         "id": 35,
                         "links": [
@@ -1740,6 +1787,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1753,6 +1801,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1776,7 +1825,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -1784,7 +1834,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1792,7 +1843,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 41
+                            "y": 11
                         },
                         "id": 56,
                         "links": [
@@ -1869,6 +1920,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1882,6 +1934,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -1906,7 +1959,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -1914,7 +1968,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "percentunit"
+                                "unit": "percentunit",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -1922,7 +1977,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 49
+                            "y": 19
                         },
                         "id": 39,
                         "links": [],
@@ -1974,6 +2029,7 @@ data:
                                     "mode": "palette-classic"
                                 },
                                 "custom": {
+                                    "axisBorderShow": false,
                                     "axisCenteredZero": false,
                                     "axisColorMode": "text",
                                     "axisLabel": "",
@@ -1987,6 +2043,7 @@ data:
                                         "tooltip": false,
                                         "viz": false
                                     },
+                                    "insertNulls": false,
                                     "lineInterpolation": "linear",
                                     "lineWidth": 1,
                                     "pointSize": 5,
@@ -2011,7 +2068,8 @@ data:
                                     "mode": "absolute",
                                     "steps": [
                                         {
-                                            "color": "green"
+                                            "color": "green",
+                                            "value": null
                                         },
                                         {
                                             "color": "red",
@@ -2019,7 +2077,8 @@ data:
                                         }
                                     ]
                                 },
-                                "unit": "short"
+                                "unit": "short",
+                                "unitScale": true
                             },
                             "overrides": []
                         },
@@ -2027,7 +2086,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 49
+                            "y": 19
                         },
                         "id": 41,
                         "links": [],
@@ -2065,6 +2124,115 @@ data:
                             }
                         ],
                         "title": "Goroutines ($instance)",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "$ds"
+                        },
+                        "description": "Shows the percent of CPU spent on garbage collection.\n\nIf % is high, then CPU usage can be decreased by changing GOGC to higher values. Increasing GOGC value will increase memory usage, and decrease CPU usage.\n\nTry searching for keyword `GOGC` at https://docs.victoriametrics.com/troubleshooting/ ",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "decimals": 0,
+                                "links": [],
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "percentunit",
+                                "unitScale": true
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 8,
+                            "w": 12,
+                            "x": 0,
+                            "y": 27
+                        },
+                        "id": 59,
+                        "links": [],
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull",
+                                    "max"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "mode": "multi",
+                                "sort": "desc"
+                            }
+                        },
+                        "pluginVersion": "9.2.6",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "$ds"
+                                },
+                                "editorMode": "code",
+                                "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(job)",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "__auto",
+                                "range": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "CPU spent on GC ($instance)",
                         "type": "timeseries"
                     }
                 ],
@@ -2156,7 +2324,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 28
+                            "y": 36
                         },
                         "id": 14,
                         "options": {
@@ -2258,7 +2426,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 28
+                            "y": 36
                         },
                         "id": 13,
                         "options": {
@@ -2360,7 +2528,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 36
+                            "y": 44
                         },
                         "id": 20,
                         "options": {
@@ -2463,7 +2631,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 36
+                            "y": 44
                         },
                         "id": 32,
                         "options": {
@@ -2562,7 +2730,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 44
+                            "y": 52
                         },
                         "id": 26,
                         "options": {
@@ -2689,7 +2857,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 43
+                            "y": 51
                         },
                         "id": 31,
                         "options": {
@@ -2791,7 +2959,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 43
+                            "y": 51
                         },
                         "id": 33,
                         "options": {
@@ -2892,7 +3060,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 51
+                            "y": 59
                         },
                         "id": 30,
                         "options": {
@@ -3013,7 +3181,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 0,
-                            "y": 9
+                            "y": 17
                         },
                         "id": 52,
                         "options": {
@@ -3105,7 +3273,7 @@ data:
                             "h": 8,
                             "w": 12,
                             "x": 12,
-                            "y": 9
+                            "y": 17
                         },
                         "id": 53,
                         "options": {
@@ -3141,9 +3309,8 @@ data:
                 "type": "row"
             }
         ],
-        "refresh": false,
-        "schemaVersion": 37,
-        "style": "dark",
+        "refresh": "",
+        "schemaVersion": 39,
         "tags": [
             "victoriametrics",
             "vmalert",
@@ -3153,9 +3320,9 @@ data:
             "list": [
                 {
                     "current": {
-                        "selected": false,
-                        "text": "VictoriaMetrics - cluster",
-                        "value": "VictoriaMetrics - cluster"
+                        "selected": true,
+                        "text": "VictoriaMetrics",
+                        "value": "P4169E866C3094E38"
                     },
                     "hide": 0,
                     "includeAll": false,

--- a/charts/victoria-metrics-k8s-stack/templates/rules/alertmanager.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/alertmanager.rules.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "alertmanager.rules" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "alertmanager.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -75,7 +75,7 @@ spec:
         (
           rate(alertmanager_notifications_failed_total{job="{{ .Values.alertmanager.name | default (printf "%s-%s" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-") }}",namespace="{{ .Release.Namespace }}"}[5m])
         /
-          rate(alertmanager_notifications_total{job="{{ .Values.alertmanager.name | default (printf "%s-%s" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-") }}",namespace="{{ .Release.Namespace }}"}[5m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="{{ .Values.alertmanager.name | default (printf "%s-%s" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-") }}",namespace="{{ .Release.Namespace }}"}[5m])
         )
         > 0.01
       for: 5m
@@ -95,7 +95,7 @@ spec:
         min by (namespace,service, integration) (
           rate(alertmanager_notifications_failed_total{job="{{ .Values.alertmanager.name | default (printf "%s-%s" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-") }}",namespace="{{ .Release.Namespace }}", integration=~`.*`}[5m])
         /
-          rate(alertmanager_notifications_total{job="{{ .Values.alertmanager.name | default (printf "%s-%s" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-") }}",namespace="{{ .Release.Namespace }}", integration=~`.*`}[5m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="{{ .Values.alertmanager.name | default (printf "%s-%s" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-") }}",namespace="{{ .Release.Namespace }}", integration=~`.*`}[5m])
         )
         > 0.01
       for: 5m
@@ -115,7 +115,7 @@ spec:
         min by (namespace,service, integration) (
           rate(alertmanager_notifications_failed_total{job="{{ .Values.alertmanager.name | default (printf "%s-%s" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-") }}",namespace="{{ .Release.Namespace }}", integration!~`.*`}[5m])
         /
-          rate(alertmanager_notifications_total{job="{{ .Values.alertmanager.name | default (printf "%s-%s" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-") }}",namespace="{{ .Release.Namespace }}", integration!~`.*`}[5m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="{{ .Values.alertmanager.name | default (printf "%s-%s" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-") }}",namespace="{{ .Release.Namespace }}", integration!~`.*`}[5m])
         )
         > 0.01
       for: 5m

--- a/charts/victoria-metrics-k8s-stack/templates/rules/etcd.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/etcd.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "etcd" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "etcd" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/general.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/general.rules.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "general.rules" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "general.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_cpu_usage_seconds_total.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_cpu_usage_seconds_total.yaml
@@ -1,0 +1,39 @@
+{{- /*
+Generated from 'k8s.rules.container_cpu_usage_seconds_total' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubernetesControlPlane-prometheusRule.yaml
+Do not change in-place! In order to change this file first read following link:
+https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack/hack
+*/ -}}
+{{- if and .Values.defaultRules.create  }}
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "k8s.rules.container_cpu_usage_seconds_total" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  labels:
+    app: {{ include "victoria-metrics-k8s-stack.name" $ }}
+{{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+{{- if .Values.defaultRules.params }}
+  - params:
+{{ toYaml .Values.defaultRules.params | indent 6 }}
+{{ indent 3 "" }}
+{{- else }}
+  -
+{{- end }} name: k8s.rules.container_cpu_usage_seconds_total
+    rules:
+    - expr: |-
+        sum by (cluster, namespace, pod, container) (
+          irate(container_cpu_usage_seconds_total{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}[5m])
+        ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (
+          1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
+        )
+      record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_memory_cache.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_memory_cache.yaml
@@ -1,14 +1,14 @@
 {{- /*
-Generated from 'kube-prometheus-general.rules' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubePrometheus-prometheusRule.yaml
+Generated from 'k8s.rules.container_memory_cache' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubernetesControlPlane-prometheusRule.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack/hack
 */ -}}
-{{- if and .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusGeneral }}
+{{- if and .Values.defaultRules.create  }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-prometheus-general.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "k8s.rules.container_memory_cache" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -27,10 +27,12 @@ spec:
 {{ indent 3 "" }}
 {{- else }}
   -
-{{- end }} name: kube-prometheus-general.rules
+{{- end }} name: k8s.rules.container_memory_cache
     rules:
-    - expr: count without(instance, pod, node) (up == 1)
-      record: count:up1
-    - expr: count without(instance, pod, node) (up == 0)
-      record: count:up0
+    - expr: |-
+        container_memory_cache{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
+          max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
+        )
+      record: node_namespace_pod_container:container_memory_cache
 {{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_memory_rss.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_memory_rss.yaml
@@ -1,14 +1,14 @@
 {{- /*
-Generated from 'kube-prometheus-general.rules' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubePrometheus-prometheusRule.yaml
+Generated from 'k8s.rules.container_memory_rss' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubernetesControlPlane-prometheusRule.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack/hack
 */ -}}
-{{- if and .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusGeneral }}
+{{- if and .Values.defaultRules.create  }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-prometheus-general.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "k8s.rules.container_memory_rss" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -27,10 +27,12 @@ spec:
 {{ indent 3 "" }}
 {{- else }}
   -
-{{- end }} name: kube-prometheus-general.rules
+{{- end }} name: k8s.rules.container_memory_rss
     rules:
-    - expr: count without(instance, pod, node) (up == 1)
-      record: count:up1
-    - expr: count without(instance, pod, node) (up == 0)
-      record: count:up0
+    - expr: |-
+        container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
+          max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
+        )
+      record: node_namespace_pod_container:container_memory_rss
 {{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_memory_swap.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_memory_swap.yaml
@@ -1,14 +1,14 @@
 {{- /*
-Generated from 'kube-prometheus-general.rules' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubePrometheus-prometheusRule.yaml
+Generated from 'k8s.rules.container_memory_swap' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubernetesControlPlane-prometheusRule.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack/hack
 */ -}}
-{{- if and .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusGeneral }}
+{{- if and .Values.defaultRules.create  }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-prometheus-general.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "k8s.rules.container_memory_swap" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -27,10 +27,12 @@ spec:
 {{ indent 3 "" }}
 {{- else }}
   -
-{{- end }} name: kube-prometheus-general.rules
+{{- end }} name: k8s.rules.container_memory_swap
     rules:
-    - expr: count without(instance, pod, node) (up == 1)
-      record: count:up1
-    - expr: count without(instance, pod, node) (up == 0)
-      record: count:up0
+    - expr: |-
+        container_memory_swap{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
+          max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
+        )
+      record: node_namespace_pod_container:container_memory_swap
 {{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_memory_working_set_bytes.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_memory_working_set_bytes.yaml
@@ -1,0 +1,38 @@
+{{- /*
+Generated from 'k8s.rules.container_memory_working_set_bytes' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubernetesControlPlane-prometheusRule.yaml
+Do not change in-place! In order to change this file first read following link:
+https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack/hack
+*/ -}}
+{{- if and .Values.defaultRules.create  }}
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "k8s.rules.container_memory_working_set_bytes" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  labels:
+    app: {{ include "victoria-metrics-k8s-stack.name" $ }}
+{{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+{{- if .Values.defaultRules.params }}
+  - params:
+{{ toYaml .Values.defaultRules.params | indent 6 }}
+{{ indent 3 "" }}
+{{- else }}
+  -
+{{- end }} name: k8s.rules.container_memory_working_set_bytes
+    rules:
+    - expr: |-
+        container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
+          max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
+        )
+      record: node_namespace_pod_container:container_memory_working_set_bytes
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_resource.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.container_resource.yaml
@@ -1,14 +1,14 @@
 {{- /*
-Generated from 'k8s.rules' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubernetesControlPlane-prometheusRule.yaml
+Generated from 'k8s.rules.container_resource' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubernetesControlPlane-prometheusRule.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack/hack
 */ -}}
-{{- if and .Values.defaultRules.create .Values.defaultRules.rules.k8s }}
+{{- if and .Values.defaultRules.create  }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "k8s.rules" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "k8s.rules.container_resource" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -27,39 +27,8 @@ spec:
 {{ indent 3 "" }}
 {{- else }}
   -
-{{- end }} name: k8s.rules
+{{- end }} name: k8s.rules.container_resource
     rules:
-    - expr: |-
-        sum by (cluster, namespace, pod, container) (
-          irate(container_cpu_usage_seconds_total{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}[5m])
-        ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (
-          1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
-        )
-      record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
-    - expr: |-
-        container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
-        * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
-          max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
-        )
-      record: node_namespace_pod_container:container_memory_working_set_bytes
-    - expr: |-
-        container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
-        * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
-          max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
-        )
-      record: node_namespace_pod_container:container_memory_rss
-    - expr: |-
-        container_memory_cache{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
-        * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
-          max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
-        )
-      record: node_namespace_pod_container:container_memory_cache
-    - expr: |-
-        container_memory_swap{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
-        * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
-          max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
-        )
-      record: node_namespace_pod_container:container_memory_swap
     - expr: |-
         kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"}  * on (namespace, pod, cluster)
         group_left() max by (namespace, pod, cluster) (
@@ -128,51 +97,4 @@ spec:
             )
         )
       record: namespace_cpu:kube_pod_container_resource_limits:sum
-    - expr: |-
-        max by (cluster, namespace, workload, pod) (
-          label_replace(
-            label_replace(
-              kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet"},
-              "replicaset", "$1", "owner_name", "(.*)"
-            ) * on(replicaset, namespace) group_left(owner_name) topk by(replicaset, namespace) (
-              1, max by (replicaset, namespace, owner_name) (
-                kube_replicaset_owner{job="kube-state-metrics"}
-              )
-            ),
-            "workload", "$1", "owner_name", "(.*)"
-          )
-        )
-      labels:
-        workload_type: deployment
-      record: namespace_workload_pod:kube_pod_owner:relabel
-    - expr: |-
-        max by (cluster, namespace, workload, pod) (
-          label_replace(
-            kube_pod_owner{job="kube-state-metrics", owner_kind="DaemonSet"},
-            "workload", "$1", "owner_name", "(.*)"
-          )
-        )
-      labels:
-        workload_type: daemonset
-      record: namespace_workload_pod:kube_pod_owner:relabel
-    - expr: |-
-        max by (cluster, namespace, workload, pod) (
-          label_replace(
-            kube_pod_owner{job="kube-state-metrics", owner_kind="StatefulSet"},
-            "workload", "$1", "owner_name", "(.*)"
-          )
-        )
-      labels:
-        workload_type: statefulset
-      record: namespace_workload_pod:kube_pod_owner:relabel
-    - expr: |-
-        max by (cluster, namespace, workload, pod) (
-          label_replace(
-            kube_pod_owner{job="kube-state-metrics", owner_kind="Job"},
-            "workload", "$1", "owner_name", "(.*)"
-          )
-        )
-      labels:
-        workload_type: job
-      record: namespace_workload_pod:kube_pod_owner:relabel
 {{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.pod_owner.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/k8s.rules.pod_owner.yaml
@@ -1,0 +1,79 @@
+{{- /*
+Generated from 'k8s.rules.pod_owner' group from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/kubernetesControlPlane-prometheusRule.yaml
+Do not change in-place! In order to change this file first read following link:
+https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack/hack
+*/ -}}
+{{- if and .Values.defaultRules.create  }}
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "k8s.rules.pod_owner" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  labels:
+    app: {{ include "victoria-metrics-k8s-stack.name" $ }}
+{{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+{{- if .Values.defaultRules.params }}
+  - params:
+{{ toYaml .Values.defaultRules.params | indent 6 }}
+{{ indent 3 "" }}
+{{- else }}
+  -
+{{- end }} name: k8s.rules.pod_owner
+    rules:
+    - expr: |-
+        max by (cluster, namespace, workload, pod) (
+          label_replace(
+            label_replace(
+              kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet"},
+              "replicaset", "$1", "owner_name", "(.*)"
+            ) * on(replicaset, namespace) group_left(owner_name) topk by(replicaset, namespace) (
+              1, max by (replicaset, namespace, owner_name) (
+                kube_replicaset_owner{job="kube-state-metrics"}
+              )
+            ),
+            "workload", "$1", "owner_name", "(.*)"
+          )
+        )
+      labels:
+        workload_type: deployment
+      record: namespace_workload_pod:kube_pod_owner:relabel
+    - expr: |-
+        max by (cluster, namespace, workload, pod) (
+          label_replace(
+            kube_pod_owner{job="kube-state-metrics", owner_kind="DaemonSet"},
+            "workload", "$1", "owner_name", "(.*)"
+          )
+        )
+      labels:
+        workload_type: daemonset
+      record: namespace_workload_pod:kube_pod_owner:relabel
+    - expr: |-
+        max by (cluster, namespace, workload, pod) (
+          label_replace(
+            kube_pod_owner{job="kube-state-metrics", owner_kind="StatefulSet"},
+            "workload", "$1", "owner_name", "(.*)"
+          )
+        )
+      labels:
+        workload_type: statefulset
+      record: namespace_workload_pod:kube_pod_owner:relabel
+    - expr: |-
+        max by (cluster, namespace, workload, pod) (
+          label_replace(
+            kube_pod_owner{job="kube-state-metrics", owner_kind="Job"},
+            "workload", "$1", "owner_name", "(.*)"
+          )
+        )
+      labels:
+        workload_type: job
+      record: namespace_workload_pod:kube_pod_owner:relabel
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kube-apiserver-availability.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kube-apiserver-availability.rules.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-apiserver-availability.rules" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-apiserver-availability.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kube-apiserver-burnrate.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kube-apiserver-burnrate.rules.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-apiserver-burnrate.rules" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-apiserver-burnrate.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kube-apiserver-histogram.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kube-apiserver-histogram.rules.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-apiserver-histogram.rules" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-apiserver-histogram.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kube-apiserver-slos.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kube-apiserver-slos.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-apiserver-slos" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-apiserver-slos" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kube-prometheus-node-recording.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kube-prometheus-node-recording.rules.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-prometheus-node-recording.rules" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-prometheus-node-recording.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kube-scheduler.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kube-scheduler.rules.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-scheduler.rules" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-scheduler.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kube-state-metrics.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kube-state-metrics.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-state-metrics" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kube-state-metrics" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kubelet.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kubelet.rules.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubelet.rules" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubelet.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-apps.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-apps.yaml
@@ -9,7 +9,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-apps" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-apps" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-resources.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-resources.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-resources" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-resources" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -160,9 +160,9 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/cputhrottlinghigh
         summary: Processes experience elevated CPU throttling.
       expr: |-
-        sum(increase(container_cpu_cfs_throttled_periods_total{container!="", }[5m])) by (container, pod, namespace)
+        sum(increase(container_cpu_cfs_throttled_periods_total{container!="", }[5m])) by (cluster, container, pod, namespace)
           /
-        sum(increase(container_cpu_cfs_periods_total{}[5m])) by (container, pod, namespace)
+        sum(increase(container_cpu_cfs_periods_total{}[5m])) by (cluster, container, pod, namespace)
           > ( 25 / 100 )
       for: 15m
       labels:

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-storage.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-storage.yaml
@@ -9,7 +9,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-storage" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-storage" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -33,7 +33,7 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeFillingUp | default false) }}
     - alert: KubePersistentVolumeFillingUp
       annotations:
-        description: The PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} is only {{`{{`}} $value | humanizePercentage {{`}}`}} free.
+        description: The PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} {{`{{`}} with $labels.cluster -{{`}}`}} on Cluster {{`{{`}} . {{`}}`}} {{`{{`}}- end {{`}}`}} is only {{`{{`}} $value | humanizePercentage {{`}}`}} free.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepersistentvolumefillingup
         summary: PersistentVolume is filling up.
       expr: |-
@@ -44,9 +44,9 @@ spec:
         ) < 0.03
         and
         kubelet_volume_stats_used_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
-        unless on(namespace, persistentvolumeclaim)
+        unless on(cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
-        unless on(namespace, persistentvolumeclaim)
+        unless on(cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
       for: 1m
       labels:
@@ -58,7 +58,7 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeFillingUp | default false) }}
     - alert: KubePersistentVolumeFillingUp
       annotations:
-        description: Based on recent sampling, the PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} is expected to fill up within four days. Currently {{`{{`}} $value | humanizePercentage {{`}}`}} is available.
+        description: Based on recent sampling, the PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} {{`{{`}} with $labels.cluster -{{`}}`}} on Cluster {{`{{`}} . {{`}}`}} {{`{{`}}- end {{`}}`}} is expected to fill up within four days. Currently {{`{{`}} $value | humanizePercentage {{`}}`}} is available.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepersistentvolumefillingup
         summary: PersistentVolume is filling up.
       expr: |-
@@ -71,9 +71,9 @@ spec:
         kubelet_volume_stats_used_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
         and
         predict_linear(kubelet_volume_stats_available_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
-        unless on(namespace, persistentvolumeclaim)
+        unless on(cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
-        unless on(namespace, persistentvolumeclaim)
+        unless on(cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
       for: 1h
       labels:
@@ -85,7 +85,7 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeInodesFillingUp | default false) }}
     - alert: KubePersistentVolumeInodesFillingUp
       annotations:
-        description: The PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} only has {{`{{`}} $value | humanizePercentage {{`}}`}} free inodes.
+        description: The PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} {{`{{`}} with $labels.cluster -{{`}}`}} on Cluster {{`{{`}} . {{`}}`}} {{`{{`}}- end {{`}}`}} only has {{`{{`}} $value | humanizePercentage {{`}}`}} free inodes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepersistentvolumeinodesfillingup
         summary: PersistentVolumeInodes are filling up.
       expr: |-
@@ -96,9 +96,9 @@ spec:
         ) < 0.03
         and
         kubelet_volume_stats_inodes_used{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
-        unless on(namespace, persistentvolumeclaim)
+        unless on(cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
-        unless on(namespace, persistentvolumeclaim)
+        unless on(cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
       for: 1m
       labels:
@@ -110,7 +110,7 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeInodesFillingUp | default false) }}
     - alert: KubePersistentVolumeInodesFillingUp
       annotations:
-        description: Based on recent sampling, the PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} is expected to run out of inodes within four days. Currently {{`{{`}} $value | humanizePercentage {{`}}`}} of its inodes are free.
+        description: Based on recent sampling, the PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} {{`{{`}} with $labels.cluster -{{`}}`}} on Cluster {{`{{`}} . {{`}}`}} {{`{{`}}- end {{`}}`}} is expected to run out of inodes within four days. Currently {{`{{`}} $value | humanizePercentage {{`}}`}} of its inodes are free.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepersistentvolumeinodesfillingup
         summary: PersistentVolumeInodes are filling up.
       expr: |-
@@ -123,9 +123,9 @@ spec:
         kubelet_volume_stats_inodes_used{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
         and
         predict_linear(kubelet_volume_stats_inodes_free{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
-        unless on(namespace, persistentvolumeclaim)
+        unless on(cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
-        unless on(namespace, persistentvolumeclaim)
+        unless on(cluster, namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
       for: 1h
       labels:
@@ -137,7 +137,7 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeErrors | default false) }}
     - alert: KubePersistentVolumeErrors
       annotations:
-        description: The persistent volume {{`{{`}} $labels.persistentvolume {{`}}`}} has status {{`{{`}} $labels.phase {{`}}`}}.
+        description: The persistent volume {{`{{`}} $labels.persistentvolume {{`}}`}} {{`{{`}} with $labels.cluster -{{`}}`}} on Cluster {{`{{`}} . {{`}}`}} {{`{{`}}- end {{`}}`}} has status {{`{{`}} $labels.phase {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepersistentvolumeerrors
         summary: PersistentVolume is having issues with provisioning.
       expr: kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-system-apiserver.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-system-apiserver.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-system-apiserver" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-system-apiserver" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-system-controller-manager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-system-controller-manager.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-system-controller-manager" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-system-controller-manager" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-system-kubelet.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-system-kubelet.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-system-kubelet" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-system-kubelet" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-system-scheduler.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-system-scheduler.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-system-scheduler" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-system-scheduler" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-system.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/kubernetes-system.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-system" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "kubernetes-system" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/node-exporter.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/node-exporter.rules.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "node-exporter.rules" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "node-exporter.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/node-exporter.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/node-exporter.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "node-exporter" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "node-exporter" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -441,6 +441,20 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodesystemdservicefailed
         summary: Systemd service has entered failed state.
       expr: node_systemd_unit_state{job="node-exporter", state="failed"} == 1
+      for: 5m
+      labels:
+        severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.NodeBondingDegraded | default false) }}
+    - alert: NodeBondingDegraded
+      annotations:
+        description: Bonding interface {{`{{`}} $labels.master {{`}}`}} on {{`{{`}} $labels.instance {{`}}`}} is in degraded state due to one or more slave failures.
+        runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodebondingdegraded
+        summary: Bonding interface is degraded
+      expr: (node_bonding_slaves - node_bonding_active) != 0
       for: 5m
       labels:
         severity: warning

--- a/charts/victoria-metrics-k8s-stack/templates/rules/node-network.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/node-network.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "node-network" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "node-network" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/node.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/node.rules.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "node.rules" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "node.rules" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -38,8 +38,8 @@ spec:
     - expr: |-
         count by (cluster, node) (
           node_cpu_seconds_total{mode="idle",job="node-exporter"}
-          * on (namespace, pod) group_left(node)
-          topk by(namespace, pod) (1, node_namespace_pod:kube_pod_info:)
+          * on (cluster, namespace, pod) group_left(node)
+          topk by(cluster, namespace, pod) (1, node_namespace_pod:kube_pod_info:)
         )
       record: node:node_num_cpu:sum
     - expr: |-

--- a/charts/victoria-metrics-k8s-stack/templates/rules/vm-health.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/vm-health.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "vm-health" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "vm-health" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -98,7 +98,7 @@ spec:
       annotations:
         description: "Logging rate for job \"{{`{{`}} $labels.job {{`}}`}}\" ({{`{{`}} $labels.instance {{`}}`}}) is {{`{{`}} $value {{`}}`}} for last 15m.\n Worth to check logs for specific error messages."
         summary: Too many logs printed for job "{{`{{`}} $labels.job {{`}}`}}" ({{`{{`}} $labels.instance {{`}}`}})
-      expr: sum(increase(vm_log_messages_total{level="error"}[5m])) by (job, instance) > 0
+      expr: sum(increase(vm_log_messages_total{level="error"}[5m])) without (app_version, location) > 0
       for: 15m
       labels:
         severity: warning
@@ -111,7 +111,7 @@ spec:
       annotations:
         description: "The rate of TSID misses during query lookups is too high for \"{{`{{`}} $labels.job {{`}}`}}\" ({{`{{`}} $labels.instance {{`}}`}}).\n Make sure you're running VictoriaMetrics of v1.85.3 or higher.\n Related issue https://github.com/VictoriaMetrics/VictoriaMetrics/issues/3502"
         summary: Too many TSID misses for job "{{`{{`}} $labels.job {{`}}`}}" ({{`{{`}} $labels.instance {{`}}`}})
-      expr: sum(rate(vm_missing_tsids_for_metric_id_total[5m])) by (job, instance) > 0
+      expr: rate(vm_missing_tsids_for_metric_id_total[5m]) > 0
       for: 10m
       labels:
         severity: critical

--- a/charts/victoria-metrics-k8s-stack/templates/rules/vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/vmagent.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "vmagent" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "vmagent" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -37,7 +37,7 @@ spec:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/G7Z9GzMGz?viewPanel=49&var-instance={{`{{`}} $labels.instance {{`}}`}}
         description: Vmagent dropped {{`{{`}} $value | humanize1024 {{`}}`}} from persistent queue on instance {{`{{`}} $labels.instance {{`}}`}} for the last 10m.
         summary: Instance {{`{{`}} $labels.instance {{`}}`}} is dropping data from persistent queue
-      expr: sum(increase(vm_persistentqueue_bytes_dropped_total[5m])) by (job, instance) > 0
+      expr: sum(increase(vm_persistentqueue_bytes_dropped_total[5m])) without (path) > 0
       for: 10m
       labels:
         severity: critical
@@ -50,7 +50,7 @@ spec:
       annotations:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/G7Z9GzMGz?viewPanel=79&var-instance={{`{{`}} $labels.instance {{`}}`}}
         summary: Job "{{`{{`}} $labels.job {{`}}`}}" on instance {{`{{`}} $labels.instance {{`}}`}} drops the rejected by remote-write server data blocks. Check the logs to find the reason for rejects.
-      expr: sum(increase(vmagent_remotewrite_packets_dropped_total[5m])) by (job, instance) > 0
+      expr: sum(increase(vmagent_remotewrite_packets_dropped_total[5m])) without (url) > 0
       for: 15m
       labels:
         severity: warning
@@ -63,7 +63,7 @@ spec:
       annotations:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/G7Z9GzMGz?viewPanel=31&var-instance={{`{{`}} $labels.instance {{`}}`}}
         summary: Job "{{`{{`}} $labels.job {{`}}`}}" on instance {{`{{`}} $labels.instance {{`}}`}} fails to scrape targets for last 15m
-      expr: sum(increase(vm_promscrape_scrapes_failed_total[5m])) by (job, instance) > 0
+      expr: increase(vm_promscrape_scrapes_failed_total[5m]) > 0
       for: 15m
       labels:
         severity: warning
@@ -77,9 +77,9 @@ spec:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/G7Z9GzMGz?viewPanel=77&var-instance={{`{{`}} $labels.instance {{`}}`}}
         summary: Job "{{`{{`}} $labels.job {{`}}`}}" on instance {{`{{`}} $labels.instance {{`}}`}} responds with errors to write requests for last 15m.
       expr: |-
-        (sum(increase(vm_ingestserver_request_errors_total[5m])) by (job, instance)
+        (sum(increase(vm_ingestserver_request_errors_total[5m])) without (name,net,type)
         +
-        sum(increase(vmagent_http_request_errors_total[5m])) by (job, instance)) > 0
+        sum(increase(vmagent_http_request_errors_total[5m])) without (path,protocol)) > 0
       for: 15m
       labels:
         severity: warning
@@ -93,7 +93,7 @@ spec:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/G7Z9GzMGz?viewPanel=61&var-instance={{`{{`}} $labels.instance {{`}}`}}
         description: "Vmagent fails to push data via remote write protocol to destination \"{{`{{`}} $labels.url {{`}}`}}\"\n Ensure that destination is up and reachable."
         summary: Job "{{`{{`}} $labels.job {{`}}`}}" on instance {{`{{`}} $labels.instance {{`}}`}} fails to push to remote storage
-      expr: sum(rate(vmagent_remotewrite_retries_count_total[5m])) by(job, instance, url) > 0
+      expr: rate(vmagent_remotewrite_retries_count_total[5m]) > 0
       for: 15m
       labels:
         severity: warning
@@ -107,7 +107,7 @@ spec:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/G7Z9GzMGz?viewPanel=84&var-instance={{`{{`}} $labels.instance {{`}}`}}
         description: "The remote write connection between vmagent \"{{`{{`}} $labels.job {{`}}`}}\" (instance {{`{{`}} $labels.instance {{`}}`}}) and destination \"{{`{{`}} $labels.url {{`}}`}}\" is saturated by more than 90% and vmagent won't be able to keep up.\n This usually means that `-remoteWrite.queues` command-line flag must be increased in order to increase the number of connections per each remote storage."
         summary: Remote write connection from "{{`{{`}} $labels.job {{`}}`}}" (instance {{`{{`}} $labels.instance {{`}}`}}) to {{`{{`}} $labels.url {{`}}`}} is saturated
-      expr: "(\n sum(rate(vmagent_remotewrite_send_duration_seconds_total[5m])) by(job, instance, url) \n / \n max(vmagent_remotewrite_queues) by(job, instance, url)\n) > 0.9"
+      expr: "(\n rate(vmagent_remotewrite_send_duration_seconds_total[5m])\n / \n vmagent_remotewrite_queues\n) > 0.9"
       for: 15m
       labels:
         severity: warning

--- a/charts/victoria-metrics-k8s-stack/templates/rules/vmcluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/vmcluster.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "vmcluster" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "vmcluster" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -63,12 +63,12 @@ spec:
       annotations:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/oS7Bi_0Wz?viewPanel=200&var-instance={{`{{`}} $labels.instance {{`}}`}}"
         description: "Disk utilisation on instance {{`{{`}} $labels.instance {{`}}`}} is more than 80%.\n Having less than 20% of free disk space could cripple merges processes and overall performance. Consider to limit the ingestion rate, decrease retention or scale the disk space if possible."
-        summary: Instance {{`{{`}} $labels.instance {{`}}`}} will run out of disk space soon
+        summary: Instance {{`{{`}} $labels.instance {{`}}`}} (job={{`{{`}} $labels.job {{`}}`}}) will run out of disk space soon
       expr: |-
-        sum(vm_data_size_bytes) by(instance) /
+        sum(vm_data_size_bytes) by(job, instance) /
         (
-         sum(vm_free_disk_space_bytes) by(instance) +
-         sum(vm_data_size_bytes) by(instance)
+         sum(vm_free_disk_space_bytes) by(job, instance) +
+         sum(vm_data_size_bytes) by(job, instance)
         ) > 0.8
       for: 30m
       labels:
@@ -120,7 +120,7 @@ spec:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/oS7Bi_0Wz?viewPanel=135&var-instance={{`{{`}} $labels.instance {{`}}`}}
         description: 'VM is rejecting to ingest rows on "{{`{{`}} $labels.instance {{`}}`}}" due to the following reason: "{{`{{`}} $labels.reason {{`}}`}}"'
         summary: Some rows are rejected on "{{`{{`}} $labels.instance {{`}}`}}" on ingestion attempt
-      expr: sum(rate(vm_rows_ignored_total[5m])) by (instance, reason) > 0
+      expr: rate(vm_rows_ignored_total[5m]) > 0
       for: 15m
       labels:
         severity: warning
@@ -157,7 +157,7 @@ spec:
       expr: |-
         sum(increase(vm_new_timeseries_created_total[24h]))
         >
-        (sum(vm_cache_entries{type="storage/hour_metric_ids"})* 3)
+        (sum(vm_cache_entries{type="storage/hour_metric_ids"}) * 3)
       for: 15m
       labels:
         severity: warning
@@ -205,7 +205,7 @@ spec:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/oS7Bi_0Wz?viewPanel=116&var-instance={{`{{`}} $labels.instance {{`}}`}}
         description: "VictoriaMetrics limits the number of labels per each metric with `-maxLabelsPerTimeseries` command-line flag.\n This prevents from ingesting metrics with too many labels. Please verify that `-maxLabelsPerTimeseries` is configured correctly or that clients which send these metrics aren't misbehaving."
         summary: Metrics ingested to vminsert on {{`{{`}} $labels.instance {{`}}`}} are exceeding labels limit
-      expr: sum(increase(vm_metrics_with_dropped_labels_total[5m])) by (instance) > 0
+      expr: increase(vm_metrics_with_dropped_labels_total[5m]) > 0
       for: 15m
       labels:
         severity: warning

--- a/charts/victoria-metrics-k8s-stack/templates/rules/vmsingle.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/vmsingle.yaml
@@ -8,7 +8,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "vmsingle" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "vmsingle" | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
   labels:
     app: {{ include "victoria-metrics-k8s-stack.name" $ }}
 {{ include "victoria-metrics-k8s-stack.labels" $ | indent 4 }}
@@ -63,12 +63,12 @@ spec:
       annotations:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/wNf0q_kZk?viewPanel=53&var-instance={{`{{`}} $labels.instance {{`}}`}}
         description: "Disk utilisation on instance {{`{{`}} $labels.instance {{`}}`}} is more than 80%.\n Having less than 20% of free disk space could cripple merges processes and overall performance. Consider to limit the ingestion rate, decrease retention or scale the disk space if possible."
-        summary: Instance {{`{{`}} $labels.instance {{`}}`}} will run out of disk space soon
+        summary: Instance {{`{{`}} $labels.instance {{`}}`}} (job={{`{{`}} $labels.job {{`}}`}}) will run out of disk space soon
       expr: |-
-        sum(vm_data_size_bytes) by(instance) /
+        sum(vm_data_size_bytes) by(job, instance) /
         (
-         sum(vm_free_disk_space_bytes) by(instance) +
-         sum(vm_data_size_bytes) by(instance)
+         sum(vm_free_disk_space_bytes) by(job, instance) +
+         sum(vm_data_size_bytes) by(job, instance)
         ) > 0.8
       for: 30m
       labels:
@@ -97,7 +97,7 @@ spec:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/wNf0q_kZk?viewPanel=58&var-instance={{`{{`}} $labels.instance {{`}}`}}
         description: 'VM is rejecting to ingest rows on "{{`{{`}} $labels.instance {{`}}`}}" due to the following reason: "{{`{{`}} $labels.reason {{`}}`}}"'
         summary: Some rows are rejected on "{{`{{`}} $labels.instance {{`}}`}}" on ingestion attempt
-      expr: sum(rate(vm_rows_ignored_total[5m])) by (instance, reason) > 0
+      expr: rate(vm_rows_ignored_total[5m]) > 0
       for: 15m
       labels:
         severity: warning
@@ -168,7 +168,7 @@ spec:
         dashboard: {{ index .Values.grafana.ingress.hosts 0 }}/d/wNf0q_kZk?viewPanel=74&var-instance={{`{{`}} $labels.instance {{`}}`}}
         description: "VictoriaMetrics limits the number of labels per each metric with `-maxLabelsPerTimeseries` command-line flag.\n This prevents from ingesting metrics with too many labels. Please verify that `-maxLabelsPerTimeseries` is configured correctly or that clients which send these metrics aren't misbehaving."
         summary: Metrics ingested in ({{`{{`}} $labels.instance {{`}}`}}) are exceeding labels limit
-      expr: sum(increase(vm_metrics_with_dropped_labels_total[5m])) by (instance) > 0
+      expr: increase(vm_metrics_with_dropped_labels_total[5m]) > 0
       for: 15m
       labels:
         severity: warning

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Update victoriametrics CRD resources yaml.
 
 ## 0.27.11
 

--- a/charts/victoria-metrics-operator/Chart.yaml
+++ b/charts/victoria-metrics-operator/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/VictoriaMetrics/operator
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
   - https://github.com/VictoriaMetrics/operator
-version: 0.27.11
+version: 0.28.0
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
 kubeVersion: ">=1.23.0-0"
 keywords:

--- a/charts/victoria-metrics-operator/crd.yaml
+++ b/charts/victoria-metrics-operator/crd.yaml
@@ -622,8 +622,6 @@ spec:
                 description: Specifies the DNS parameters of a pod. Parameters specified
                   here will be merged to the generated DNS configuration based on
                   DNSPolicy.
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
                 properties:
                   nameservers:
                     description: A list of DNS name server IP addresses. This will
@@ -656,6 +654,8 @@ spec:
                       type: string
                     type: array
                 type: object
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
               dnsPolicy:
                 description: DNSPolicy set DNS policy for the pod
                 type: string
@@ -6617,8 +6617,6 @@ spec:
                 description: Specifies the DNS parameters of a pod. Parameters specified
                   here will be merged to the generated DNS configuration based on
                   DNSPolicy.
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
                 properties:
                   nameservers:
                     description: A list of DNS name server IP addresses. This will
@@ -6651,6 +6649,8 @@ spec:
                       type: string
                     type: array
                 type: object
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
               dnsPolicy:
                 description: DNSPolicy sets DNS policy for the pod
                 type: string
@@ -7592,8 +7592,6 @@ spec:
                 description: Datasource Victoria Metrics or VMSelect url. Required
                   parameter. e.g. http://127.0.0.1:8428
                 properties:
-                  OAuth2:
-                    x-kubernetes-preserve-unknown-fields: true
                   basicAuth:
                     description: BasicAuth allow an endpoint to authenticate over
                       basic authentication
@@ -7771,6 +7769,8 @@ spec:
                     description: Victoria Metrics or VMSelect url. Required parameter.
                       E.g. http://127.0.0.1:8428
                     type: string
+                  OAuth2:
+                    x-kubernetes-preserve-unknown-fields: true
                 required:
                 - url
                 type: object
@@ -7778,8 +7778,6 @@ spec:
                 description: Specifies the DNS parameters of a pod. Parameters specified
                   here will be merged to the generated DNS configuration based on
                   DNSPolicy.
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
                 properties:
                   nameservers:
                     description: A list of DNS name server IP addresses. This will
@@ -7812,6 +7810,8 @@ spec:
                       type: string
                     type: array
                 type: object
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
               dnsPolicy:
                 description: DNSPolicy sets DNS policy for the pod
                 type: string
@@ -7985,8 +7985,6 @@ spec:
                   notifier options could be chosen: notifierConfigRef or notifiers
                   +  notifier'
                 properties:
-                  OAuth2:
-                    x-kubernetes-preserve-unknown-fields: true
                   basicAuth:
                     description: BasicAuth allow an endpoint to authenticate over
                       basic authentication
@@ -8232,6 +8230,8 @@ spec:
                   url:
                     description: AlertManager url.  E.g. http://127.0.0.1:9093
                     type: string
+                  OAuth2:
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               notifierConfigRef:
                 description: 'NotifierConfigRef reference for secret with notifier
@@ -8264,8 +8264,6 @@ spec:
                   description: VMAlertNotifierSpec defines the notifier url for sending
                     information about alerts
                   properties:
-                    OAuth2:
-                      x-kubernetes-preserve-unknown-fields: true
                     basicAuth:
                       description: BasicAuth allow an endpoint to authenticate over
                         basic authentication
@@ -8511,6 +8509,8 @@ spec:
                     url:
                       description: AlertManager url.  E.g. http://127.0.0.1:9093
                       type: string
+                    OAuth2:
+                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               podDisruptionBudget:
@@ -8604,8 +8604,6 @@ spec:
                   has been successfully persisted (via RemoteWrite) before. see -remoteRead.url
                   docs in vmalerts for details. E.g. http://127.0.0.1:8428
                 properties:
-                  OAuth2:
-                    x-kubernetes-preserve-unknown-fields: true
                   basicAuth:
                     description: BasicAuth allow an endpoint to authenticate over
                       basic authentication
@@ -8788,6 +8786,8 @@ spec:
                   url:
                     description: URL of the endpoint to send samples to.
                     type: string
+                  OAuth2:
+                    x-kubernetes-preserve-unknown-fields: true
                 required:
                 - url
                 type: object
@@ -8798,8 +8798,6 @@ spec:
                   in the form of time series named ALERTS and ALERTS_FOR_STATE see
                   -remoteWrite.url docs in vmalerts for details. E.g. http://127.0.0.1:8428
                 properties:
-                  OAuth2:
-                    x-kubernetes-preserve-unknown-fields: true
                   basicAuth:
                     description: BasicAuth allow an endpoint to authenticate over
                       basic authentication
@@ -8996,6 +8994,8 @@ spec:
                   url:
                     description: URL of the endpoint to send samples to.
                     type: string
+                  OAuth2:
+                    x-kubernetes-preserve-unknown-fields: true
                 required:
                 - url
                 type: object
@@ -9487,8 +9487,6 @@ spec:
                 description: Specifies the DNS parameters of a pod. Parameters specified
                   here will be merged to the generated DNS configuration based on
                   DNSPolicy.
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
                 properties:
                   nameservers:
                     description: A list of DNS name server IP addresses. This will
@@ -9521,6 +9519,8 @@ spec:
                       type: string
                     type: array
                 type: object
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
               dnsPolicy:
                 description: DNSPolicy sets DNS policy for the pod
                 type: string
@@ -10184,6 +10184,20 @@ spec:
                   description: VMAuthUnauthorizedPath defines url_map for unauthorized
                     access
                   properties:
+                    drop_src_path_prefix_parts:
+                      description: DropSrcPathPrefixParts is the number of `/`-delimited
+                        request path prefix parts to drop before proxying the request
+                        to backend. See https://docs.victoriametrics.com/vmauth.html#dropping-request-path-prefix
+                        for more details.
+                      type: integer
+                    headers:
+                      description: 'Headers represent additional http headers, that
+                        vmauth uses in form of ["header_key: header_value"] multiple
+                        values for header key: ["header_key: value1,value2"] it''s
+                        available since 1.68.0 version of vmauth'
+                      items:
+                        type: string
+                      type: array
                     ip_filters:
                       description: IPFilters defines filter for src ip address enterprise
                         only
@@ -10197,6 +10211,35 @@ spec:
                             type: string
                           type: array
                       type: object
+                    load_balancing_policy:
+                      description: 'LoadBalancingPolicy defines load balancing policy
+                        to use for backend urls. Supported policies: least_loaded,
+                        first_available. See https://docs.victoriametrics.com/vmauth.html#load-balancing
+                        for more details (default "least_loaded")'
+                      enum:
+                      - least_loaded
+                      - first_available
+                      type: string
+                    response_headers:
+                      description: 'ResponseHeaders represent additional http headers,
+                        that vmauth adds for request response in form of ["header_key:
+                        header_value"] multiple values for header key: ["header_key:
+                        value1,value2"] it''s available since 1.93.0 version of vmauth'
+                      items:
+                        type: string
+                      type: array
+                    retry_status_codes:
+                      description: RetryStatusCodes defines http status codes in numeric
+                        format for request retries e.g. [429,503]
+                      items:
+                        type: integer
+                      type: array
+                    src_hosts:
+                      description: SrcHosts is the list of regular expressions, which
+                        match the request hostname.
+                      items:
+                        type: string
+                      type: array
                     src_paths:
                       description: Paths src request paths
                       items:
@@ -10544,8 +10587,6 @@ spec:
                     description: Specifies the DNS parameters of a pod. Parameters
                       specified here will be merged to the generated DNS configuration
                       based on DNSPolicy.
-                    items:
-                      x-kubernetes-preserve-unknown-fields: true
                     properties:
                       nameservers:
                         description: A list of DNS name server IP addresses. This
@@ -10578,6 +10619,8 @@ spec:
                           type: string
                         type: array
                     type: object
+                    items:
+                      x-kubernetes-preserve-unknown-fields: true
                   dnsPolicy:
                     description: DNSPolicy sets DNS policy for the pod
                     type: string
@@ -11397,8 +11440,6 @@ spec:
                     description: Specifies the DNS parameters of a pod. Parameters
                       specified here will be merged to the generated DNS configuration
                       based on DNSPolicy.
-                    items:
-                      x-kubernetes-preserve-unknown-fields: true
                     properties:
                       nameservers:
                         description: A list of DNS name server IP addresses. This
@@ -11431,6 +11472,8 @@ spec:
                           type: string
                         type: array
                     type: object
+                    items:
+                      x-kubernetes-preserve-unknown-fields: true
                   dnsPolicy:
                     description: DNSPolicy sets DNS policy for the pod
                     type: string
@@ -12595,8 +12638,6 @@ spec:
                     description: Specifies the DNS parameters of a pod. Parameters
                       specified here will be merged to the generated DNS configuration
                       based on DNSPolicy.
-                    items:
-                      x-kubernetes-preserve-unknown-fields: true
                     properties:
                       nameservers:
                         description: A list of DNS name server IP addresses. This
@@ -12629,6 +12670,8 @@ spec:
                           type: string
                         type: array
                     type: object
+                    items:
+                      x-kubernetes-preserve-unknown-fields: true
                   dnsPolicy:
                     description: DNSPolicy sets DNS policy for the pod
                     type: string
@@ -17332,8 +17375,6 @@ spec:
                 description: Specifies the DNS parameters of a pod. Parameters specified
                   here will be merged to the generated DNS configuration based on
                   DNSPolicy.
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
                 properties:
                   nameservers:
                     description: A list of DNS name server IP addresses. This will
@@ -17366,6 +17407,8 @@ spec:
                       type: string
                     type: array
                 type: object
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
               dnsPolicy:
                 description: DNSPolicy sets DNS policy for the pod
                 type: string
@@ -19645,6 +19688,10 @@ spec:
                         vmauth uses in form of ["header_key: header_value"] multiple
                         values for header key: ["header_key: value1,value2"] it''s
                         available since 1.68.0 version of vmauth'
+                      items:
+                        type: string
+                      type: array
+                    hosts:
                       items:
                         type: string
                       type: array

--- a/hack/helm/victoria-metrics-k8s-stack.yaml
+++ b/hack/helm/victoria-metrics-k8s-stack.yaml
@@ -1,3 +1,7 @@
+## override to prevent objects name collision
+fullnameOverride: "vm-stack"
+victoria-metrics-operator:
+  fullnameOverride: "vm-operator"
 vmsingle:
   ingress:
     enabled: true


### PR DESCRIPTION
… and bump dependencies

1. update crd yaml
2. bump chart/victoria-metrics-k8s-stack dependencies: kube-state-metrics -> 5.16.0, prometheus-node-exporter -> 4.27.0, grafana -> 7.3.0
3. sync dashboards and rules from upstream
4. override release fullname for victoria-metrics-k8s-stack's `install chart` test, otherwise it could have objects collision due to truncated name.