### PR TITLE
victoria-metrics-cluster: change components image template

### DIFF
--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-- TODO
+**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+
+- support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 
 ## 0.10.8
 

--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+**Update note**: The VictoriaMetrics components image tag template has been updated. This change introduces `.Values.<component>.image.variant` to specify tag suffixes like `-scratch`, `-cluster`, `-enterprise`. Additionally, you can now omit `.Values.<component>.image.tag` to automatically use the version specified in `.Chart.AppVersion`.
 
 - support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 

--- a/charts/victoria-metrics-agent/templates/deployment.yaml
+++ b/charts/victoria-metrics-agent/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           {{- if .Values.securityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.securityContext "context" $) | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}{{- with .Values.image.variant }}-{{ . }}{{- end }}"
           workingDir: {{ .Values.containerWorkingDir }}
           args:
             - -promscrape.config=/config/scrape.yml

--- a/charts/victoria-metrics-agent/templates/statefulset.yaml
+++ b/charts/victoria-metrics-agent/templates/statefulset.yaml
@@ -58,7 +58,7 @@ spec:
           {{- if .Values.securityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.securityContext "context" $) | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}{{- with .Values.image.variant }}-{{ . }}{{- end }}"
           workingDir: {{ .Values.containerWorkingDir }}
           args:
             - -promscrape.config=/config/scrape.yml

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -34,6 +34,9 @@ statefulset:
 image:
   repository: victoriametrics/vmagent
   tag: "" # rewrites Chart.AppVersion
+  # Variant of the image to use.
+  # e.g. enterprise, scratch
+  variant: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-- TODO
+**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+
+- support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 
 ## 0.9.8
 

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+**Update note**: The VictoriaMetrics components image tag template has been updated. This change introduces `.Values.<component>.image.variant` to specify tag suffixes like `-scratch`, `-cluster`, `-enterprise`. Additionally, you can now omit `.Values.<component>.image.tag` to automatically use the version specified in `.Chart.AppVersion`.
 
 - support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -55,7 +55,7 @@ spec:
           {{- if .Values.server.securityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.server.securityContext "context" $) | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.server.image.repository }}:{{ default .Chart.AppVersion .Values.server.image.tag }}"
+          image: "{{ .Values.server.image.repository }}:{{ default .Chart.AppVersion .Values.server.image.tag }}{{- with .Values.server.image.variant }}-{{ . }}{{- end }}"
           args:
             - -rule=/config/alert-rules.yaml
             - -datasource.url={{ .Values.server.datasource.url}}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -31,6 +31,9 @@ server:
   image:
     repository: victoriametrics/vmalert
     tag: "" # rewrites Chart.AppVersion
+    # Variant of the image to use.
+    # e.g. enterprise, scratch
+    variant: ""
     pullPolicy: IfNotPresent
   nameOverride: ""
   fullnameOverride: ""

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-- TODO
+**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+
+- support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 
 ## 0.4.12
 

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+**Update note**: The VictoriaMetrics components image tag template has been updated. This change introduces `.Values.<component>.image.variant` to specify tag suffixes like `-scratch`, `-cluster`, `-enterprise`. Additionally, you can now omit `.Values.<component>.image.tag` to automatically use the version specified in `.Chart.AppVersion`.
 
 - support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 

--- a/charts/victoria-metrics-auth/templates/deployment.yaml
+++ b/charts/victoria-metrics-auth/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           {{- if .Values.securityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.securityContext "context" $) | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}{{- with .Values.image.variant }}-{{ . }}{{- end }}"
           workingDir: {{ .Values.containerWorkingDir }}
           args:
             - -auth.config=/config/auth.yml

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -14,6 +14,9 @@ image:
   repository: victoriametrics/vmauth
   # -- Tag of Docker image
   tag: "" # rewrites Chart.AppVersion
+  # Variant of the image to use.
+  # e.g. enterprise, scratch
+  variant: ""
   # -- Pull policy of Docker image
   pullPolicy: IfNotPresent
 

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Next release
 
