### PR TITLE
Fix image tag in victoria-metrics-operator/templates/uninstall_hook.yaml

### DIFF
--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/alertmanager.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/alertmanager.rules.yaml
@@ -84,8 +84,8 @@ rules:
     summary: 'Alertmanager instances within the same cluster have different configurations.'
   condition: '{{ true }}'
   expr: |-
-    count by (namespace,service) (
-      count_values by (namespace,service) ("config_hash", alertmanager_config_hash{job="{{ include "victoria-metrics-k8s-stack.alertmanager.name" . }}",namespace="{{ .Release.Namespace }}"})
+    count by (namespace,service,cluster) (
+      count_values by (namespace,service,cluster) ("config_hash", alertmanager_config_hash{job="{{ include "victoria-metrics-k8s-stack.alertmanager.name" . }}",namespace="{{ .Release.Namespace }}"})
     )
     != 1
   for: 20m

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/alertmanager.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/alertmanager.rules.yaml
@@ -84,8 +84,8 @@ rules:
     summary: 'Alertmanager instances within the same cluster have different configurations.'
   condition: '{{ true }}'
   expr: |-
-    count by (namespace,service,cluster) (
-      count_values by (namespace,service,cluster) ("config_hash", alertmanager_config_hash{job="{{ include "victoria-metrics-k8s-stack.alertmanager.name" . }}",namespace="{{ .Release.Namespace }}"})
+    count by (namespace,service) (
+      count_values by (namespace,service) ("config_hash", alertmanager_config_hash{job="{{ include "victoria-metrics-k8s-stack.alertmanager.name" . }}",namespace="{{ .Release.Namespace }}"})
     )
     != 1
   for: 20m

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fix cleanup job image tag when `.Capabilities.KubeVersion.Minor` returns version with plus sign. See [this pull request](https://github.com/VictoriaMetrics/helm-charts/pull/1169) by @dimaslv.
 
 ## 0.33.4
 

--- a/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
+++ b/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
@@ -24,7 +24,7 @@ spec:
     {{- end }}
       containers:
         - name: kubectl
-          image: "{{ (index .Values "cleanupImage" "repository") }}:{{ (index .Values "cleanupImage" "tag" | default (printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor)) }}"
+          image: "{{ (index .Values "cleanupImage" "repository") }}:{{ (index .Values "cleanupImage" "tag" | default (printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor | replace "+" "")) }}"
           imagePullPolicy: "{{ (index .Values "cleanupImage" "pullPolicy") }}"
           resources:
             limits:


### PR DESCRIPTION
.Capabilities.KubeVersion.Minor returns version with plus sign, but for example there is no such tag as 1.27+ for bitnami/kubectl image (https://hub.docker.com/r/bitnami/kubectl/tags?page=&page_size=&ordering=&name=1.27%2B).