### PR TITLE
victoria-metrics-operator: add missing permission to allow patching `…

### DIFF
--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- add missing permission to allow patching `horizontalpodautoscalers` when operator watches single namespace.
 
 ## 0.33.5
 

--- a/charts/victoria-metrics-operator/Chart.yaml
+++ b/charts/victoria-metrics-operator/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/VictoriaMetrics/operator
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
   - https://github.com/VictoriaMetrics/operator
-version: 0.33.5
+version: 0.33.6
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
 kubeVersion: ">=1.23.0-0"
 keywords:

--- a/charts/victoria-metrics-operator/templates/cluster_role.yaml
+++ b/charts/victoria-metrics-operator/templates/cluster_role.yaml
@@ -140,13 +140,7 @@ rules:
   - vmscrapeconfigs
   - vmscrapeconfigs/finalizers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - '*'
 - apiGroups:
   - operator.victoriametrics.com
   resources:
@@ -196,13 +190,7 @@ rules:
     - roles
     - rolebindings
   verbs:
-    - get
-    - list
-    - create
-    - patch
-    - update
-    - watch
-    - delete
+    - '*'
 - apiGroups:
     - storage.k8s.io
   resources:
@@ -229,12 +217,7 @@ rules:
 - apiGroups:
     - autoscaling
   verbs:
-    - list
-    - get
-    - delete
-    - create
-    - update
-    - watch
+    - '*'
   resources:
     - horizontalpodautoscalers
 - apiGroups:

--- a/charts/victoria-metrics-operator/templates/role.yaml
+++ b/charts/victoria-metrics-operator/templates/role.yaml
@@ -133,13 +133,7 @@ rules:
   - vmscrapeconfigs
   - vmscrapeconfigs/finalizers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - '*'
 - apiGroups:
     - operator.victoriametrics.com
   resources:
@@ -186,25 +180,13 @@ rules:
     - roles
     - rolebindings
   verbs:
-    - get
-    - list
-    - create
-    - patch
-    - update
-    - watch
-    - delete
+    - '*'
 - apiGroups:
     - autoscaling
   resources:
     - horizontalpodautoscalers
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+    - '*'
 - apiGroups:
     - networking.k8s.io
     - extensions


### PR DESCRIPTION
…horizontalpodautoscalers` when operator watches single namespace

address https://github.com/VictoriaMetrics/helm-charts/issues/1202