### PR TITLE
charts/victoria-metrics-k8s-stack: remove outdated comment

### DIFF
--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -913,8 +913,6 @@ kube-state-metrics:
   vmServiceScrape:
     spec: {}
 
-  #TODO: selector override for kube-state-metrics deployed separatelly
-
 #################################################
 ###              Service Monitors           #####
 #################################################


### PR DESCRIPTION
It is already possible to specify custom selector for KSM metrics by using `.Values.kube-state-metrics.vmServiceScrape.spec` so comment is not relevant.