### PR TITLE
victoria-metrics-operator: fix default image tag when using `Chart.Ap…

### DIFF
--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fix default image tag when using `Chart.AppVersion`, previously the version is missing "v".
 
 ## 0.32.1
 

--- a/charts/victoria-metrics-operator/Chart.yaml
+++ b/charts/victoria-metrics-operator/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
-appVersion: 0.45.0
+appVersion: v0.45.0
 description: Victoria Metrics Operator
 name: victoria-metrics-operator
 home: https://github.com/VictoriaMetrics/operator
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
   - https://github.com/VictoriaMetrics/operator
-version: 0.32.1
+version: 0.32.2
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
 kubeVersion: ">=1.23.0-0"
 keywords:


### PR DESCRIPTION
…pVersion`