### PR TITLE
charts/victoria-metrics-cluster: fix templating of ingress port

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Updated `.Values.vmbackupmanager.livenessProbe` to `.Values.vmbackupmanager.probe.liveness`
 - Updated `.Values.vmbackupmanager.startupProbe` to `.Values.vmbackupmanager.probe.startup`
 - Added global imagePullSecrets and image.registry
+- Fix templating of Ingress port when using custom port name.
 
 ## 0.11.23
 

--- a/charts/victoria-metrics-cluster/templates/vminsert-ingress.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-ingress.yaml
@@ -37,7 +37,7 @@ spec:
             service:
               name: {{ $serviceName }}
               port:
-                number: {{ $servicePort }}
+                number: {{ .port | default $servicePort }}
             {{- else }}
             serviceName: {{ $serviceName }}
             servicePort: {{ .port | default "http"}}


### PR DESCRIPTION
This allows to override port number for ingestion protocols such as openTSDB, Graphite and others.