### PR TITLE
charts/victoria-metrics-k8s-stack: fix remoteWrite URLs templating

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Fix templating of VMAgent `remoteWrite` in case both `VMSingle` and `VMCluster` are disabled. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/865) for details.
 
 ## 0.19.1
 

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.19.1
+version: 0.19.2
 appVersion: v1.98.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -162,11 +162,11 @@ VM Agent remoteWrites
 */}}
 {{- define "victoria-metrics-k8s-stack.vmAgentRemoteWrite" -}}
 remoteWrite:
-{{- if or .Values.vmsingle.enabled .Values.vmcluster.enabled .Values.externalVM.write }}
+{{- if or .Values.vmsingle.enabled .Values.vmcluster.enabled .Values.externalVM.write.url }}
 - {{ include "victoria-metrics-k8s-stack.vmWriteEndpoint" . | nindent 2 }}
+{{- end }}
 {{ range .Values.vmagent.additionalRemoteWrites }}
 -{{ toYaml . | nindent 2 }}
-{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Fixes templating of remoteWrite URLs in case built-in VMSingle and VMCluster are both disabled. See: https://github.com/VictoriaMetrics/helm-charts/issues/865

P.S. I've tested changes on a local cluster and it works just as expected while it fails in CI. I'll investigate why CI fails for k8s-stack and address this in a separate PR.