### PR TITLE
common: added more generic template functions

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## Next release
 
-- TODO
+- Added `vm.service` for unified service name generation
+- Added `vm.url` to construct service DNS name
+- Added `vm.name` for chart name
+- Added `vm.fullname` which is actively used in resource name construction
+- Added `vm.chart` to construct chart name label value
+- Added `vm.labels` for common labels
+- Added `vm.sa` for service account name
+- Added `vm.release` for release name
+- Added `vm.selectorLabels` for common selector labels
 
 ## 0.0.7
 

--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next release
 
 - Added `vm.service` for unified service name generation
-- Added `vm.url` to construct service DNS name
+- Added `vm.url` to construct service base url
 - Added `vm.name` for chart name
 - Added `vm.fullname` which is actively used in resource name construction
 - Added `vm.chart` to construct chart name label value

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.7
+version: 0.0.8
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_helpers.tpl
+++ b/charts/victoria-metrics-common/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{- /* Expand the name of the chart. */ -}}
+{{- define "vm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- /*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/ -}}
+{{- define "vm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- /* Create chart name and version as used by the chart label. */ -}}
+{{- define "vm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- /* Create the name of the service account to use */ -}}
+{{- define "vm.sa" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "vm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- /* Common labels */ -}}
+{{- define "vm.labels" -}}
+helm.sh/chart: {{ include "vm.chart" . }}
+{{ include "vm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "vm.release" -}}
+{{ default .Release.Name .Values.argocdReleaseOverride | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{- /* Selector labels */ -}}
+{{- define "vm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vm.name" . }}
+app.kubernetes.io/instance: {{ include "vm.release" . }}
+{{- with .extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/victoria-metrics-common/templates/_service.tpl
+++ b/charts/victoria-metrics-common/templates/_service.tpl
@@ -1,0 +1,37 @@
+{{- /* Create the name for VM service */ -}}
+{{- define "vm.service" -}}
+  {{- $global := .global -}}
+  {{- $value := (include "vm.fullname" $global) -}}
+  {{- with .vmService -}}
+    {{- $service := (index $global .) | default dict -}}
+    {{- $prefix := ternary . (printf "vm%s" .) (hasPrefix "vm" .) -}}
+    {{- $value = ($service).name | default (printf "%s-%s" $prefix $value) -}}
+  {{- end -}}
+  {{- if hasKey . "vmIdx" -}}
+    {{- $value = (printf "%s-%d.%s" $value .vmIdx $value) -}}
+  {{- end -}}
+  {{- $value -}}
+{{- end }}
+
+{{- define "vm.url" -}}
+  {{- $name := (include "vm.service" .) -}}
+  {{- $global := .global -}}
+  {{- $ns := $global.Release.Namespace -}}
+  {{- $proto := "http" -}}
+  {{- $port := 80 -}}
+  {{- $path := .vmRoute | default "/" -}}
+  {{- $isSecure := false -}}
+  {{- if .vmSecure -}}
+    {{- $isSecure = .vmSecure -}}
+  {{- end -}}
+  {{- with .vmService -}}
+    {{- $service := index ($global.Values) . | default dict -}}
+    {{- $spec := $service.spec | default dict -}}
+    {{- $isSecure = ($spec.extraArgs).tls | default $isSecure -}}
+    {{- $proto = (ternary "https" "http" $isSecure) -}}
+    {{- $port = (ternary 443 80 $isSecure) -}}
+    {{- $port = $spec.port | default $port -}}
+    {{- $path = dig "http.pathPrefix" $path ($spec.extraArgs | default dict) -}}
+  {{- end -}}
+  {{- printf "%s://%s.%s.svc:%d%s" $proto $name $ns (int $port) $path -}}
+{{- end -}}


### PR DESCRIPTION
- Added `vm.service` for unified service name generation
- Added `vm.url` to construct service DNS name
- Added `vm.name` for chart name
- Added `vm.fullname` which is actively used in resource name construction
- Added `vm.chart` to construct chart name label value
- Added `vm.labels` for common labels
- Added `vm.sa` for service account name
- Added `vm.release` for release name
- Added `vm.selectorLabels` for common selector labels