### PR TITLE
feat: Support envFrom in alertmanager Deployment

### DIFF
--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- add an option to provide additional environment variables for Alertmanager via `.Values.alertmanager.envFrom`.
 
 ## 0.9.9
 

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: victoria-metrics-alert
 description: Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.9.9
+version: 0.9.10
 appVersion: v1.101.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -114,6 +114,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | alertmanager.config.route.repeat_interval | string | `"24h"` |  |
 | alertmanager.configMap | string | `""` |  |
 | alertmanager.enabled | bool | `false` |  |
+| alertmanager.envFrom | object | `{} ` |  |
 | alertmanager.extraArgs | object | `{}` |  |
 | alertmanager.extraContainers | list | `[]` |  |
 | alertmanager.extraHostPathMounts | list | `[]` |  |

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -114,7 +114,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | alertmanager.config.route.repeat_interval | string | `"24h"` |  |
 | alertmanager.configMap | string | `""` |  |
 | alertmanager.enabled | bool | `false` |  |
-| alertmanager.envFrom | object | `{} ` |  |
+| alertmanager.envFrom | list | `[]` |  |
 | alertmanager.extraArgs | object | `{}` |  |
 | alertmanager.extraContainers | list | `[]` |  |
 | alertmanager.extraHostPathMounts | list | `[]` |  |

--- a/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
@@ -72,6 +72,12 @@ spec:
           ports:
             - name: web
               containerPort: 9093
+          {{- if .Values.alertmanager.envFrom }}
+          envFrom:
+            {{- with .Values.alertmanager.envFrom -}}
+            {{ toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
           env:
             - name: POD_IP
               valueFrom:

--- a/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
@@ -72,11 +72,9 @@ spec:
           ports:
             - name: web
               containerPort: 9093
-          {{- if .Values.alertmanager.envFrom }}
+          {{- with .Values.alertmanager.envFrom }}
           envFrom:
-            {{- with .Values.alertmanager.envFrom -}}
             {{ toYaml . | nindent 12 }}
-            {{- end }}
           {{- end }}
           env:
             - name: POD_IP

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -314,7 +314,7 @@ alertmanager:
   listenAddress: "0.0.0.0:9093"
   extraArgs: {}
   # key: value
-
+  envFrom: []
   # external URL, that alertmanager will expose to receivers
   baseURL: ""
   # external URL Prefix, Prefix for the internal routes of web endpoints

--- a/hack/vmalert-lint-hack.yaml
+++ b/hack/vmalert-lint-hack.yaml
@@ -25,6 +25,12 @@ server:
   podDisruptionBudget:
     enabled: true
 
+alertmanager:
+  enabled: true
+  envFrom:
+    - configMapRef:
+        name: alertmanager-config
+
 license:
 #  key: "asdf"
   secret:


### PR DESCRIPTION
This PR adds a user-configurable envFrom option specifically for the alertmanager Deployment. This parameter is already supported in the alert server Deployment.