### PR TITLE
Fix cert-manager managed webhooks

### DIFF
--- a/charts/victoria-metrics-operator/templates/webhook.yaml
+++ b/charts/victoria-metrics-operator/templates/webhook.yaml
@@ -41,11 +41,11 @@ webhooks:
           - UPDATE
         resources:
           - {{ $name }}{{ ternary "" "s" (hasSuffix "s" $name) }}
+---
 {{- end }}
 {{- end }}
 {{- if .Values.admissionWebhooks.certManager.enabled }}
 {{- if not .Values.admissionWebhooks.certManager.issuer -}}
----
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:


### PR DESCRIPTION
The `Issuer` and `ValidatingWebhookConfiguration` resources are getting glued together.