### PR TITLE
ci: setup a license for vmanomaly chart testing

### DIFF
--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -85,6 +85,10 @@ jobs:
           kubectl taint --all=true nodes node.cloudprovider.kubernetes.io/uninitialized- || true
 
       - name: Run chart-testing (install)
+        env:
+          VMANOMALY_LICENSE_CICD: ${{ secrets.VMANOMALY_LICENSE_CICD }}
         run: |
+          kubectl create namespace ${{ matrix.chart }}-testing
+          kubectl create secret -n=${{ matrix.chart }}-testing generic vmanomaly-license --from-literal=license=$VMANOMALY_LICENSE_CICD
           helm dep update charts/${{ matrix.chart }}
-          ct install --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml"
+          ct install --namespace=${{ matrix.chart }}-testing --config .github/ci/ct.yaml --charts "charts/${{ matrix.chart }}" --helm-extra-set-args "--values ./hack/helm/${{ matrix.chart }}.yaml"

--- a/hack/helm/victoria-metrics-anomaly.yaml
+++ b/hack/helm/victoria-metrics-anomaly.yaml
@@ -1,4 +1,3 @@
-eula: true
 config:
   reader:
     datasource_url: http://cluster-victoria-metrics-cluster-vmselect.default.svc.cluster.local:8481/select/
@@ -20,3 +19,8 @@ config:
       url: "http://cluster-victoria-metrics-cluster-vminsert.default.svc.cluster.local:8480/insert/"
       extra_labels:
         job: "vmanomaly"
+
+license:
+  secret:
+    name: "vmanomaly-license"
+    key: "license"


### PR DESCRIPTION
Creating a secret when testing any chart for simplicity. Currently, only vmanomaly chart needs the license key to for testing.

FYI: @Cambaza @fred-navruzov 