### PR TITLE
charts/vmalert: allow overriding alertmanager listen addr

### DIFF
--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Allow overriding Alertmanager listen address and port via `alertmanager.listenAddress`.
 
 ## 0.9.0
 

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: victoria-metrics-alert
 description: Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.9.0
+version: 0.9.1
 appVersion: v1.97.1
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - --storage.path=/data
             {{- end}}
             - --data.retention={{ .Values.alertmanager.retention }}
-            - --web.listen-address=0.0.0.0:9093
+            - --web.listen-address={{ .Values.alertmanager.listenAddress }}
             - --cluster.advertise-address=$(POD_IP):6783
             {{ if .Values.alertmanager.baseURL }}
             - --web.external-url={{ .Values.alertmanager.baseURL }}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -299,6 +299,7 @@ alertmanager:
   tolerations: []
   imagePullSecrets: []
   podSecurityContext: {}
+  listenAddress: "0.0.0.0:9093"
   extraArgs: {}
   # key: value
 


### PR DESCRIPTION
Allow overriding Alertmanager listen addr to support IPv6-only clusters. See: https://github.com/VictoriaMetrics/helm-charts/issues/856