### PR TITLE
Validate manifests with `kubectl` in CI

### DIFF
--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -92,4 +92,4 @@ jobs:
           kubectl create secret -n=${{ matrix.chart }}-testing generic vmanomaly-license --from-literal=license=$VMANOMALY_LICENSE_CICD
           helm dep update charts/${{ matrix.chart }}
           ct install --namespace=${{ matrix.chart }}-testing --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml" --skip-clean-up
-          helm template charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml | kubectl apply -f - --dry-run=server
+          helm template --namespace=${{ matrix.chart }}-testing charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml | kubectl apply -f - --dry-run=server

--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -91,5 +91,5 @@ jobs:
           kubectl create namespace ${{ matrix.chart }}-testing
           kubectl create secret -n=${{ matrix.chart }}-testing generic vmanomaly-license --from-literal=license=$VMANOMALY_LICENSE_CICD
           helm dep update charts/${{ matrix.chart }}
+          ct install --namespace=${{ matrix.chart }}-testing --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml" --skip-clean-up
           helm template charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml | kubectl apply -f - --dry-run=server
-          ct install --namespace=${{ matrix.chart }}-testing --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml"

--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -92,4 +92,4 @@ jobs:
           kubectl create secret -n=${{ matrix.chart }}-testing generic vmanomaly-license --from-literal=license=$VMANOMALY_LICENSE_CICD
           helm dep update charts/${{ matrix.chart }}
           ct install --namespace=${{ matrix.chart }}-testing --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml" --skip-clean-up
-          helm template --namespace=${{ matrix.chart }}-testing charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml | kubectl apply -f - --dry-run=server
+          helm template --namespace=${{ matrix.chart }}-testing charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml --validate | kubectl apply -f - --dry-run=server

--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -92,4 +92,4 @@ jobs:
           kubectl create secret -n=${{ matrix.chart }}-testing generic vmanomaly-license --from-literal=license=$VMANOMALY_LICENSE_CICD
           helm dep update charts/${{ matrix.chart }}
           ct install --namespace=${{ matrix.chart }}-testing --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml" --skip-clean-up
-          helm template --namespace=${{ matrix.chart }}-testing charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml --validate | kubectl apply -f - --dry-run=server
+          helm template --namespace=${{ matrix.chart }}-testing charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml --validate --skip-crds | kubectl apply -f - --dry-run=server

--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -91,5 +91,8 @@ jobs:
           kubectl create namespace ${{ matrix.chart }}-testing
           kubectl create secret -n=${{ matrix.chart }}-testing generic vmanomaly-license --from-literal=license=$VMANOMALY_LICENSE_CICD
           helm dep update charts/${{ matrix.chart }}
-          helm template --namespace=${{ matrix.chart }}-testing charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml --validate | kubectl apply -f - --dry-run=server
+          # Skip run for k8s stack chart as it fails CRD check
+          if [ "${{ matrix.chart }}" != "victoria-metrics-k8s-stack" ]; then
+            helm template --namespace=${{ matrix.chart }}-testing charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml --validate | kubectl apply -f - --dry-run=server
+          fi
           ct install --namespace=${{ matrix.chart }}-testing --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml" --skip-clean-up

--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -91,5 +91,5 @@ jobs:
           kubectl create namespace ${{ matrix.chart }}-testing
           kubectl create secret -n=${{ matrix.chart }}-testing generic vmanomaly-license --from-literal=license=$VMANOMALY_LICENSE_CICD
           helm dep update charts/${{ matrix.chart }}
-          ct install --namespace=${{ matrix.chart }}-testing --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml" --skip-clean-up
           helm template --namespace=${{ matrix.chart }}-testing charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml --validate --skip-crds | kubectl apply -f - --dry-run=server
+          ct install --namespace=${{ matrix.chart }}-testing --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml" --skip-clean-up

--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -91,4 +91,5 @@ jobs:
           kubectl create namespace ${{ matrix.chart }}-testing
           kubectl create secret -n=${{ matrix.chart }}-testing generic vmanomaly-license --from-literal=license=$VMANOMALY_LICENSE_CICD
           helm dep update charts/${{ matrix.chart }}
+          helm template charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml | kubectl apply -f - --dry-run=server
           ct install --namespace=${{ matrix.chart }}-testing --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml"

--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -73,7 +73,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Create k3d cluster
         uses: nolar/setup-k3d-k3s@v1

--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -91,5 +91,5 @@ jobs:
           kubectl create namespace ${{ matrix.chart }}-testing
           kubectl create secret -n=${{ matrix.chart }}-testing generic vmanomaly-license --from-literal=license=$VMANOMALY_LICENSE_CICD
           helm dep update charts/${{ matrix.chart }}
-          helm template --namespace=${{ matrix.chart }}-testing charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml --validate --skip-crds | kubectl apply -f - --dry-run=server
+          helm template --namespace=${{ matrix.chart }}-testing charts/${{ matrix.chart }} --values ./hack/helm/${{ matrix.chart }}.yaml --validate | kubectl apply -f - --dry-run=server
           ct install --namespace=${{ matrix.chart }}-testing --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml" --skip-clean-up


### PR DESCRIPTION
Helm only outputs a warning if there are schema issues, but will continue anyway. This adds a step before install that performs validation against the k8s server before proceeding with the helm chart install.

Would be nice to have it in the linting CI, however this is the only place in CI that we have a cluster to work with. In order to validate the manifests properly, `--dry-run=server` is required.

~Not sure if you would want it as a linting step, so I've left it as a draft PR.~ actually, since the testing runs on PR's and on Push anyway, that seems fine.

I've updated so that it verifies with `kubectl` post-install since we will rely on CRDs for some charts. I'm not able to test the CI directly, but it seems we setup a k3d cluster for each chart, so it's safe to use `--skip-clean-up` and the CI will terminate everything. Though if this isn't the case then we could remove it manually post-validation