### PR TITLE
Prometheus converter disabled by default in stack chart

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Enable [conversion of Prometheus CRDs](https://docs.victoriametrics.com/operator/migration/#objects-conversion) by default. See [this](https://github.com/VictoriaMetrics/helm-charts/pull/1069) pull request for details.
 
 ## 0.23.2
 

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.23.2
+version: 0.23.3
 appVersion: v1.101.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -21,7 +21,7 @@ victoria-metrics-operator:
   createCRD: false # we disable crd creation by operator chart as we create them in this chart
   operator:
     # -- By default, operator converts prometheus-operator objects.
-    disable_prometheus_converter: true
+    disable_prometheus_converter: false
 
 serviceAccount:
   # -- Specifies whether a service account should be created


### PR DESCRIPTION
 Based on the documentation in the values file and in the [operator migration documentation](https://docs.victoriametrics.com/operator/migration/#objects-conversion). I believe that this should be set to false initially. This is similar to the [values in the operator stand alone chart](https://github.com/VictoriaMetrics/helm-charts/blob/dae3850b4cd9b1ca8a742a72dde9e0be0ddffc11/charts/victoria-metrics-operator/values.yaml#L69) where it is set to disabled false.

```yaml
operator:
    # -- By default, operator converts prometheus-operator objects.
    disable_prometheus_converter: true
```