### PR TITLE
Make alertmanager deployment more extensible

### DIFF
--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Support adding extra arguments, containers, volumes and volume mounts to the alertmanager deployment.
 
 ## 0.8.7
 

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -115,6 +115,10 @@ Change the values according to the need of the environment in ``victoria-metrics
 | alertmanager.configMap | string | `""` |  |
 | alertmanager.enabled | bool | `false` |  |
 | alertmanager.extraArgs | object | `{}` |  |
+| alertmanager.extraContainers | list | `[]` |  |
+| alertmanager.extraHostPathMounts | list | `[]` |  |
+| alertmanager.extraVolumeMounts | list | `[]` |  |
+| alertmanager.extraVolumes | list | `[]` |  |
 | alertmanager.image | string | `"prom/alertmanager"` |  |
 | alertmanager.imagePullSecrets | list | `[]` |  |
 | alertmanager.ingress.annotations | object | `{}` |  |

--- a/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
@@ -98,8 +98,20 @@ spec:
             - name: config
               mountPath: /config
               readOnly: true
+            {{- range .Values.server.extraHostPathMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+            {{- end }}
+            {{- with .Values.server.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.alertmanager.resources | nindent 12 }}
+        {{- with .Values.alertmanager.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.alertmanager.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -126,4 +138,12 @@ spec:
         - name: config
           configMap:
             name: {{ include "vmalert.alertmanager.configname" . }}
+        {{- range .Values.alertmanager.extraHostPathMounts }}
+        - name: {{ .name }}
+          hostPath:
+            path: {{ .hostPath }}
+        {{- end }}
+        {{- with .Values.alertmanager.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 {{- end -}}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -372,6 +372,33 @@ alertmanager:
     # -- Size of the volume. Better to set the same as resource limit memory property.
     size: 50Mi
 
+  # Additional hostPath mounts
+  extraHostPathMounts:
+    []
+    # - name: certs-dir
+    #   mountPath: /etc/kubernetes/certs
+    #   subPath: ""
+    #   hostPath: /etc/kubernetes/certs
+  #   readOnly: true
+
+  # Extra Volumes for the pod
+  extraVolumes:
+    []
+    #- name: example
+    #  configMap:
+    #    name: example
+
+  # Extra Volume Mounts for the container
+  extraVolumeMounts:
+    []
+    # - name: example
+    #   mountPath: /example
+
+  extraContainers:
+    []
+    #- name: config-reloader
+    #  image: reloader-image
+
 # -- Add extra specs dynamically to this chart
 extraObjects: []
 


### PR DESCRIPTION
Add the ability to add extra arguments, containers, volumes, and volume mounts to the alertmanager deployment.

I implemented this change to able to add a sidecar to the alertmanager for automatic config reloading, and decided to round it out with the features from the server deployment.