### PR TITLE
Allow to disable default grafana datasource

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release
 
 - Moved dashboards templating logic out of sync script to Helm template
+- Allow to disable default grafana datasource
 
 ## 0.24.5
 

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -420,6 +420,7 @@ Change the values according to the need of the environment in ``victoria-metrics
 | grafana.ingress.path | string | `"/"` |  |
 | grafana.ingress.pathType | string | `"Prefix"` |  |
 | grafana.ingress.tls | list | `[]` |  |
+| grafana.provisionDefaultDatasource | bool | `true` |  |
 | grafana.sidecar.dashboards.additionalDashboardAnnotations | object | `{}` |  |
 | grafana.sidecar.dashboards.additionalDashboardLabels | object | `{}` |  |
 | grafana.sidecar.dashboards.enabled | bool | `true` |  |

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
@@ -17,7 +17,7 @@ data:
   datasource.yaml: |-
     apiVersion: 1
     datasources:
-{{- if or .Values.vmsingle.enabled  .Values.vmcluster.enabled }}
+{{- if and (.Values.grafana.provisionDefaultDatasource) (or .Values.vmsingle.enabled  .Values.vmcluster.enabled) }}
     - name: VictoriaMetrics
       type: {{ default "prometheus" .Values.grafana.defaultDatasourceType }}
       {{- $readEndpoint:= (include "victoria-metrics-k8s-stack.vmReadEndpoint" . | fromYaml) }}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -774,6 +774,8 @@ grafana:
 
   ## ForceDeployDatasource Create datasource configmap even if grafana deployment has been disabled
   forceDeployDatasource: false
+  # Set to false to disable the default datasource connected directly to victoria-metrics
+  provisionDefaultDatasource: true
 
   ## Configure additional grafana datasources (passed through tpl)
   ## ref: http://docs.grafana.org/administration/provisioning/#datasources


### PR DESCRIPTION
We have a proxy inbetween grafana and the victoria metrics prometheus endpoint. This proxy handles authentication and authorization based on forwarded oauth identities. As all datasources available in Grafana can be used by everbody, I need to be able to remove the default datasource, so that there is not direct connection to the prometheus endpoint.

This was also requested by another guy in #520 