-- Added fix for [issue](https://github.com/VictoriaMetrics/helm-charts/issues/1060) to support the custom port name for vmselect and vminsert in [pull request](https://github.com/VictoriaMetrics/helm-charts/pull/1061)
+**Update note**: The VictoriaMetrics components image tag template has been updated. This change introduces `.Values.<component>.image.variant` to specify tag suffixes like `-scratch`, `-cluster`, `-enterprise`. Additionally, you can now omit `.Values.<component>.image.tag` to automatically use the version specified in `.Chart.AppVersion`.
+
+- fix workload's readinessProbe and livenessProbe when using custom port name. Thanks to @hanumanhuda for [the pull request](https://github.com/VictoriaMetrics/helm-charts/pull/1061).
+- support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 
 ## 0.11.18
 

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -236,7 +236,7 @@ Return if ingress supports pathType.
 {{- end -}}
 {{- if .Values.vmstorage.vmbackupmanager.restore.onStart.enabled }}
 - name: {{ template "victoria-metrics.name" . }}-vmbackupmanager-restore
-  image: "{{ .Values.vmstorage.vmbackupmanager.image.repository }}:{{ .Values.vmstorage.vmbackupmanager.image.tag }}"
+  image: "{{ .Values.vmstorage.vmbackupmanager.image.repository }}:{{ default .Chart.AppVersion .Values.vmstorage.vmbackupmanager.image.tag }}{{- with .Values.vmstorage.vmbackupmanager.image.variant }}-{{ . }}{{- end }}"
   imagePullPolicy: "{{ .Values.vmstorage.image.pullPolicy }}"
   {{- with .Values.vmstorage.podSecurityContext }}
   securityContext:  {{ toYaml . | nindent 4 }}

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "victoria-metrics.name" . }}-{{ .Values.vminsert.name }}
-          image: "{{ .Values.vminsert.image.repository }}:{{ .Values.vminsert.image.tag }}"
+          image: "{{ .Values.vminsert.image.repository }}:{{ default .Chart.AppVersion .Values.vminsert.image.tag }}{{- with .Values.vminsert.image.variant }}-{{ . }}{{- end }}"
           imagePullPolicy: "{{ .Values.vminsert.image.pullPolicy }}"
           {{- if .Values.vminsert.containerWorkingDir }}
           workingDir: {{ .Values.vminsert.containerWorkingDir }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "victoria-metrics.name" . }}-{{ .Values.vmselect.name }}
-          image: "{{ .Values.vmselect.image.repository }}:{{ .Values.vmselect.image.tag }}"
+          image: "{{ .Values.vmselect.image.repository }}:{{ default .Chart.AppVersion .Values.vmselect.image.tag }}{{- with .Values.vmselect.image.variant }}-{{ . }}{{- end }}"
           imagePullPolicy: "{{ .Values.vmselect.image.pullPolicy }}"
           {{- if .Values.vmselect.containerWorkingDir }}
           workingDir: {{ .Values.vmselect.containerWorkingDir }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "victoria-metrics.name" . }}-{{ .Values.vmselect.name }}
-          image: "{{ .Values.vmselect.image.repository }}:{{ .Values.vmselect.image.tag }}"
+          image: "{{ .Values.vmselect.image.repository }}:{{ default .Chart.AppVersion .Values.vmselect.image.tag }}{{- with .Values.vmselect.image.variant }}-{{ . }}{{- end }}"
           imagePullPolicy: "{{ .Values.vmselect.image.pullPolicy }}"
           {{- if .Values.vmselect.containerWorkingDir }}
           workingDir: {{ .Values.vmselect.containerWorkingDir }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "victoria-metrics.name" . }}-{{ .Values.vmstorage.name }}
-          image: "{{ .Values.vmstorage.image.repository }}:{{ .Values.vmstorage.image.tag }}"
+          image: "{{ .Values.vmstorage.image.repository }}:{{ default .Chart.AppVersion .Values.vmstorage.image.tag }}{{- with .Values.vmstorage.image.variant }}-{{ . }}{{- end }}"
           imagePullPolicy: "{{ .Values.vmstorage.image.pullPolicy }}"
           {{- if .Values.vmstorage.containerWorkingDir }}
           workingDir: {{ .Values.vmstorage.containerWorkingDir }}
@@ -122,7 +122,7 @@ spec:
           {{- include "chart.license.mount" . | nindent 12 }}
         {{- if .Values.vmstorage.vmbackupmanager.enable }}
         - name: {{ template "victoria-metrics.name" . }}-vmbackupmanager
-          image: "{{ .Values.vmstorage.vmbackupmanager.image.repository }}:{{ .Values.vmstorage.vmbackupmanager.image.tag }}"
+          image: "{{ .Values.vmstorage.vmbackupmanager.image.repository }}:{{ default .Chart.AppVersion .Values.vmstorage.vmbackupmanager.image.tag }}{{- with .Values.vmstorage.vmbackupmanager.image.variant }}-{{ . }}{{- end }}"
           imagePullPolicy: "{{ .Values.vmstorage.image.pullPolicy }}"
           {{- if .Values.vmstorage.securityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.vmstorage.securityContext "context" $) | nindent 12 }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -51,9 +51,13 @@ vmselect:
     # -- Image repository
     repository: victoriametrics/vmselect
     # -- Image tag
-    tag: v1.101.0-cluster
+    # override Chart.AppVersion
+    tag: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
+    # Variant of the image to use.
+    # e.g. cluster, enterprise-cluster
+    variant: "cluster"
   ports: 
     name: "http"
   # -- Name of Priority Class
