### PR TITLE
victoria-metrics-cluster: Port name fix for custom port name in readiness and liveness check

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Added fix for [issue](https://github.com/VictoriaMetrics/helm-charts/issues/1060) to support the custom port name for vmselect and vminsert in [pull request](https://github.com/VictoriaMetrics/helm-charts/pull/1061)
 
 ## 0.11.18
 

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -129,7 +129,7 @@ spec:
             {{- else }}
               path: /health
             {{- end }}
-              port: http
+              port: "{{ .Values.vminsert.ports.name  | default "http" }}"
             {{- if .Values.vminsert.extraArgs.tls }}
               scheme: HTTPS
             {{- else }}
@@ -141,7 +141,7 @@ spec:
             failureThreshold: {{ .Values.vminsert.probe.readiness.failureThreshold }}
           livenessProbe:
             tcpSocket:
-              port: http
+              port: "{{ .Values.vminsert.ports.name  | default "http" }}"
             initialDelaySeconds: {{ .Values.vminsert.probe.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.vminsert.probe.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.vminsert.probe.liveness.timeoutSeconds }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -95,7 +95,7 @@ spec:
             {{- else }}
               path: /health
             {{- end }}
-              port: http
+              port: "{{ .Values.vmselect.ports.name | default "http" }}" 
             {{- if .Values.vmselect.extraArgs.tls }}
               scheme: HTTPS
             {{- else }}
@@ -107,7 +107,7 @@ spec:
             failureThreshold: {{ .Values.vmselect.probe.readiness.failureThreshold }}
           livenessProbe:
             tcpSocket:
-              port: http
+              port: "{{ .Values.vmselect.ports.name | default "http" }}" 
             initialDelaySeconds: {{ .Values.vmselect.probe.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.vmselect.probe.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.vmselect.probe.liveness.timeoutSeconds }}


### PR DESCRIPTION
fixing https://github.com/VictoriaMetrics/helm-charts/issues/1060