### PR TITLE
Update service_account.yaml with proper end statement placement

### DIFF
--- a/charts/victoria-metrics-operator/templates/service_account.yaml
+++ b/charts/victoria-metrics-operator/templates/service_account.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "vm-operator.labels" . | indent 4 }}
-{{- end -}}
 {{- with .Values.extraLabels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -14,3 +13,4 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
+{{- end -}}


### PR DESCRIPTION
The prior configuration allowed the generation of an empty service account yaml file with indented labels or annotations.

![image](https://github.com/VictoriaMetrics/helm-charts/assets/6004145/8558421b-49b4-4c4a-80e4-f7d580053470)
