### PR TITLE
feat: VPA for VMAlert

### DIFF
--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -237,10 +237,10 @@ Change the values according to the need of the environment in ``victoria-metrics
 | server.strategy.rollingUpdate.maxUnavailable | string | `"25%"` |  |
 | server.strategy.type | string | `"RollingUpdate"` |  |
 | server.tolerations | list | `[]` |  |
-| server.VerticalPodAutoscaler.enabled | bool | `false` |  |
-| server.VerticalPodAutoscaler.recommenders | object | `{}` |  |
-| server.VerticalPodAutoscaler.updatePolicy | object | `{}` |  |
-| server.VerticalPodAutoscaler.resourcePolicy | object | `{}` |  |
+| server.verticalPodAutoscaler.enabled | bool | `false` |  |
+| server.verticalPodAutoscaler.recommenders | object | `{}` |  |
+| server.verticalPodAutoscaler.updatePolicy | object | `{}` |  |
+| server.verticalPodAutoscaler.resourcePolicy | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automountToken | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -237,6 +237,10 @@ Change the values according to the need of the environment in ``victoria-metrics
 | server.strategy.rollingUpdate.maxUnavailable | string | `"25%"` |  |
 | server.strategy.type | string | `"RollingUpdate"` |  |
 | server.tolerations | list | `[]` |  |
+| server.VerticalPodAutoscaler.enabled | bool | `false` |  |
+| server.VerticalPodAutoscaler.recommenders | object | `{}` |  |
+| server.VerticalPodAutoscaler.updatePolicy | object | `{}` |  |
+| server.VerticalPodAutoscaler.resourcePolicy | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automountToken | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/victoria-metrics-alert/templates/vpa.yaml
+++ b/charts/victoria-metrics-alert/templates/vpa.yaml
@@ -2,23 +2,23 @@
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ include "chart.fullname" . }}
+  name: {{ include "vmalert.server.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.server.VerticalPodAutoscaler.recommenders }}
   recommenders:
     {{- range .Values.server.VerticalPodAutoscaler.recommenders }}
     - name: {{ . }}
-    {{- end -}}
-  {{- end -}}
+    {{- end }}
+  {{- end }}
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "chart.fullname" . }}
+    name: {{ include "vmalert.server.fullname" . }}
   {{- if .Values.server.VerticalPodAutoscaler.updatePolicy }}
   updatePolicy:
     {{ toYaml .Values.server.VerticalPodAutoscaler.updatePolicy | nindent 4 }}
-  {{- end -}}
+  {{- end }}
   {{- if .Values.server.VerticalPodAutoscaler.resourcePolicy }}
   resourcePolicy:
     {{ toYaml .Values.server.VerticalPodAutoscaler.resourcePolicy | nindent 4 }}

--- a/charts/victoria-metrics-alert/templates/vpa.yaml
+++ b/charts/victoria-metrics-alert/templates/vpa.yaml
@@ -8,7 +8,7 @@ spec:
   {{- if .Values.server.verticalPodAutoscaler.recommenders }}
   recommenders:
     {{- range .Values.server.verticalPodAutoscaler.recommenders }}
-    - name: {{ . }}
+    - name: {{ .name }}
     {{- end }}
   {{- end }}
   targetRef:

--- a/charts/victoria-metrics-alert/templates/vpa.yaml
+++ b/charts/victoria-metrics-alert/templates/vpa.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.server.VerticalPodAutoscaler.enabled }}
+{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") (.Values.server.verticalPodAutoscaler.enabled) }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "vmalert.server.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- if .Values.server.VerticalPodAutoscaler.recommenders }}
+  {{- if .Values.server.verticalPodAutoscaler.recommenders }}
   recommenders:
-    {{- range .Values.server.VerticalPodAutoscaler.recommenders }}
+    {{- range .Values.server.verticalPodAutoscaler.recommenders }}
     - name: {{ . }}
     {{- end }}
   {{- end }}
@@ -15,12 +15,12 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "vmalert.server.fullname" . }}
-  {{- if .Values.server.VerticalPodAutoscaler.updatePolicy }}
+  {{- if .Values.server.verticalPodAutoscaler.updatePolicy }}
   updatePolicy:
-    {{ toYaml .Values.server.VerticalPodAutoscaler.updatePolicy | nindent 4 }}
+    {{ toYaml .Values.server.verticalPodAutoscaler.updatePolicy | nindent 4 }}
   {{- end }}
-  {{- if .Values.server.VerticalPodAutoscaler.resourcePolicy }}
+  {{- if .Values.server.verticalPodAutoscaler.resourcePolicy }}
   resourcePolicy:
