### PR TITLE
victoria-metrics-k8s-stack: fix vmalertmanager configuration when usi…

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fix vmalertmanager configuration when using `.VMAlertmanagerSpec.ConfigRawYaml`.
 
 ## 0.24.1
 

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- fix vmalertmanager configuration when using `.VMAlertmanagerSpec.ConfigRawYaml`.
+- fix vmalertmanager configuration when using `.VMAlertmanagerSpec.ConfigRawYaml`. See [this pull request](https://github.com/VictoriaMetrics/helm-charts/pull/1136).
 
 ## 0.24.1
 

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -307,7 +307,6 @@ Change the values according to the need of the environment in ``victoria-metrics
 | defaultDashboardsEnabled | bool | `true` |  |
 | defaultRules.annotations | object | `{}` | Annotations for default rules |
 | defaultRules.create | bool | `true` |  |
-| defaultRules.disabled | object | `{}` |  |
 | defaultRules.group | object | `{"spec":{"params":{}}}` | Common properties for VMRule groups |
 | defaultRules.group.spec.params | object | `{}` | Optional HTTP URL parameters added to each rule request |
 | defaultRules.groups.alertmanager.create | bool | `true` |  |

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -187,7 +187,9 @@ Alermanager spec
 */}}
 {{- define "victoria-metrics-k8s-stack.alertmanagerSpec" -}}
 {{ omit .Values.alertmanager.spec  "configMaps" "configSecret" | toYaml }}
+{{- if not .Values.alertmanager.spec.configRawYaml }}
 configSecret: {{ .Values.alertmanager.spec.configSecret | default (printf "%s-alertmanager" (include "victoria-metrics-k8s-stack.fullname" .)) }}
+{{- end }}
 {{- if .Values.alertmanager.spec.configMaps }}
 configMaps:
 {{- range compact .Values.alertmanager.spec.configMaps }}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/vmalertmanager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/vmalertmanager.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.alertmanager.enabled }}
-{{- if not .Values.alertmanager.spec.configSecret }}
+{{- if and .Values.alertmanager.spec.configRawYaml .Values.alertmanager.config }}
+{{- fail "ERROR: Both .Values.alertmanager.spec.configRawYaml and .Values.alertmanager.config are set, but only one is allowed." }}
+{{- end }}
+{{- if and (not .Values.alertmanager.spec.configSecret) (not .Values.alertmanager.spec.configRawYaml) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -40,24 +40,21 @@ defaultRules:
   # -- Common properties for VMRule groups
   group:
     spec:
-
       # -- Optional HTTP URL parameters added to each rule request
       params: {}
 
   # -- Common properties for VMRules
   rule:
     spec:
-
       # -- Additional labels for VMRule alerts
       labels: {}
-        # severity: critical
-
       # -- Additional annotations for VMRule alerts
       annotations: {}
 
   # -- Per rule properties
   rules: {}
     # CPUThrottlingHigh:
+    #   create: true
     #   spec:
     #     for: 15m
     #     labels:
@@ -65,7 +62,6 @@ defaultRules:
   groups:
     etcd:
       create: true
-
       # -- Common properties for all rules in a group
       rules: {}
       # spec:
@@ -175,9 +171,6 @@ defaultRules:
 
   # -- Runbook url prefix for default rules
   runbookUrl: https://runbooks.prometheus-operator.dev/runbooks
-
-  # Disabled VMRules
-  disabled: {}
 
   # -- Labels for default rules
   labels: {}


### PR DESCRIPTION
…ng `.VMAlertmanagerSpec.ConfigRawYaml`

`vmalertmanagerSpec.configSecret` has [higher priority](https://github.com/VictoriaMetrics/operator/blob/master/api/operator/v1beta1/vmalertmanager_types.go#L86) than `vmalertmanagerSpec.configRawYaml`, so it can't be specified when users add `.Values.alertmanager.spec.configRawYaml`.