### PR TITLE
charts/victoria-metrics-k8s-stack: add `promscrape.dropOriginalLabels` by default

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Do not store original labels in `vmagent`'s memory by default. This reduces memory usage of `vmagent` but makes `vmagent`'s debugging UI less informative. See [this docs](https://docs.victoriametrics.com/vmagent/#relabel-debug) for details on relabeling debug. 
 
 ## 0.18.12
 

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -522,6 +522,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | vmagent.ingress.pathType | string | `"Prefix"` |  |
 | vmagent.ingress.tls | list | `[]` |  |
 | vmagent.spec.externalLabels.cluster | string | `"cluster-name"` |  |
+| vmagent.spec.extraArgs."promscrape.dropOriginalLabels" | string | `"true"` |  |
 | vmagent.spec.extraArgs."promscrape.streamParse" | string | `"true"` |  |
 | vmagent.spec.image.tag | string | `"v1.97.1"` |  |
 | vmagent.spec.scrapeInterval | string | `"20s"` |  |

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -587,6 +587,9 @@ vmagent:
       cluster: cluster-name
     extraArgs:
       promscrape.streamParse: "true"
+      # Do not store original labels in vmagent's memory by default. This reduces the amount of memory used by vmagent
+      # but makes vmagent debugging UI less informative. See: https://docs.victoriametrics.com/vmagent/#relabel-debug
+      promscrape.dropOriginalLabels: "true"
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName


### PR DESCRIPTION
This is useful to lower vmagent's memory usage by default by sacrificing built-in relabeling debug UI.