@@ -292,7 +296,11 @@ vminsert:
     # -- Image repository
     repository: victoriametrics/vminsert
     # -- Image tag
-    tag: v1.101.0-cluster
+    # override Chart.AppVersion    
+    tag: ""
+    # Variant of the image to use.
+    # e.g. cluster, enterprise-cluster
+    variant: "cluster"
     # -- Image pull policy
     pullPolicy: IfNotPresent
   ports: 
@@ -485,7 +493,11 @@ vmstorage:
     # -- Image repository
     repository: victoriametrics/vmstorage
     # -- Image tag
-    tag: v1.101.0-cluster
+    # override Chart.AppVersion
+    tag: ""
+    # Variant of the image to use.
+    # e.g. cluster, enterprise-cluster
+    variant: "cluster"
     # -- Image pull policy
     pullPolicy: IfNotPresent
   ports: 
@@ -679,7 +691,11 @@ vmstorage:
       # -- vmbackupmanager image repository
       repository: victoriametrics/vmbackupmanager
       # -- vmbackupmanager image tag
-      tag: v1.101.0-enterprise
+      # override Chart.AppVersion
+      tag: ""
+      # Variant of the image to use.
+      # e.g. enterprise
+      variant: "enterprise"
     # -- disable hourly backups
     disableHourly: false
     # -- disable daily backups

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -52,12 +52,12 @@ vmselect:
     repository: victoriametrics/vmselect
     # -- Image tag
     # override Chart.AppVersion
-    tag: ""
+    tag: v1.101.0-cluster
     # -- Image pull policy
     pullPolicy: IfNotPresent
     # Variant of the image to use.
     # e.g. cluster, enterprise-cluster
-    variant: "cluster"
+    variant: ""
   ports: 
     name: "http"
   # -- Name of Priority Class
@@ -297,10 +297,10 @@ vminsert:
     repository: victoriametrics/vminsert
     # -- Image tag
     # override Chart.AppVersion    
-    tag: ""
+    tag: v1.101.0-cluster
     # Variant of the image to use.
     # e.g. cluster, enterprise-cluster
-    variant: "cluster"
+    variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
   ports: 
@@ -494,10 +494,10 @@ vmstorage:
     repository: victoriametrics/vmstorage
     # -- Image tag
     # override Chart.AppVersion
-    tag: ""
+    tag: v1.101.0-cluster
     # Variant of the image to use.
     # e.g. cluster, enterprise-cluster
-    variant: "cluster"
+    variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
   ports: 
@@ -692,10 +692,10 @@ vmstorage:
       repository: victoriametrics/vmbackupmanager
       # -- vmbackupmanager image tag
       # override Chart.AppVersion
-      tag: ""
-      # Variant of the image to use.
-      # e.g. enterprise
-      variant: "enterprise"
+      tag: v1.101.0-enterprise
+      # Variant of the image tag to use.
+      # e.g. enterprise.
+      variant: ""
     # -- disable hourly backups
     disableHourly: false
     # -- disable daily backups

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-- TODO
+**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+
+- support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 
 ## 0.1.61
 

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+**Update note**: The VictoriaMetrics components image tag template has been updated. This change introduces `.Values.<component>.image.variant` to specify tag suffixes like `-scratch`, `-cluster`, `-enterprise`. Additionally, you can now omit `.Values.<component>.image.tag` to automatically use the version specified in `.Chart.AppVersion`.
 
 - support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 

--- a/charts/victoria-metrics-gateway/templates/deployment.yaml
+++ b/charts/victoria-metrics-gateway/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
           {{- if .Values.securityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.securityContext "context" $) | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}{{- with .Values.image.variant }}-{{ . }}{{- end }}"
           workingDir: {{ .Values.containerWorkingDir }}
           args:
             - -clusterMode={{ .Values.clusterMode }}

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -13,7 +13,11 @@ image:
   # -- Victoria Metrics gateway Docker repository and image name
   repository: victoriametrics/vmgateway
   # -- Tag of Docker image
+  # override Chart.AppVersion
   tag: v1.101.0-enterprise
+  # Variant of the image to use.
+  # e.g. enterprise, enterprise-scratch
+  variant: ""
   # -- Pull policy of Docker image
   pullPolicy: IfNotPresent
 

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-- TODO
+**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+
+- support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 
 ## 0.32.0
 

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+**Update note**: The VictoriaMetrics components image tag template has been updated. This change introduces `.Values.<component>.image.variant` to specify tag suffixes like `-scratch`, `-cluster`, `-enterprise`. Additionally, you can now omit `.Values.<component>.image.tag` to automatically use the version specified in `.Chart.AppVersion`.
 
 - support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 

