### PR TITLE
charts/vmauth: changes ready httpGet probe with tcpSocket

### DIFF
--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- replaces httpGet ready probe with tcpSocket check. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/528) for details
 
 ## 0.4.6
 

--- a/charts/victoria-metrics-auth/templates/deployment.yaml
+++ b/charts/victoria-metrics-auth/templates/deployment.yaml
@@ -65,12 +65,7 @@ spec:
           env: {{ toYaml . | nindent 10 }}
           {{- end }}
           readinessProbe:
-            httpGet:
-            {{- if index  .Values.extraArgs "http.pathPrefix" }}
-              path: {{ trimSuffix "/" (index .Values.extraArgs "http.pathPrefix") }}/health
-            {{- else }}
-              path: /health
-            {{- end }}
+            tcpSocket:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 15


### PR DESCRIPTION
it allows to properly configure tls configuration for vmauth chart https://github.com/VictoriaMetrics/helm-charts/issues/528