### PR TITLE
victoria-metrics-operator: clean up vmauth when uninstall chart with …

### DIFF
--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         chart: ${{ fromJSON(needs.get-changed-charts.outputs.charts) }}
-        k8s_version: ["v1.25.10", "v1.26.14", "v1.27.11","1.28.7","1.29.2"]
+        k8s_version: ["v1.25.10", "v1.26.14", "v1.27.11","v1.28.7","v1.29.2"]
       fail-fast: false
     steps:
       - name: Checkout

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- clean up vmauth as well when uninstall chart with `cleanupCRD: true`, since it also has `finalizers`.
 
 ## 0.29.5
 

--- a/charts/victoria-metrics-operator/Chart.yaml
+++ b/charts/victoria-metrics-operator/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/VictoriaMetrics/operator
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
   - https://github.com/VictoriaMetrics/operator
-version: 0.29.5
+version: 0.29.6
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
 kubeVersion: ">=1.23.0-0"
 keywords:

--- a/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
+++ b/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
@@ -37,11 +37,12 @@ spec:
             - /bin/sh
             - -c
             - >
-              kubectl delete vmalerts --all --ignore-not-found=true;
               kubectl delete vmagents --all --ignore-not-found=true;
-              kubectl delete vmsingles --all --ignore-not-found=true;
               kubectl delete vmalertmanagers --all --ignore-not-found=true;
+              kubectl delete vmalerts --all --ignore-not-found=true;
+              kubectl delete vmauths --all --ignore-not-found=true;
               kubectl delete vmclusters --all --ignore-not-found=true;
+              kubectl delete vmsingles --all --ignore-not-found=true;
       restartPolicy: OnFailure
     {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -91,10 +92,11 @@ rules:
   - apiGroups: ["operator.victoriametrics.com"]
     resources:
       - vmagents
-      - vmalerts
-      - vmsingles
       - vmalertmanagers
+      - vmalerts
+      - vmauths
       - vmclusters
+      - vmsingles
     verbs: ["get", "list", "watch","delete"]
 ---
 {{- end }}

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -13,7 +13,7 @@ image:
 # -- with this option, if you remove this chart, all crd resources will be deleted with it.
 createCRD: true
 
-# -- Tells helm to clean up vm cr resources when uninstalling
+# -- Tells helm to clean up all the vm resources under this release's namespace when uninstalling
 cleanupCRD: false
 cleanupImage:
   repository: gcr.io/google_containers/hyperkube


### PR DESCRIPTION
…`cleanupCRD: true`

since vmauth also has victoriametrics `finalizers`, thus can't be deleted after operator is deleted