--- a/charts/victoria-metrics-operator/templates/deployment.yaml
+++ b/charts/victoria-metrics-operator/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: {{ template "vm-operator.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}{{- with .Values.image.variant }}-{{ . }}{{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.envFrom }}
           envFrom:

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -5,7 +5,11 @@ image:
   # -- Image repository
   repository: victoriametrics/operator
   # -- Image tag
-  tag: v0.45.0
+  # override Chart.AppVersion
+  tag: ""
+  # Variant of the image to use.
+  # e.g. scratch
+  variant: ""
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-- TODO
+**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+
+- support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 
 ## 0.9.21
 

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-**Update note: VictoriaMetrics components image tag template have been changed, tag suffix like `-scratch`, `-cluster`, `-enterprise` can be specified in `.Values.<component>.image.variant`, `.Values.<component>.image.tag` can be omitted if it's the same as `.Chart.AppVersion`.
+**Update note**: The VictoriaMetrics components image tag template has been updated. This change introduces `.Values.<component>.image.variant` to specify tag suffixes like `-scratch`, `-cluster`, `-enterprise`. Additionally, you can now omit `.Values.<component>.image.tag` to automatically use the version specified in `.Chart.AppVersion`.
 
 - support specifying image tag suffix like "-enterprise" for VictoriaMetrics components using `.Values.<component>.image.variant`.
 

--- a/charts/victoria-metrics-single/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-single/templates/server-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           {{- if .Values.server.securityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.server.securityContext "context" $) | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.server.image.repository }}:{{ default .Chart.AppVersion .Values.server.image.tag }}"
+          image: "{{ .Values.server.image.repository }}:{{ default .Chart.AppVersion .Values.server.image.tag }}{{- with .Values.server.image.variant }}-{{ . }}{{- end }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           {{- if .Values.server.containerWorkingDir }}
           workingDir: {{ .Values.server.containerWorkingDir }}
@@ -168,7 +168,7 @@ spec:
           {{- end }}
         {{- if .Values.server.vmbackupmanager.enable }}
         - name: {{ template "victoria-metrics.name" . }}-vmbackupmanager
-          image: "{{ .Values.server.vmbackupmanager.image.repository }}:{{ .Values.server.vmbackupmanager.image.tag }}"
+          image: "{{ .Values.server.vmbackupmanager.image.repository }}:{{ default .Chart.AppVersion .Values.server.vmbackupmanager.image.tag }}{{- with .Values.server.vmbackupmanager.image.variant }}-{{ . }}{{- end }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           args:
             - {{ printf "%s=%t" "--eula" .Values.server.vmbackupmanager.eula | quote}}

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
           {{- if .Values.server.securityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.server.securityContext "context" $) | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.server.image.repository }}:{{ default .Chart.AppVersion .Values.server.image.tag }}"
+          image: "{{ .Values.server.image.repository }}:{{ default .Chart.AppVersion .Values.server.image.tag }}{{- with .Values.server.image.variant }}-{{ . }}{{- end }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           {{- if .Values.server.containerWorkingDir }}
           workingDir: {{ .Values.server.containerWorkingDir }}
@@ -165,7 +165,7 @@ spec:
           {{- end }}
         {{- if .Values.server.vmbackupmanager.enable }}
         - name: {{ template "victoria-metrics.name" . }}-vmbackupmanager
-          image: "{{ .Values.server.vmbackupmanager.image.repository }}:{{ .Values.server.vmbackupmanager.image.tag }}"
+          image: "{{ .Values.server.vmbackupmanager.image.repository }}:{{ default .Chart.AppVersion .Values.server.vmbackupmanager.image.tag }}{{- with .Values.server.vmbackupmanager.image.variant }}-{{ . }}{{- end }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           args:
             - {{ printf "%s=%t" "--eula" .Values.server.vmbackupmanager.eula | quote}}

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -45,6 +45,9 @@ server:
     repository: victoriametrics/victoria-metrics
     # -- Image tag
     tag: "" # rewrites Chart.AppVersion
+    # Variant of the image tag to use.
+    # e.g. enterprise.
+    variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
   # -- Name of Priority Class
@@ -251,6 +254,9 @@ server:
       repository: victoriametrics/vmbackupmanager
       # -- vmbackupmanager image tag
       tag: v1.101.0-enterprise
+      # Variant of the image tag to use.
+      # e.g. enterprise.
+      variant: ""
     # -- disable hourly backups
     disableHourly: false
     # -- disable daily backups


### PR DESCRIPTION
This change syncs the image tags with `.Chart.AppVersion` directly, and makes it possible to upgrade chart without modifying image tag for users who use customized images with suffix `-enterprise` or `-scratch`. 
But it brings breaking change for user who is using non-default tags, they need to remove the `-cluster` suffix in tags.