### PR TITLE
victoria-metrics-distributed: fix default multitenancy mode and disable it by default

### DIFF
--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fix default multitenancy mode, see https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-distributed#how-to-use-multitenancy.
 
 ## 0.1.1
 

--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- fix default multitenancy mode, see https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-distributed#how-to-use-multitenancy.
+- Breaking change: disable multitenancy mode by default, see how to enable it in https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-distributed#how-to-use-multitenancy. See [this pull request](https://github.com/VictoriaMetrics/helm-charts/pull/1137) for details.
 
 ## 0.1.1
 

--- a/charts/victoria-metrics-distributed/Chart.lock
+++ b/charts/victoria-metrics-distributed/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-k8s-stack
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.23.2
-digest: sha256:a72c1548a85a85b4c2752d70231d253b94060fac10b14ac2ea8bc371f1fc1ab5
-generated: "2024-06-26T15:02:14.484885+08:00"
+  version: 0.24.1
+digest: sha256:ced67f540257c97e13dec7c12e29faa04f4d9328e7275f48865a3f8a6825d057
+generated: "2024-07-11T17:41:26.890616+08:00"

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-distributed
 description: A Helm chart for Running VMCluster on Multiple Availability Zones
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v1.101.0"
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
@@ -30,6 +30,6 @@ annotations:
 
 dependencies:
   - name: victoria-metrics-k8s-stack
-    version: "0.23.*"
+    version: "0.24.*"
     repository: https://victoriametrics.github.io/helm-charts
     condition: victoria-metrics-k8s-stack.enabled

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-distributed
 description: A Helm chart for Running VMCluster on Multiple Availability Zones
 type: application
-version: 0.1.2
+version: 0.2.0
 appVersion: "v1.101.0"
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-distributed/README.md
+++ b/charts/victoria-metrics-distributed/README.md
@@ -71,7 +71,7 @@ And to avoid getting incomplete responses from `zone-eu-1` which gets recovered 
 
 ### How to use [multitenancy](https://docs.victoriametrics.com/cluster-victoriametrics/#multitenancy)?
 
