### PR TITLE
charts/victoria-logs-single: chart improvements, update to 0.8.0

### DIFF
--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-- TODO
+- Upgrade VictoriaLogs to [v0.8.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v0.8.0-victorialogs)
+- Move `.Values.server.name`, `.Values.server.fullnameOverride` to `.Values.global.victoriaLogs.server`. This allows to avoid issues with Fluent Bit output definition. See the [pull request]() for the details.
+- Include `kubernetes_namespace_name` field in the [stream fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) configuration of Fluent Bit output.
 
 ## 0.3.8
 

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v0.5.2-victorialogs
+appVersion: v0.8.0-victorialogs
 description: Victoria Logs Single version - high-performance, cost-effective and scalable logs storage
 name: victoria-logs-single
-version: 0.3.8
+version: 0.4.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/README.md
+++ b/charts/victoria-logs-single/README.md
@@ -1,6 +1,6 @@
 # Victoria Logs Helm Chart for Single Version
 
- ![Version: 0.3.8](https://img.shields.io/badge/Version-0.3.8-informational?style=flat-square)
+ ![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/victoriametrics)](https://artifacthub.io/packages/helm/victoriametrics/victoria-logs-single)
 [![Slack](https://img.shields.io/badge/join%20slack-%23victoriametrics-brightgreen.svg)](https://slack.victoriametrics.com/)
 
@@ -115,7 +115,7 @@ Change the values according to the need of the environment in ``victoria-logs-si
 |-----|------|---------|-------------|
 | extraObjects | list | `[]` |  |
 | fluent-bit.config.filters | string | `"[FILTER]\n    Name kubernetes\n    Match kube.*\n    Merge_Log On\n    Keep_Log On\n    K8S-Logging.Parser On\n    K8S-Logging.Exclude On\n[FILTER]\n    Name                nest\n    Match               *\n    Wildcard            pod_name\n    Operation lift\n    Nested_under kubernetes\n    Add_prefix   kubernetes_\n"` |  |
-| fluent-bit.config.outputs | string | `"[OUTPUT]\n    Name http\n    Match kube.*\n    Host {{ .Release.Name }}-victoria-logs-single-server\n    port 9428\n    compress gzip\n    uri /insert/jsonline?_stream_fields=stream,kubernetes_pod_name,kubernetes_container_name&_msg_field=log&_time_field=date\n    format json_lines\n    json_date_format iso8601\n    header AccountID 0\n    header ProjectID 0\n"` | Note that Host must be replaced to match your VictoriaLogs service name Default format is: {{release_name}}-victoria-logs-single-server |
+| fluent-bit.config.outputs | string | `"[OUTPUT]\n    Name http\n    Match kube.*\n    Host {{ include \"victoria-logs.server.fullname\" . }}\n    port 9428\n    compress gzip\n    uri /insert/jsonline?_stream_fields=stream,kubernetes_pod_name,kubernetes_container_name,kubernetes_namespace_name&_msg_field=log&_time_field=date\n    format json_lines\n    json_date_format iso8601\n    header AccountID 0\n    header ProjectID 0\n"` | Note that Host must be replaced to match your VictoriaLogs service name Default format points to VictoriaLogs service. |
 | fluent-bit.daemonSetVolumeMounts[0].mountPath | string | `"/var/log"` |  |
 | fluent-bit.daemonSetVolumeMounts[0].name | string | `"varlog"` |  |
 | fluent-bit.daemonSetVolumeMounts[1].mountPath | string | `"/var/lib/docker/containers"` |  |
@@ -128,6 +128,9 @@ Change the values according to the need of the environment in ``victoria-logs-si
 | fluent-bit.enabled | bool | `false` | Enable deployment of fluent-bit |
 | fluent-bit.resources | object | `{}` |  |
 | global.compatibility.openshift.adaptSecurityContext | string | `"auto"` |  |
+| global.nameOverride | string | `""` |  |
+| global.victoriaLogs.server.fullnameOverride | string | `nil` | Overrides the full name of server component |
+| global.victoriaLogs.server.name | string | `"server"` | Server container name |
 | podDisruptionBudget.enabled | bool | `false` | See `kubectl explain poddisruptionbudget.spec` for more. Ref: [https://kubernetes.io/docs/tasks/run-application/configure-pdb/](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | podDisruptionBudget.extraLabels | object | `{}` |  |
 | printNotes | bool | `true` | Print chart notes |
@@ -144,10 +147,9 @@ Change the values according to the need of the environment in ``victoria-logs-si
 | server.extraLabels | object | `{}` | Sts/Deploy additional labels |
 | server.extraVolumeMounts | list | `[]` |  |
 | server.extraVolumes | list | `[]` |  |
-| server.fullnameOverride | string | `nil` | Overrides the full name of server component |
 | server.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | server.image.repository | string | `"victoriametrics/victoria-logs"` | Image repository |
-| server.image.tag | string | `"v0.5.2-victorialogs"` | Image tag |
+| server.image.tag | string | `"v0.8.0-victorialogs"` | Image tag |
 | server.ingress.annotations | string | `nil` | Ingress annotations |
 | server.ingress.enabled | bool | `false` | Enable deployment of ingress for server component |
 | server.ingress.extraLabels | object | `{}` | Ingress extra labels |
@@ -162,7 +164,6 @@ Change the values according to the need of the environment in ``victoria-logs-si
 | server.livenessProbe.initialDelaySeconds | int | `30` |  |
 | server.livenessProbe.periodSeconds | int | `30` |  |
 | server.livenessProbe.timeoutSeconds | int | `5` |  |
-| server.name | string | `"server"` | Server container name |
 | server.nodeSelector | object | `{}` | Pod's node selector. Ref: [https://kubernetes.io/docs/user-guide/node-selection/](https://kubernetes.io/docs/user-guide/node-selection/) |
 | server.persistentVolume.accessModes | list | `["ReadWriteOnce"]` | Array of access modes. Must match those of existing PV or dynamic provisioner. Ref: [http://kubernetes.io/docs/user-guide/persistent-volumes/](http://kubernetes.io/docs/user-guide/persistent-volumes/) |
 | server.persistentVolume.annotations | object | `{}` | Persistant volume annotations |

--- a/charts/victoria-logs-single/templates/_helpers.tpl
+++ b/charts/victoria-logs-single/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "victoria-logs.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.global.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,10 +12,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "victoria-logs.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.global.victoriaLogs.server.fullnameOverride -}}
+{{- .Values.global.victoriaLogs.server.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name := default .Chart.Name .Values.global.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -54,23 +54,27 @@ app.kubernetes.io/managed-by: {{ .Release.Service | trunc 63 | trimSuffix "-" }}
 {{- end -}}
 
 {{- define "victoria-logs.server.matchLabels" -}}
-app: {{ .Values.server.name }}
+app: {{ .Values.global.victoriaLogs.server.name }}
 {{ include "victoria-logs.common.matchLabels" . }}
 {{- end -}}
 
 {{/*
 Create a fully qualified server name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+
+Use hardcoded default value as this template will be used in Fluent Bit chart
+and .Chart.Name will be "fluent-bit" in sub-chart context.
 */}}
 {{- define "victoria-logs.server.fullname" -}}
-{{- if .Values.server.fullnameOverride -}}
-{{- .Values.server.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.global.victoriaLogs.server.fullnameOverride -}}
+{{- .Values.global.victoriaLogs.server.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+
+{{- $name := default "victoria-logs-single" .Values.global.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.server.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Values.global.victoriaLogs.server.name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.server.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.global.victoriaLogs.server.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -79,17 +83,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "split-host-port" -}}
 {{- $hp := split ":" . -}}
 {{- printf "%s" $hp._1 -}}
-{{- end -}}
-
-{{/*
-Defines the name of scrape configuration map
-*/}}
-{{- define "victoria-logs.server.scrape.configname" -}}
-{{- if .Values.server.scrape.configMap -}}
-{{- .Values.server.scrape.configMap -}}
-{{- else -}}
-{{- include "victoria-logs.server.fullname" . -}}-scrapeconfig
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/victoria-logs-single/templates/server-deployment.yaml
+++ b/charts/victoria-logs-single/templates/server-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         {{- include "victoria-logs.initContiners" . | nindent 8 }}
       {{- end }}
       containers:
-        - name: {{ template "victoria-logs.name" . }}-{{ .Values.server.name }}
+        - name: {{ template "victoria-logs.name" . }}-{{ .Values.global.victoriaLogs.server.name }}
           {{- if .Values.server.securityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.server.securityContext "context" $) | nindent 12 }}
           {{- end }}
@@ -98,7 +98,7 @@ spec:
               readOnly: {{ .readOnly }}
           {{- end }}
           {{- range .Values.server.extraConfigmapMounts }}
-            - name: {{ $.Values.server.name }}-{{ .name }}
+            - name: {{ $.Values.global.victoriaLogs.server }}-{{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}

--- a/charts/victoria-logs-single/templates/server-statefulset.yaml
+++ b/charts/victoria-logs-single/templates/server-statefulset.yaml
@@ -43,7 +43,7 @@ spec:
         {{- include "victoria-logs.initContiners" . | nindent 8 }}
       {{- end }}
       containers:
-        - name: {{ template "victoria-logs.name" . }}-{{ .Values.server.name }}
+        - name: {{ template "victoria-logs.name" . }}-{{ .Values.global.victoriaLogs.server.name }}
           {{- if .Values.server.securityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.server.securityContext "context" $) | nindent 12 }}
           {{- end }}

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -2,6 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 global:
+  nameOverride: ""
+  victoriaLogs:
+    server:
+      # -- Overrides the full name of server component
+      fullnameOverride:
+
+      # -- Server container name
+      name: server
+
   compatibility:
     openshift:
       adaptSecurityContext: "auto"
@@ -18,19 +27,15 @@ podDisruptionBudget:
 server:
   # -- Enable deployment of server component. Deployed as StatefulSet
   enabled: true
-  # -- Server container name
-  name: server
   image:
     # -- Image repository
     repository: victoriametrics/victoria-logs
     # -- Image tag
-    tag: "v0.5.2-victorialogs"
+    tag: "v0.8.0-victorialogs"
     # -- Image pull policy
     pullPolicy: IfNotPresent
   # -- Name of Priority Class
   priorityClassName: ""
-  # -- Overrides the full name of server component
-  fullnameOverride:
   # -- Data retention period in month
   retentionPeriod: 1
   # Extra command line arguments for container of component
@@ -304,15 +309,15 @@ fluent-bit:
 
   config:
     # -- Note that Host must be replaced to match your VictoriaLogs service name
-    # Default format is: {{release_name}}-victoria-logs-single-server
+    # Default format points to VictoriaLogs service.
     outputs: |
       [OUTPUT]
           Name http
           Match kube.*
-          Host {{ .Release.Name }}-victoria-logs-single-server
+          Host {{ include "victoria-logs.server.fullname" . }}
           port 9428
           compress gzip
-          uri /insert/jsonline?_stream_fields=stream,kubernetes_pod_name,kubernetes_container_name&_msg_field=log&_time_field=date
+          uri /insert/jsonline?_stream_fields=stream,kubernetes_pod_name,kubernetes_container_name,kubernetes_namespace_name&_msg_field=log&_time_field=date
           format json_lines
           json_date_format iso8601
           header AccountID 0


### PR DESCRIPTION
- update VictoriaLogs to v0.8.0
- Move parameters used for service name templating from ".Values.server" to ".Values.global.victoriaLogs". This is required to make a seamless integration with Fluent Bit output. Moving values to ".Values.global" allows to ensure that service name rendered in subchart will be using the same context as parent chart.
  - Include k8s namespace in default stream fields configuration to make it easier to filter logs.
  - Remove unused "scrape" template.