### PR TITLE
common: support long and short cmd flags

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next release
 
-- TODO
+- Support short and long args flags in `vm.args`
+- Updated `vm.enterprise.only` error message
 
 ## 0.0.6
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.6
+version: 0.0.7
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_enterprise.tpl
+++ b/charts/victoria-metrics-common/templates/_enterprise.tpl
@@ -15,7 +15,11 @@
   {{- $licenseSecretKey := (include "vm.license.secret.key" .) -}}
   {{- $licenseSecretName := (include "vm.license.secret.name" .) -}}
   {{- if and (empty $licenseKey) (and (empty $licenseSecretName) (empty $licenseSecretKey)) -}}
-    {{ fail "Pass valid license at .Values.license or .Values.global.license if you have an enterprise license for running this software. See https://victoriametrics.com/legal/esa/ for details"}}
+    {{ fail `Pass valid license at .Values.license or .Values.global.license if you have an enterprise license for running this software.
+       See https://victoriametrics.com/legal/esa/ for details.
+       Documentation - https://docs.victoriametrics.com/enterprise.html
+       for more information, visit https://victoriametrics.com/products/enterprise/
+       To request a trial license, go to https://victoriametrics.com/products/enterprise/trial/` }}
   {{- end -}}
 {{- end -}}
 

--- a/charts/victoria-metrics-common/templates/_pod.tpl
+++ b/charts/victoria-metrics-common/templates/_pod.tpl
@@ -86,10 +86,12 @@ Net probe port
 {{- end -}}
 
 {{- define "vm.arg" -}}
-{{- if and (kindIs "bool" .value) .value -}}
--{{ .key }}
+{{- if empty .value }}
+{{ .key }}
+{{- else if and (kindIs "bool" .value) .value -}}
+-{{ ternary "" "-" (eq (len .key) 1) }}{{ .key }}
 {{- else -}}
--{{ .key }}={{ .value }}
+-{{ ternary "" "-" (eq (len .key) 1) }}{{ .key }}={{ .value }}
 {{- end -}}
 {{- end -}}
 
@@ -97,15 +99,18 @@ Net probe port
 command line arguments
 */ -}}
 {{- define "vm.args" -}}
-{{- $args := default list -}}
-{{- range $key, $value := . -}}
-{{- if kindIs "slice" $value -}}
-{{- range $v := $value -}}
-{{- $args = append $args (include "vm.arg" (dict "key" $key "value" $v)) -}}
-{{- end -}}
-{{- else -}}
-{{- $args = append $args (include "vm.arg" (dict "key" $key "value" $value)) -}}
-{{- end -}}
-{{- end -}}
-{{- toYaml (dict "args" $args) -}}
+  {{- $args := default list -}}
+  {{- range $key, $value := . -}}
+    {{- if not $key -}}
+      {{- fail "Empty key in command line args is not allowed" -}}
+    {{- end -}}
+    {{- if kindIs "slice" $value -}}
+      {{- range $v := $value -}}
+        {{- $args = append $args (include "vm.arg" (dict "key" $key "value" $v)) -}}
+      {{- end -}}
+    {{- else -}}
+      {{- $args = append $args (include "vm.arg" (dict "key" $key "value" $value)) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- toYaml (dict "args" $args) -}}
 {{- end -}}


### PR DESCRIPTION
- support long and short cmd flags, support positional args in `vm.args` template, fail values with empty keys
- update `vm.enterprise.only` error message