### PR TITLE
Fix vmagent ClusterRole and ClusterRoleBinding to correctly render Role and RoleBinding

### DIFF
--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fix possible template error when `.Values.rbac.namespaced=true`. Thanks to @guptaachin for [the pull request](https://github.com/VictoriaMetrics/helm-charts/pull/1179).
 
 ## 0.10.11
 

--- a/charts/victoria-metrics-agent/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ ternary "Role" "ClusterRole" $namespaced }}
 metadata:
   name: {{ template "chart.fullname" . }}{{- ternary "" "-clusterrole" $namespaced }}
-  {{- if not $namespaced }}
+  {{- if $namespaced }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:

--- a/charts/victoria-metrics-agent/templates/clusterrole.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrole.yaml
@@ -24,9 +24,6 @@ rules:
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources:
-  - nodes
-  - nodes/proxy
-  - nodes/metrics
   - services
   - endpoints
   - pods
@@ -38,6 +35,12 @@ rules:
   - ingresses
   verbs: ["get", "list", "watch"]
 {{- if not $namespaced }}
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - nodes/metrics
+  verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 {{- end }}

--- a/charts/victoria-metrics-agent/templates/clusterrolebinding.yaml
+++ b/charts/victoria-metrics-agent/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ ternary "RoleBinding" "ClusterRoleBinding" $namespaced }}
 metadata:
   name: {{ template "chart.fullname" . }}{{- ternary "" "-clusterrolebinding" $namespaced }}
-  {{- if not $namespaced }}
+  {{- if $namespaced }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:


### PR DESCRIPTION
Reported here - https://github.com/VictoriaMetrics/helm-charts/issues/1178

Issue Summary
On setting the rbac to render Role and RoleBindings, namespace is not rendered in metadata
```
rbac:
  create: true
  namespaced: true
```
This causes the helm chart to fail installation.