### PR TITLE
fix: Use double hyphen for license and licenseFile parameters

### DIFF
--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fix license flags templates, Thanks to @akatch for [the pull request](https://github.com/VictoriaMetrics/helm-charts/pull/1140).
 
 ## 0.9.23
 

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.101.0
 description: Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.9.23
+version: 0.9.24
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-single/templates/_helpers.tpl
+++ b/charts/victoria-metrics-single/templates/_helpers.tpl
@@ -183,10 +183,10 @@ Return license flag if necessary.
 */}}
 {{- define "victoria-metrics.license.flag" -}}
 {{- if .Values.license.key -}}
--license={{ .Values.license.key }}
+--license={{ .Values.license.key }}
 {{- end }}
 {{- if and .Values.license.secret.name .Values.license.secret.key -}}
--licenseFile=/etc/vm-license-key/{{ .Values.license.secret.key }}
+--licenseFile=/etc/vm-license-key/{{ .Values.license.secret.key }}
 {{- end -}}
 {{- end -}}
 
@@ -226,7 +226,7 @@ Enforce license for vmbackupmanager
 {{- end -}}
 {{- end -}}
 
-{{/* 
+{{/*
 Return true if the detected platform is Openshift
 Usage:
 {{- include "common.compatibility.isOpenshift" . -}}

--- a/charts/victoria-metrics-single/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-single/templates/server-deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - {{ printf "%s=%s" "--retentionPeriod" (toString .Values.server.retentionPeriod) | quote}}
             - {{ printf "%s=%s" "--storageDataPath" .Values.server.persistentVolume.mountPath | quote}}
           {{- if .Values.server.scrape.enabled }}
-            - -promscrape.config=/scrapeconfig/scrape.yml
+            - --promscrape.config=/scrapeconfig/scrape.yml
           {{- end }}
           {{- range $key, $value := .Values.server.extraArgs }}
           {{- if kindIs "slice" $value }}

--- a/charts/victoria-metrics-single/templates/server-statefulset.yaml
+++ b/charts/victoria-metrics-single/templates/server-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
             - {{ printf "%s=%s" "--retentionPeriod" (toString .Values.server.retentionPeriod) | quote}}
             - {{ printf "%s=%s" "--storageDataPath" .Values.server.persistentVolume.mountPath | quote}}
           {{- if .Values.server.scrape.enabled }}
-            - -promscrape.config=/scrapeconfig/scrape.yml
+            - --promscrape.config=/scrapeconfig/scrape.yml
           {{- end }}
           {{- range $key, $value := .Values.server.extraArgs }}
           {{- if kindIs "slice" $value }}


### PR DESCRIPTION
This PR updates the templates helper to use a double hyphen for the `license` and `licenseFile` parameters, to match the double hyphen used for other parameters provided to the container.