### PR TITLE
victoria-metrics-operator: fix missing patch serviceaccounts permission

### DIFF
--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fix missing serviceaccounts patch permission in ClusterRole, see [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1012) for details.
 
 ## 0.31.1
 

--- a/charts/victoria-metrics-operator/templates/cluster_role.yaml
+++ b/charts/victoria-metrics-operator/templates/cluster_role.yaml
@@ -57,30 +57,44 @@ rules:
   - ""
   resources:
   - services
+  - services/finalizers
   verbs:
   - '*'
 - apiGroups:
   - ""
   resources:
-  - services/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
   verbs:
   - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - 'create'
+- apiGroups:
+    - ""
+  resources:
+    - nodes
+    - nodes/proxy
+    - services
+    - endpoints
+    - pods
+    - endpointslices
+    - configmaps
+    - nodes/metrics
+    - namespaces
+  verbs:
+    - get
+    - list
+    - watch
 - apiGroups:
   - apps
   resources:
   - deployments
   - deployments/finalizers
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
   - replicasets
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
   - statefulsets
   - statefulsets/finalizers
   - statefulsets/status
@@ -157,22 +171,6 @@ rules:
   - patch
   - update
 - apiGroups:
-    - ""
-  resources:
-    - nodes
-    - nodes/proxy
-    - services
-    - endpoints
-    - pods
-    - endpointslices
-    - configmaps
-    - nodes/metrics
-    - namespaces
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
     - "extensions"
     - "networking.k8s.io"
   resources:
@@ -218,18 +216,6 @@ rules:
     - update
     - use
     - watch
-    - delete
-- apiGroups:
-    - ""
-  resources:
-    - serviceaccounts
-    - serviceaccounts/finalizers
-  verbs:
-    - get
-    - list
-    - create
-    - watch
-    - update
     - delete
 - apiGroups:
     - storage.k8s.io
@@ -293,10 +279,4 @@ rules:
     - list
     - watch
     - get
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - 'create'
 {{- end -}}


### PR DESCRIPTION
address https://github.com/VictoriaMetrics/helm-charts/issues/1012.
follow up https://github.com/VictoriaMetrics/operator/commit/6f35883c2d4766e66d899b432ed5acbc505545d9, operator needs SA patch permission