### PR TITLE
chore(victoria-metrics-distributed): add optional writePath as vmagent may needs endpoint suffixes due to removal of CLI flag

### DIFF
--- a/charts/victoria-metrics-distributed/templates/_helpers.tpl
+++ b/charts/victoria-metrics-distributed/templates/_helpers.tpl
@@ -82,7 +82,7 @@ Lists all the ingest vmauth addresss as remote write addresses for per zone vmag
 {{- define "per-zone-vmagent.remoteWriteAddr" -}}
 {{- range $zone := .Values.availabilityZones }}
 {{- if $zone.allowIngest }}
-{{ printf "- url: http://vmauth-%s:8427" ( $zone.vmauthIngest.name | default (printf "vmauth-write-balancer-%s" $zone.name ) ) | indent 2 }}
+{{ printf "- url: http://vmauth-%s:8427%s" ( $zone.vmauthIngest.name | default (printf "vmauth-write-balancer-%s" $zone.name ) ) ($zone.vmagent.writePath | default "") | indent 2 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-distributed/values.yaml
+++ b/charts/victoria-metrics-distributed/values.yaml
@@ -68,6 +68,11 @@ availabilityZones:
     vmagent:
       enabled: true
       name: ""
+      ## vmagent's -remoteWrite.multitenantURL has been removed as of
+      ## https://github.com/VictoriaMetrics/operator/releases/tag/v0.46.0, so
+      ## writePath would need to be set (uncomment it) if cluster has a newer operator...
+      ## check https://docs.victoriametrics.com/cluster-victoriametrics/#url-format
+      # writePath: "/insert/multitenant/prometheus/api/v1/write"
       annotations: {}
       spec: {}
     vmcluster:


### PR DESCRIPTION
## Why
For users that have [VM Operator v0.46.0+](https://github.com/VictoriaMetrics/operator/releases/tag/v0.46.0) running on their cluster, there's a breaking change where VMAgent no longer supports the `-remoteWrite.multitenantURL` (which this vm-distrubuted chart assumes).

Therefore, we have to:

> multitenant endpoints suffix /insert/multitenant/<suffix> needs to be added in remoteWrite.url if storage supports multitenancy when using remoteWriteSettings.useMultiTenantMode, as upstream [vmagent](https://docs.victoriametrics.com/vmagent/) has deprecated -remoteWrite.multitenantURL command-line flag since v1.102.0.

This PR supports that.

Without it, for users using the latest operator, they'll see somthing like this in the vmagent logs:

```
YYYY-MM-DDT17:56:01.515Z	error	VictoriaMetrics/app/vmagent/remotewrite/client.go:439	sending a block with size 288236 bytes to "1:secret-url" was rejected (skipping the block): status code 400; response body: remoteAddr: "<redacted>:50268"; requestURI: /; missing route for ""
```

## This is a no-op by default

Only users that have the operator on the cluster out-of-band need this. 

(or) when the community decides to update the dependent stack on this chart for the new operator...

... that's when users can uncomment:

```
...
  vmagent:
  ...
    # writePath: "/insert/multitenant/prometheus/api/v1/write"
```