### PR TITLE
ci: update install-chart ci k8s version

### DIFF
--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         chart: ${{ fromJSON(needs.get-changed-charts.outputs.charts) }}
-        k8s_version: ["v1.24.14", "v1.25.10", "v1.26.5", "v1.27.2"]
+        k8s_version: ["v1.25.10", "v1.26.14", "v1.27.11","1.28.7","1.29.2"]
       fail-fast: false
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ helm uninstall victoria-metrics -n NAMESPACE
 
 ## Kubernetes compatibility versions
 
-helm charts tested at kubernetes versions from 1.23 to 1.27.
+helm charts tested at kubernetes versions from 1.25 to 1.29.
 
 ## List of Charts
 


### PR DESCRIPTION
drop k8s 1.24.x and add latest version
https://endoflife.date/kubernetes#:~:text=Kubernetes%20is%20an%20open%2Dsource,deployment%2C%20scaling%2C%20and%20management.&text=Kubernetes%20follows%20an%20N%2D2,a%2015%2Dweek%20release%20cycle.
>Kubernetes follows an N-2 support policy (meaning that the 3 most recent minor versions receive security and bug fixes) along with a [15-week release cycle](https://github.com/kubernetes/enhancements/tree/master/keps/sig-release/2572-release-cadence). This results in a release being supported for 14 months (12 months of support and 2 months of upgrade period).