-By default, all the data that written to `vmauth-global-write` belong to tenant `0`. To write data to different tenants, creating new tenant user in `vmauth-global-write`.    
+By default, all the data that written to `vmauth-global-write` belong to tenant `0`. To write data to different tenants, set `.Values.enableMultitenancy=true` and create new tenant users for `vmauth-global-write`.  
 For example, writing data to tenant `1088` with following steps:
 1. create tenant VMUser for vmauth `vmauth-global-write` to use:
 ```
@@ -214,6 +214,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | availabilityZones[1].topologySpreadConstraints | list | `[{"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]` | topologySpreadConstraints allows to customize the default topologySpreadConstraints. |
 | availabilityZones[1].vmagent | object | `{"annotations":{},"enabled":true,"name":"","spec":{}}` | vmagent only meant to proxy write requests to each az, doesn't support customized remote write address |
 | availabilityZones[1].vmcluster.spec | object | `{"replicationFactor":2,"retentionPeriod":"14","vminsert":{"extraArgs":{},"replicaCount":2,"resources":{}},"vmselect":{"extraArgs":{},"replicaCount":2,"resources":{}},"vmstorage":{"replicaCount":2,"resources":{},"storageDataPath":"/vm-data"}}` | spec for VMCluster crd, see https://docs.victoriametrics.com/operator/api.html#vmclusterspec |
+| enableMultitenancy | bool | `true` | enable multitenancy mode see https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-distributed#how-to-use-multitenancy |
 | extraVMAgent | object | `{"enabled":true,"spec":{"selectAllByDefault":true}}` | set up an extra vmagent to scrape all the scrape objects by default, and write data to above vmauth-global-ingest endpoint. |
 | fullnameOverride | string | `""` | overrides the chart's computed fullname. |
 | nameOverride | string | `"vm-distributed"` | overrides the chart's name |

--- a/charts/victoria-metrics-distributed/README.md
+++ b/charts/victoria-metrics-distributed/README.md
@@ -1,6 +1,6 @@
 # Victoria Metrics Helm Chart for Setting up VMCluster on Multiple Availability Zones
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/victoriametrics)](https://artifacthub.io/packages/helm/victoriametrics/victoria-metrics-distributed)
 [![Slack](https://img.shields.io/badge/join%20slack-%23victoriametrics-brightgreen.svg)](https://slack.victoriametrics.com/)
 
@@ -214,7 +214,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | availabilityZones[1].topologySpreadConstraints | list | `[{"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]` | topologySpreadConstraints allows to customize the default topologySpreadConstraints. |
 | availabilityZones[1].vmagent | object | `{"annotations":{},"enabled":true,"name":"","spec":{}}` | vmagent only meant to proxy write requests to each az, doesn't support customized remote write address |
 | availabilityZones[1].vmcluster.spec | object | `{"replicationFactor":2,"retentionPeriod":"14","vminsert":{"extraArgs":{},"replicaCount":2,"resources":{}},"vmselect":{"extraArgs":{},"replicaCount":2,"resources":{}},"vmstorage":{"replicaCount":2,"resources":{},"storageDataPath":"/vm-data"}}` | spec for VMCluster crd, see https://docs.victoriametrics.com/operator/api.html#vmclusterspec |
-| enableMultitenancy | bool | `true` | enable multitenancy mode see https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-distributed#how-to-use-multitenancy |
+| enableMultitenancy | bool | `false` | enable multitenancy mode see https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-distributed#how-to-use-multitenancy |
 | extraVMAgent | object | `{"enabled":true,"spec":{"selectAllByDefault":true}}` | set up an extra vmagent to scrape all the scrape objects by default, and write data to above vmauth-global-ingest endpoint. |
 | fullnameOverride | string | `""` | overrides the chart's computed fullname. |
 | nameOverride | string | `"vm-distributed"` | overrides the chart's name |

--- a/charts/victoria-metrics-distributed/README.md.gotmpl
+++ b/charts/victoria-metrics-distributed/README.md.gotmpl
@@ -71,7 +71,7 @@ And to avoid getting incomplete responses from `zone-eu-1` which gets recovered 
 
 ### How to use [multitenancy](https://docs.victoriametrics.com/cluster-victoriametrics/#multitenancy)?
 
-By default, all the data that written to `vmauth-global-write` belong to tenant `0`. To write data to different tenants, creating new tenant user in `vmauth-global-write`. {{template "twospaces"}}  
+By default, all the data that written to `vmauth-global-write` belong to tenant `0`. To write data to different tenants, set `.Values.enableMultitenancy=true` and create new tenant users for `vmauth-global-write`. {{template "twospaces"}}
 For example, writing data to tenant `1088` with following steps:
 1. create tenant VMUser for vmauth `vmauth-global-write` to use:
 ```

--- a/charts/victoria-metrics-distributed/templates/_helpers.tpl
+++ b/charts/victoria-metrics-distributed/templates/_helpers.tpl
@@ -80,7 +80,7 @@ Create the name of the service account to use
 Lists all the ingest vmauth addresss as remote write addresses for per zone vmagent
 */}}
 {{- define "per-zone-vmagent.remoteWriteAddr" -}}
-{{- $multitenacySuffix := "" }}
+{{- $multitenacySuffix := "/insert/0/prometheus/api/v1/write" }}
 {{- if .Values.enableMultitenancy }}
   {{- $multitenacySuffix = "/insert/multitenant/prometheus/api/v1/write" }}
 {{- end }}

--- a/charts/victoria-metrics-distributed/templates/_helpers.tpl
+++ b/charts/victoria-metrics-distributed/templates/_helpers.tpl
@@ -80,9 +80,13 @@ Create the name of the service account to use
 Lists all the ingest vmauth addresss as remote write addresses for per zone vmagent
 */}}
 {{- define "per-zone-vmagent.remoteWriteAddr" -}}
+{{- $multitenacySuffix := "" }}
+{{- if .Values.enableMultitenancy }}
+  {{- $multitenacySuffix = "/insert/multitenant/prometheus/api/v1/write" }}
+{{- end }}
 {{- range $zone := .Values.availabilityZones }}
 {{- if $zone.allowIngest }}
-{{ printf "- url: http://vmauth-%s:8427" ( $zone.vmauthIngest.name | default (printf "vmauth-write-balancer-%s" $zone.name ) ) | indent 2 }}
+{{ printf "- url: http://vmauth-%s:8427%s" ( $zone.vmauthIngest.name | default (printf "vmauth-write-balancer-%s" $zone.name ) ) $multitenacySuffix | indent 2 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-distributed/templates/per-az/vmagent.yaml
+++ b/charts/victoria-metrics-distributed/templates/per-az/vmagent.yaml
@@ -35,14 +35,18 @@ spec:
 {{- toYaml $topologySpreadConstraints | nindent 2 }}
   remoteWrite:
 {{- default "{}" (include "per-zone-vmagent.remoteWriteAddr" $top) }}
-  remoteWriteSettings:
-    useMultiTenantMode: true
 {{- $spec := deepCopy $zone.vmagent.spec }}
 {{- $spec := unset $spec "nodeSelector" }}
 {{- $spec := unset $spec "affinity" }}
 {{- $spec := unset $spec "topologySpreadConstraints" }}
+{{- $spec := unset $spec "remoteWriteSettings" }}
 {{- if $spec }}
 {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- if $.Values.enableMultitenancy }}
+  {{- $mergedSettings := merge (default (default dict) $zone.vmagent.spec.remoteWriteSettings) (dict "useMultiTenantMode" true) }}
+  remoteWriteSettings:
+    {{- toYaml $mergedSettings | nindent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-distributed/values.yaml
+++ b/charts/victoria-metrics-distributed/values.yaml
@@ -223,6 +223,11 @@ extraVMAgent:
   spec:
     selectAllByDefault: true
 
+
+# -- enable multitenancy mode
+# see https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-distributed#how-to-use-multitenancy
+enableMultitenancy: true
+
 # -- set up vm operator and other resources like vmalert, grafana if needed
 victoria-metrics-k8s-stack:
   enabled: true

--- a/charts/victoria-metrics-distributed/values.yaml
+++ b/charts/victoria-metrics-distributed/values.yaml
@@ -226,7 +226,7 @@ extraVMAgent:
 
 # -- enable multitenancy mode
 # see https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-distributed#how-to-use-multitenancy
-enableMultitenancy: true
+enableMultitenancy: false
 
 # -- set up vm operator and other resources like vmalert, grafana if needed
 victoria-metrics-k8s-stack:


### PR DESCRIPTION
Disable multitenancy mode by default since it increases memory usage in vmagent, and most of the users not use it.
See how to enable it in https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-distributed#how-to-use-multitenancy.