### PR TITLE
fix: add metadata.namespace in serviceaccount template

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/serviceaccount.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "victoria-metrics-k8s-stack.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "victoria-metrics-k8s-stack.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
When we only use `helm template`, the `metadata.namespace` field will not be rendered, which can cause GitOps sync operations to fail.