### PR TITLE
feat(crd): view and admin aggregate roles for CRDs

### DIFF
--- a/charts/victoria-metrics-operator/templates/crd_clusterrole.yaml
+++ b/charts/victoria-metrics-operator/templates/crd_clusterrole.yaml
@@ -1,0 +1,64 @@
+{{- /* do not update crds here, please update in /victoria-metrics-operator/crd.yaml */ -}}
+{{- /* this is used to add "helm.sh/resource-policy: keep" annotation for each crd */ -}}
+{{- /* see this pull request https://github.com/VictoriaMetrics/helm-charts/pull/771 for details */ -}}
+{{- if .Values.createCRD }}
+{{- if .Values.rbac.createAggregate }}
+{{- $files := .Files }}
+{{- $fileContentsList := $files.Get "crd.yaml" | splitList "---" }}
+{{- $groups := dict }}
+{{- range $fileContentsList }}
+    {{- $fileContents := . | fromYaml }}
+    {{- $group := $fileContents.spec.group }}
+    {{- $plural:= $fileContents.spec.names.plural }}
+    {{- $resources := get $groups $group | default (list) }}
+    {{- $resources := append $resources $plural }}
+    {{- $groups := set $groups $group $resources }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: victoriametrics:admin
+  labels:
+    {{- include "vm-operator.labels" . | nindent 4 }}
+    {{- .Values.rbac.labels.admin | toYaml | nindent 4 }}
+rules:
+- apiGroups: 
+  {{- range $group, $resources := $groups }}
+  - {{ $group }}
+  resources:
+  {{- range $resource := $resources }}
+  - {{ $resource }}
+  {{- end }}
+  {{- end }}
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: victoriametrics:readonly
+  labels:
+    {{- include "vm-operator.labels" . | nindent 4 }}
+    {{- .Values.rbac.labels.view | toYaml | nindent 4 }}
+rules:
+- apiGroups:
+  {{- range $group, $resources := $groups }}
+  - {{ $group }}
+  resources:
+  {{- range $resource := $resources }}
+  - {{ $resource }}
+  {{- end }}
+  {{- end }}
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
+{{- end }}

--- a/charts/victoria-metrics-operator/templates/crd_clusterrole.yaml
+++ b/charts/victoria-metrics-operator/templates/crd_clusterrole.yaml
@@ -1,8 +1,10 @@
-{{- /* do not update crds here, please update in /victoria-metrics-operator/crd.yaml */ -}}
-{{- /* this is used to add "helm.sh/resource-policy: keep" annotation for each crd */ -}}
-{{- /* see this pull request https://github.com/VictoriaMetrics/helm-charts/pull/771 for details */ -}}
+{{- /* This template generates readonly and admin cluster roles for */ -}}
+{{- /* each CRD present in the helm chart.  The clusterroles use the */ -}}
+{{- /* kubernetes clusterrole aggregation feature to include these */ -}}
+{{- /* cluster roles into the default view and admin roles */ -}}
+{{- /* See https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles */ -}}
 {{- if .Values.createCRD }}
-{{- if .Values.rbac.createAggregate }}
+{{- if .Values.rbac.createAggregateClusterRoles }}
 {{- $files := .Files }}
 {{- $fileContentsList := $files.Get "crd.yaml" | splitList "---" }}
 {{- $groups := dict }}
@@ -43,7 +45,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: victoriametrics:readonly
+  name: victoriametrics:view
   labels:
     {{- include "vm-operator.labels" . | nindent 4 }}
     {{- .Values.rbac.labels.view | toYaml | nindent 4 }}

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -41,7 +41,7 @@ rbac:
   # Note: The PSP will only be deployed, if Kubernetes (<1.25) supports the resource.
   pspEnabled: true
   # -- create agregate clusterroles for CRD readonly and admin permissions
-  createAggregate: true
+  createAggregateClusterRoles: true
 
   labels:
     view:

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -40,6 +40,14 @@ rbac:
   create: true
   # Note: The PSP will only be deployed, if Kubernetes (<1.25) supports the resource.
   pspEnabled: true
+  # -- create agregate clusterroles for CRD readonly and admin permissions
+  createAggregate: true
+
+  labels:
+    view:
+      rbac.authorization.k8s.io/aggregate-to-view: "true"
+    admin:
+      rbac.authorization.k8s.io/aggregate-to-admin: "true"
 
 # -- Labels to be added to the all resources
 extraLabels: {}


### PR DESCRIPTION
Kubernetes has view and admin roles that aggregate permissions from
other clusterroles that have the right annotations.

The advantage to this is that the view clusterrole doesn't need to be
edited whenever a new CRD is installed, but can still be extended so
view and admin also provide view and admin access to new CRDs.

The functionality is similar to drop-in files in systemd and other
linux/unix tooling.

The change adds the aggregate role functionality to the victoria-metrics-operator
helm chart. So whenever the CRDs are installed the user can also choose
to install the clusterroles that extend the view and admin default
clusterroles.
