### PR TITLE
charts/victoria-logs-single: fix command printed after chart installation

### DIFF
--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fix invalid label selector usage in notes printed after chart installation 
 
 ## 0.5.1
 

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.15.0-victorialogs
 description: Victoria Logs Single version - high-performance, cost-effective and scalable logs storage
 name: victoria-logs-single
-version: 0.5.1
+version: 0.5.2
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/templates/NOTES.txt
+++ b/charts/victoria-logs-single/templates/NOTES.txt
@@ -18,7 +18,7 @@ Logs Ingestion:
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "victoria-logs.server.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     echo http://$SERVICE_IP:{{ .Values.server.service.servicePort }}
 {{- else if contains "ClusterIP"  .Values.server.service.type }}
-    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ .Values.server.name }}" -o jsonpath="{.items[0].metadata.name}")
+    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ .Values.global.victoriaLogs.server.name }}" -o jsonpath="{.items[0].metadata.name}")
     kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.server.service.servicePort }}
 {{- end }}
 


### PR DESCRIPTION
Fix label selector which is printed in post installation notes.