-    {{ toYaml .Values.server.VerticalPodAutoscaler.resourcePolicy | nindent 4 }}
+    {{ toYaml .Values.server.verticalPodAutoscaler.resourcePolicy | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-alert/templates/vpa.yaml
+++ b/charts/victoria-metrics-alert/templates/vpa.yaml
@@ -17,10 +17,10 @@ spec:
     name: {{ include "vmalert.server.fullname" . }}
   {{- if .Values.server.verticalPodAutoscaler.updatePolicy }}
   updatePolicy:
-    {{ toYaml .Values.server.verticalPodAutoscaler.updatePolicy | nindent 4 }}
+    {{- toYaml .Values.server.verticalPodAutoscaler.updatePolicy | nindent 4 }}
   {{- end }}
   {{- if .Values.server.verticalPodAutoscaler.resourcePolicy }}
   resourcePolicy:
-    {{ toYaml .Values.server.verticalPodAutoscaler.resourcePolicy | nindent 4 }}
+    {{- toYaml .Values.server.verticalPodAutoscaler.resourcePolicy | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-alert/templates/vpa.yaml
+++ b/charts/victoria-metrics-alert/templates/vpa.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.VerticalPodAutoscaler.enabled }}
+{{- if .Values.server.VerticalPodAutoscaler.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "chart.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- if .Values.VerticalPodAutoscaler.recommenders }}
+  {{- if .Values.server.VerticalPodAutoscaler.recommenders }}
   recommenders:
-    {{- range .Values.VerticalPodAutoscaler.recommenders }}
+    {{- range .Values.server.VerticalPodAutoscaler.recommenders }}
     - name: {{ . }}
     {{- end -}}
   {{- end -}}
@@ -15,12 +15,12 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "chart.fullname" . }}
-  {{- if .Values.VerticalPodAutoscaler.updatePolicy }}
+  {{- if .Values.server.VerticalPodAutoscaler.updatePolicy }}
   updatePolicy:
-    {{ toYaml .Values.VerticalPodAutoscaler.updatePolicy | nindent 4 }}
+    {{ toYaml .Values.server.VerticalPodAutoscaler.updatePolicy | nindent 4 }}
   {{- end -}}
-  {{- if .Values.VerticalPodAutoscaler.resourcePolicy }}
+  {{- if .Values.server.VerticalPodAutoscaler.resourcePolicy }}
   resourcePolicy:
-    {{ toYaml .Values.VerticalPodAutoscaler.resourcePolicy | nindent 4 }}
+    {{ toYaml .Values.server.VerticalPodAutoscaler.resourcePolicy | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-alert/templates/vpa.yaml
+++ b/charts/victoria-metrics-alert/templates/vpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.VerticalPodAutoscaler.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "chart.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{- if .Values.VerticalPodAutoscaler.recommenders }}
+  recommenders:
+    {{- range .Values.VerticalPodAutoscaler.recommenders }}
+    - name: {{ . }}
+    {{- end -}}
+  {{- end -}}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "chart.fullname" . }}
+  {{- if .Values.VerticalPodAutoscaler.updatePolicy }}
+  updatePolicy:
+    {{ toYaml .Values.VerticalPodAutoscaler.updatePolicy | nindent 4 }}
+  {{- end -}}
+  {{- if .Values.VerticalPodAutoscaler.resourcePolicy }}
+  resourcePolicy:
+    {{ toYaml .Values.VerticalPodAutoscaler.resourcePolicy | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -53,7 +53,7 @@ server:
     []
     #- configMapRef:
     #    name: special-config
-    
+
   # Readiness & Liveness probes
   probe:
     readiness:
@@ -271,6 +271,26 @@ server:
   config:
     alerts:
       groups: []
+
+  # -- Vertical Pod Autoscaler
+  VerticalPodAutoscaler:
+    # -- Use VPA for vmalert
+    enabled: false
+    # recommenders:
+    #   - name: 'alternative'
+    # updatePolicy:
+    #   updateMode: "Auto"
+    #   minReplicas: 1
+    # resourcePolicy:
+    #   containerPolicies:
+    #     - containerName: '*'
+    #       minAllowed:
+    #         cpu: 100m
+    #         memory: 128Mi
+    #       maxAllowed:
+    #         cpu: 1
+    #         memory: 500Mi
+    #       controlledResources: ["cpu", "memory"]
 
 serviceMonitor:
   enabled: false

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -273,7 +273,7 @@ server:
       groups: []
 
   # -- Vertical Pod Autoscaler
-  VerticalPodAutoscaler:
+  verticalPodAutoscaler:
     # -- Use VPA for vmalert
     enabled: false
     # recommenders:


### PR DESCRIPTION
Reason for this change - For components like VMAlert where scaling horizontally doesn't solve issues with processing alerts, scaling vertically is the only option to deal with scaling problems. 

Tested locally by installing VMAlert with and without VPA enabled from values file and both the times the installation worked.