### PR TITLE
charts/victoria-metrics-k8s-stack: do not add "cluster" label by default

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Do not add `cluster` external label at VMAgent by default. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/774) for the details. 
 
 ## 0.23.1
 

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -583,8 +583,10 @@ vmagent:
     image:
       tag: v1.101.0
     scrapeInterval: 20s
-    externalLabels:
-      cluster: cluster-name
+    externalLabels: {}
+      # For multi-cluster setups it is useful to use "cluster" label to identify the metrics source.
+      # For example:
+      # cluster: cluster-name
     extraArgs:
       promscrape.streamParse: "true"
       # Do not store original labels in vmagent's memory by default. This reduces the amount of memory used by vmagent


### PR DESCRIPTION
Adding "cluster" label by default is only useful for multi-cluster setups, which is a rare case. It is also hard to override this value to an empty map due to merge logic in Helm.