### PR TITLE
relabel __meta_kubernetes_namespace to kubernetes_namespace

### DIFF
--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -447,7 +447,7 @@ config:
         - source_labels: [__meta_kubernetes_pod_container_name]
           target_label: container
         - source_labels: [__meta_kubernetes_namespace]
-          target_label: namespace
+          target_label: kubernetes_namespace
         - source_labels: [__meta_kubernetes_service_name]
           target_label: service
         - source_labels: [__meta_kubernetes_service_name]
@@ -509,7 +509,7 @@ config:
         - source_labels: [__meta_kubernetes_pod_container_name]
           target_label: container
         - source_labels: [__meta_kubernetes_namespace]
-          target_label: namespace
+          target_label: kubernetes_namespace
         - source_labels: [__meta_kubernetes_service_name]
           target_label: service
         - source_labels: [__meta_kubernetes_service_name]


### PR DESCRIPTION
Hello!
The reasons why I created this PR:
1) Do the same as for `victoria-metrics-single` (https://github.com/VictoriaMetrics/helm-charts/blob/master/charts/victoria-metrics-single/values.yaml#L556)
2) Fix an issue when the exporter passes the namespace field and this rule override it with a value from `__meta_kubernetes_namespace`. For acutally at least for [trivy-operator](https://github.com/aquasecurity/trivy-operator) and [k8s-image-availability-exporter](https://github.com/deckhouse/k8s-image-availability-exporter).