### PR TITLE
ci: disable artifacthub changes annotations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,9 @@ jobs:
                 export RN_CONTENT="$(awk '/^## Next release/{flag=1;next}/^## /{flag=0}flag' $changelog | awk 'NF {p=1} p')"
           
                 # ArtifactHub annotation in Chart.yaml file
-                yq -M -i eval '.annotations["artifacthub.io/changes"] = strenv(RN_CONTENT)' $CHART_FILE
+                # artifacthub expects content of changes annotation to be yaml escaped string 
+                # currently, it's not possible to properly escape it with shell and requires to write script with python/go/other pl
+                # yq -M -i eval '.annotations["artifacthub.io/changes"] = strenv(RN_CONTENT)' $CHART_FILE
           
                 # Create release notes
                 echo "# Release notes for version $CHART_VERSION" > $RN_FILE


### PR DESCRIPTION
current version of annotations could break a release and requires a strict format of changelog entries

 Well known solution for it use some python script. But it brings additional complexity