### PR TITLE
common: added more templates

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## Next release
 
-- TODO
+- Added `vm.service` for unified service name generation
+- Added `vm.url` to construct service DNS name
+- Added `vm.name` for chart name
+- Added `vm.fullname` which is actively used in resource name construction
+- Added `vm.chart` to construct chart name label value
+- Added `vm.labels` for common labels
+- Added `vm.sa` for service account name
+- Added `vm.release` for release name
+- Added `vm.selectorLabels` for common selector labels
 
 ## 0.0.7
 

--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next release
 
 - Added `vm.service` for unified service name generation
-- Added `vm.url` to construct service DNS name
+- Added `vm.url` to construct service base url
 - Added `vm.name` for chart name
 - Added `vm.fullname` which is actively used in resource name construction
 - Added `vm.chart` to construct chart name label value

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.7
+version: 0.0.8
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_enterprise.tpl
+++ b/charts/victoria-metrics-common/templates/_enterprise.tpl
@@ -1,13 +1,16 @@
 {{- define "vm.license.secret.key" -}}
-{{- ((.Values.license).secret).key | default (((.Values.global).license).secret).key | default "" -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- (($Values.license).secret).key | default ((($Values.global).license).secret).key | default "" -}}
 {{- end -}}
 
 {{- define "vm.license.secret.name" -}}
-{{- ((.Values.license).secret).name | default (((.Values.global).license).secret).name | default "" -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- (($Values.license).secret).name | default ((($Values.global).license).secret).name | default "" -}}
 {{- end -}}
 
 {{- define "vm.license.key" -}}
-{{- (.Values.license).key | default ((.Values.global).license).key | default "" -}}
+  {{- $Values := (.helm).Values | default .Values }}
+  {{- ($Values.license).key | default (($Values.global).license).key | default "" -}}
 {{- end -}}
 
 {{- define "vm.enterprise.only" -}}
@@ -27,38 +30,36 @@
 Return license volume mount
 */}}
 {{- define "vm.license.volume" -}}
-{{- $licenseSecretKey := (include "vm.license.secret.key" .) -}}
-{{- $licenseSecretName := (include "vm.license.secret.name" .) -}}
-{{- if and $licenseSecretName $licenseSecretKey -}}
-- name: license-key
-  secret:
-    secretName: {{ $licenseSecretName }}
-{{- end -}}
+  {{- $licenseSecretKey := (include "vm.license.secret.key" .) -}}
+  {{- $licenseSecretName := (include "vm.license.secret.name" .) -}}
+  {{- if and $licenseSecretName $licenseSecretKey -}}
+    {{- $volume := list (dict "name" "license-key" "secret" (dict "secretName" $licenseSecretName)) -}}
+    {{- toYaml $volume -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*
 Return license volume mount for container
 */}}
 {{- define "vm.license.mount" -}}
-{{- $licenseSecretKey := (include "vm.license.secret.key" .) -}}
-{{- $licenseSecretName := (include "vm.license.secret.name" .) -}}
-{{- if and $licenseSecretName $licenseSecretKey -}}
-- name: license-key
-  mountPath: /etc/vm-license-key
-  readOnly: true
-{{- end -}}
+  {{- $licenseSecretKey := (include "vm.license.secret.key" .) -}}
+  {{- $licenseSecretName := (include "vm.license.secret.name" .) -}}
+  {{- if and $licenseSecretName $licenseSecretKey -}}
+    {{- $mount := list (dict "name" "license-key" "mountPath" "/etc/vm-license-key" "readOnly" true) -}}
+    {{- toYaml $mount -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*
 Return license flag if necessary.
 */}}
 {{- define "vm.license.flag" -}}
-{{- $licenseKey := (include "vm.license.key" .) -}}
-{{- $licenseSecretKey := (include "vm.license.secret.key" .) -}}
-{{- $licenseSecretName := (include "vm.license.secret.name" .) -}}
-{{- if $licenseKey -}}
-license: {{ $licenseKey }}
-{{- else if and $licenseSecretName $licenseSecretKey -}}
-licenseFile: /etc/vm-license-key/{{ $licenseSecretKey }}
-{{- end -}}
+  {{- $licenseKey := (include "vm.license.key" .) -}}
+  {{- $licenseSecretKey := (include "vm.license.secret.key" .) -}}
+  {{- $licenseSecretName := (include "vm.license.secret.name" .) -}}
+  {{- if $licenseKey -}}
+    license: {{ $licenseKey }}
+  {{- else if and $licenseSecretName $licenseSecretKey -}}
+    licenseFile: /etc/vm-license-key/{{ $licenseSecretKey }}
+  {{- end -}}
 {{- end -}}

--- a/charts/victoria-metrics-common/templates/_enterprise.tpl
+++ b/charts/victoria-metrics-common/templates/_enterprise.tpl
@@ -33,8 +33,9 @@ Return license volume mount
   {{- $licenseSecretKey := (include "vm.license.secret.key" .) -}}
   {{- $licenseSecretName := (include "vm.license.secret.name" .) -}}
   {{- if and $licenseSecretName $licenseSecretKey -}}
-    {{- $volume := list (dict "name" "license-key" "secret" (dict "secretName" $licenseSecretName)) -}}
-    {{- toYaml $volume -}}
+- name: license-key
+  secret:
+    secretName: {{ $licenseSecretName }}
   {{- end -}}
 {{- end -}}
 
@@ -45,8 +46,9 @@ Return license volume mount for container
   {{- $licenseSecretKey := (include "vm.license.secret.key" .) -}}
   {{- $licenseSecretName := (include "vm.license.secret.name" .) -}}
   {{- if and $licenseSecretName $licenseSecretKey -}}
-    {{- $mount := list (dict "name" "license-key" "mountPath" "/etc/vm-license-key" "readOnly" true) -}}
-    {{- toYaml $mount -}}
+- name: license-key
+  mountPath: /etc/vm-license-key
+  readOnly: true
   {{- end -}}
 {{- end -}}
 

--- a/charts/victoria-metrics-common/templates/_helpers.tpl
+++ b/charts/victoria-metrics-common/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{- /* Expand the name of the chart. */ -}}
+{{- define "vm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- /*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/ -}}
+{{- define "vm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- /* Create chart name and version as used by the chart label. */ -}}
+{{- define "vm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- /* Create the name of the service account to use */ -}}
+{{- define "vm.sa" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "vm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- /* Common labels */ -}}
+{{- define "vm.labels" -}}
+helm.sh/chart: {{ include "vm.chart" . }}
+{{ include "vm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "vm.release" -}}
+{{ default .Release.Name .Values.argocdReleaseOverride | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{- /* Selector labels */ -}}
+{{- define "vm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vm.name" . }}
+app.kubernetes.io/instance: {{ include "vm.release" . }}
+{{- with .extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/victoria-metrics-common/templates/_helpers.tpl
+++ b/charts/victoria-metrics-common/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "vm.validate.args" -}}
-  {{- $Chart .helm.Chart | default .Chart -}}
+  {{- $Chart := (.helm).Chart | default .Chart -}}
   {{- if empty $Chart -}}
     {{- fail "invalid template data" -}}
   {{- end -}}
@@ -8,8 +8,8 @@
 {{- /* Expand the name of the chart. */ -}}
 {{- define "vm.name" -}}
   {{- include "vm.validate.args" . -}}
-  {{- $Chart := .helm.Chart | default .Chart -}}
-  {{- $Values := .helm.Values | default .Values -}}
+  {{- $Chart := (.helm).Chart | default .Chart -}}
+  {{- $Values := (.helm).Values | default .Values -}}
   {{- $Values.nameOverride | default $Values.global.nameOverride | default $Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end -}}
 
@@ -20,23 +20,23 @@ If release name contains chart name it will be used as a full name.
 */ -}}
 {{- define "vm.fullname" -}}
   {{- include "vm.validate.args" . -}}
-  {{- $Values := .helm.Values | default .Values -}}
-  {{- $Chart := .helm.Chart | default .Chart -}}
-  {{- $Release := helm.Release | default .Release -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $Chart := (.helm).Chart | default .Chart -}}
+  {{- $Release := (.helm).Release | default .Release -}}
   {{- $appKey := .appKey -}}
   {{- $fullname := default list -}}
   {{- if $Values.fullnameOverride -}}
     {{- $fullname = append $fullname .Values.fullnameOverride -}}
-  {{- else if and $appKey (dig $Chart.Name $appKey "fullnameOverride" "" ($Values.global) -}}
+  {{- else if and $appKey (dig $Chart.Name $appKey "fullnameOverride" "" ($Values.global)) -}}
     {{- $fullname = append $fullname (index .Values.global $Chart.Name $appKey "fullnameOverride") -}}
   {{- else }}
-    {{- $name := default $Chart.Name $Values.nameOverride -}}
     {{- $fullname = append $fullname $Release.Name -}}
-    {{- if not (contains $name $fullname) -}}
+    {{- $name := default $Chart.Name $Values.nameOverride -}}
+    {{- if not (contains $name ($fullname | join "-")) -}}
       {{- $fullname = append $fullname $name -}}
     {{- end -}}
     {{- if $appKey -}}
-      {{- $suffix := index $Values $appKey "name" | default (index $Values.global $appKey "name") -}}
+      {{- $suffix := (index $Values $appKey "name") | default (dig $Chart.Name $appKey "name" "" $Values.global) -}}
       {{- if $suffix -}}
         {{- $fullname = append $fullname $suffix -}}
       {{- end -}}
@@ -48,14 +48,14 @@ If release name contains chart name it will be used as a full name.
 {{- /* Create chart name and version as used by the chart label. */ -}}
 {{- define "vm.chart" -}}
   {{- include "vm.validate.args" . -}}
-  {{- $Chart := .helm.Chart | default .Chart -}}
+  {{- $Chart := (.helm).Chart | default .Chart -}}
   {{- printf "%s-%s" $Chart.Name $Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{- /* Create the name of the service account to use */ -}}
 {{- define "vm.sa.name" -}}
   {{- include "vm.validate.args" . -}}
-  {{- $Values := .helm.Values | default .Values -}}
+  {{- $Values := (.helm).Values | default .Values -}}
   {{- if $Values.serviceAccount.create }}
     {{- default (include "vm.fullname" .) $Values.serviceAccount.name }}
   {{- else -}}
@@ -63,14 +63,21 @@ If release name contains chart name it will be used as a full name.
   {{- end }}
 {{- end }}
 
+{{- define "vm.metaLabels" -}}
+  {{- include "vm.validate.args" . -}}
+  {{- $Release := (.helm).Release | default .Release -}}
+  {{- $labels := .extraLabels | default dict -}}
+  {{- $_ := set $labels "helm.sh/chart" (include "vm.chart" .) -}}
+  {{- $_ := set $labels "app.kubernetes.io/managed-by" $Release.Service -}}
+  {{- toYaml $labels -}}
+{{- end -}}
+
 {{- /* Common labels */ -}}
 {{- define "vm.labels" -}}
   {{- include "vm.validate.args" . -}}
-  {{- $Release := .helm.Release | default .Release -}}
-  {{- $Chart := .helm.Chart | default .Chart -}}
+  {{- $Chart := (.helm).Chart | default .Chart -}}
   {{- $labels := fromYaml (include "vm.selectorLabels" .) -}}
-  {{- $_ := set $labels "helm.sh/chart" (include "vm.chart" .) -}}
-  {{- $_ := set $labels "app.kubernetes.io/managed-by" $Release.Service -}}
+  {{- $labels = mergeOverwrite $labels (fromYaml (include "vm.metaLabels" .)) -}}
   {{- with $Chart.AppVersion -}}
     {{- $_ := set $labels "app.kubernetes.io/version" ($Chart.AppVersion) -}}
   {{- end -}}
@@ -79,24 +86,30 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "vm.release" -}}
   {{- include "vm.validate.args" . -}}
-  {{- $Release := .helm.Release | default .Release -}}
-  {{- $Values := .helm.Values | default .Values -}}
+  {{- $Release := (.helm).Release | default .Release -}}
+  {{- $Values := (.helm).Values | default .Values -}}
   {{- default $Release.Name $Values.argocdReleaseOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "vm.app.name" -}}
+  {{- if .appKey -}}
+    {{- $Values := (.helm).Values | default .Values -}}
+    {{- $Chart := (.helm).Chart | default .Chart -}}
+    {{- if (index $Values .appKey).name -}}
+      {{- (index $Values .appKey).name -}}
+    {{- else if dig $Chart.Name .appKey "name" "" ($Values.global) -}}
+      {{- index $Values.global $Chart.Name .appKey "name" -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{- /* Selector labels */ -}}
 {{- define "vm.selectorLabels" -}}
-  {{- $labels := ternary (default dict) (.extraLabels | default dict) (empty .helm) -}}
+  {{- $labels := .extraLabels | default dict -}}
   {{- $_ := set $labels "app.kubernetes.io/name" (include "vm.name" .) -}}
   {{- $_ := set $labels "app.kubernetes.io/instance" (include "vm.release" .) -}}
-  {{- if .appKey -}}
-    {{- $Values := .helm.Values | default .Values -}}
-    {{- $Chart := .helm.Chart | default .Chart -}}
-    {{- if dig .appKey "name" "" $Values -}}
-      {{- $_ := set $labels "app" (index $Values .appKey "name") -}}
-    {{- else if dig $Chart.Name .appKey "name" "" ($Values.global) -}}
-      {{- $_ := set $labels "app" (index $Values.global $Chart.Name .appKey "name") -}}
-    {{- end -}}
+  {{- with (include "vm.app.name" .) -}}
+    {{- $_ := set $labels "app" . -}}
   {{- end -}}
   {{- toYaml $labels -}}
 {{- end }}

--- a/charts/victoria-metrics-common/templates/_image.tpl
+++ b/charts/victoria-metrics-common/templates/_image.tpl
@@ -2,16 +2,18 @@
 Victoria Metrics Image
 */}}
 {{- define "vm.image" -}}
-{{- $image := (tpl (printf "%s:%s" .app.image.repository (.app.image.tag | default .Chart.AppVersion)) .) -}}
-{{- $license := .Values.license | default dict }}
-{{- if and (or $license.key .Values.eula (dig "secret" "name" "" $license)) (empty .app.image.tag) -}}
-  {{- $_ := set .app.image "variant" "enterprise" -}}
-{{- end -}}
-{{- with .app.image.variant -}}
-  {{- $image = (printf "%s-%s" $image .) -}}
-{{- end -}}
-{{- with .app.image.registry | default ((.Values.global).image).registry | default "" -}}
-  {{- $image = (printf "%s/%s" . $image) -}}
-{{- end -}}
-{{- $image -}}
+  {{- $Chart := (.helm).Chart | default .Chart -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $image := (tpl (printf "%s:%s" .app.image.repository (.app.image.tag | default $Chart.AppVersion)) .) -}}
+  {{- $license := $Values.license | default dict }}
+  {{- if and (or $license.key $Values.eula (dig "secret" "name" "" $license)) (empty .app.image.tag) -}}
+    {{- $_ := set .app.image "variant" "enterprise" -}}
+  {{- end -}}
+  {{- with .app.image.variant -}}
+    {{- $image = (printf "%s-%s" $image .) -}}
+  {{- end -}}
+  {{- with .app.image.registry | default (($Values.global).image).registry | default "" -}}
+    {{- $image = (printf "%s/%s" . $image) -}}
+  {{- end -}}
+  {{- $image -}}
 {{- end -}}

--- a/charts/victoria-metrics-common/templates/_ingress.tpl
+++ b/charts/victoria-metrics-common/templates/_ingress.tpl
@@ -1,8 +1,8 @@
 {{- define "vm.ingress.port" }}
-{{- $port := dict "name" "http" }}
-{{- with .port }}
-  {{- $numberTypes := list "int" "float64" }}
-  {{- $port = dict (ternary "number" "name" (has (kindOf .) $numberTypes)) . }}
-{{- end -}}
-{{- toYaml $port -}}
+  {{- $port := dict "name" "http" }}
+  {{- with .port }}
+    {{- $numberTypes := list "int" "float64" }}
+    {{- $port = dict (ternary "number" "name" (has (kindOf .) $numberTypes)) . }}
+  {{- end -}}
+  {{- toYaml $port -}}
 {{- end }}

--- a/charts/victoria-metrics-common/templates/_pod.tpl
+++ b/charts/victoria-metrics-common/templates/_pod.tpl
@@ -1,9 +1,9 @@
 {{- define "vm.port.from.flag" -}}
-{{- $port := .default -}}
-{{- with .flag -}}
-{{- $port = regexReplaceAll ".*:(\\d+)" . "${1}" -}}
-{{- end -}}
-{{- $port -}}
+  {{- $port := .default -}}
+  {{- with .flag -}}
+    {{- $port = regexReplaceAll ".*:(\\d+)" . "${1}" -}}
+  {{- end -}}
+  {{- $port -}}
 {{- end }}
 
 {{- /*
@@ -12,28 +12,30 @@ Usage:
 {{- include "vm.compatibility.isOpenshift" . -}}
 */ -}}
 {{- define "vm.compatibility.isOpenshift" -}}
-{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" -}}
-{{- true -}}
-{{- end -}}
+  {{- $Capabilities := (.helm).Capabilities | default .Capabilities -}}
+  {{- if $Capabilities.APIVersions.Has "security.openshift.io/v1" -}}
+    {{- true -}}
+  {{- end -}}
 {{- end -}}
 
 {{- /*
 Render a compatible securityContext depending on the platform. By default it is maintained as it is. In other platforms like Openshift we remove default user/group values that do not work out of the box with the restricted-v1 SCC
 Usage:
-{{- include "vm.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) -}}
+{{- include "vm.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "helm" $) -}}
 */ -}}
 {{- define "vm.compatibility.renderSecurityContext" -}}
-{{- $adaptedContext := .secContext -}}
-{{- $adaptSecurityCtx := ((((.context.Values).global).compatibility).openshift).adaptSecurityContext | default "" -}}
-{{- if or (eq $adaptSecurityCtx "force") (and (eq $adaptSecurityCtx "auto") (include "vm.compatibility.isOpenshift" .context)) -}}
-  {{- /* Remove incompatible user/group values that do not work in Openshift out of the box */ -}}
-  {{- $adaptedContext = omit $adaptedContext "fsGroup" "runAsUser" "runAsGroup" -}}
-  {{- if not .secContext.seLinuxOptions -}} 
-    {{- /* If it is an empty object, we remove it from the resulting context because it causes validation issues */ -}}
-    {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+  {{- $adaptedContext := .secContext -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $adaptSecurityCtx := (((($Values).global).compatibility).openshift).adaptSecurityContext | default "" -}}
+  {{- if or (eq $adaptSecurityCtx "force") (and (eq $adaptSecurityCtx "auto") (include "vm.compatibility.isOpenshift" .)) -}}
+    {{- /* Remove incompatible user/group values that do not work in Openshift out of the box */ -}}
+    {{- $adaptedContext = omit $adaptedContext "fsGroup" "runAsUser" "runAsGroup" -}}
+    {{- if not $adaptedContext.seLinuxOptions -}}
+      {{- /* If it is an empty object, we remove it from the resulting context because it causes validation issues */ -}}
+      {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+    {{- end -}}
   {{- end -}}
-{{- end -}}
-{{- omit $adaptedContext "enabled" | toYaml -}}
+  {{- omit $adaptedContext "enabled" | toYaml -}}
 {{- end -}}
 
 {{- /*
@@ -68,31 +70,31 @@ Render probe
 HTTP GET probe path
 */ -}}
 {{- define "vm.probe.http.path" -}}
-{{- index .app.extraArgs "http.pathPrefix" | default "" | trimSuffix "/" -}}/health
+  {{- index .app.extraArgs "http.pathPrefix" | default "" | trimSuffix "/" -}}/health
 {{- end -}}
 
 {{- /*
 HTTP GET probe scheme
 */ -}}
 {{- define "vm.probe.http.scheme" -}}
-{{- ternary "HTTPS" "HTTP" (.app.extraArgs.tls | default false) -}}
+  {{- ternary "HTTPS" "HTTP" (.app.extraArgs.tls | default false) -}}
 {{- end -}}
 
 {{- /*
 Net probe port
 */ -}}
 {{- define "vm.probe.port" -}}
-{{- dig "ports" "name" "http" (.app | dict) -}}
+  {{- dig "ports" "name" "http" (.app | dict) -}}
 {{- end -}}
 
 {{- define "vm.arg" -}}
-{{- if empty .value }}
-{{ .key }}
-{{- else if and (kindIs "bool" .value) .value -}}
--{{ ternary "" "-" (eq (len .key) 1) }}{{ .key }}
-{{- else -}}
--{{ ternary "" "-" (eq (len .key) 1) }}{{ .key }}={{ .value }}
-{{- end -}}
+  {{- if empty .value }}
+    {{- .key -}}
+  {{- else if and (kindIs "bool" .value) .value -}}
+    -{{ ternary "" "-" (eq (len .key) 1) }}{{ .key }}
+  {{- else -}}
+    -{{ ternary "" "-" (eq (len .key) 1) }}{{ .key }}={{ .value }}
+  {{- end -}}
 {{- end -}}
 
 {{- /*

--- a/charts/victoria-metrics-common/templates/_service.tpl
+++ b/charts/victoria-metrics-common/templates/_service.tpl
@@ -1,7 +1,7 @@
 {{- /* Create the name for VM service */ -}}
 {{- define "vm.service" -}}
   {{- include "vm.validate.args" . -}}
-  {{- $Values := .helm.Values | default .Values -}}
+  {{- $Values := (.helm).Values | default .Values -}}
   {{- $name := (include "vm.fullname" .) -}}
   {{- with .appKey -}}
     {{- $service := (index $Values .) | default dict -}}
@@ -11,13 +11,13 @@
   {{- if hasKey . "appIdx" -}}
     {{- $name = (printf "%s-%d.%s" $name .appIdx $name) -}}
   {{- end -}}
-  {{- $value -}}
+  {{- $name -}}
 {{- end }}
 
 {{- define "vm.url" -}}
   {{- $name := (include "vm.service" .) -}}
-  {{- $Release := .helm.Release | default .Release -}}
-  {{- $Values := .helm.Values | default .Values -}}
+  {{- $Release := (.helm).Release | default .Release -}}
+  {{- $Values := (.helm).Values | default .Values -}}
   {{- $ns := $Release.Namespace -}}
   {{- $proto := "http" -}}
   {{- $port := 80 -}}

--- a/charts/victoria-metrics-common/templates/_service.tpl
+++ b/charts/victoria-metrics-common/templates/_service.tpl
@@ -1,0 +1,37 @@
+{{- /* Create the name for VM service */ -}}
+{{- define "vm.service" -}}
+  {{- $global := .global -}}
+  {{- $value := (include "vm.fullname" $global) -}}
+  {{- with .vmService -}}
+    {{- $service := (index $global .) | default dict -}}
+    {{- $prefix := ternary . (printf "vm%s" .) (hasPrefix "vm" .) -}}
+    {{- $value = ($service).name | default (printf "%s-%s" $prefix $value) -}}
+  {{- end -}}
+  {{- if hasKey . "vmIdx" -}}
+    {{- $value = (printf "%s-%d.%s" $value .vmIdx $value) -}}
+  {{- end -}}
+  {{- $value -}}
+{{- end }}
+
+{{- define "vm.url" -}}
+  {{- $name := (include "vm.service" .) -}}
+  {{- $global := .global -}}
+  {{- $ns := $global.Release.Namespace -}}
+  {{- $proto := "http" -}}
+  {{- $port := 80 -}}
+  {{- $path := .vmRoute | default "/" -}}
+  {{- $isSecure := false -}}
+  {{- if .vmSecure -}}
+    {{- $isSecure = .vmSecure -}}
+  {{- end -}}
+  {{- with .vmService -}}
+    {{- $service := index ($global.Values) . | default dict -}}
+    {{- $spec := $service.spec | default dict -}}
+    {{- $isSecure = ($spec.extraArgs).tls | default $isSecure -}}
+    {{- $proto = (ternary "https" "http" $isSecure) -}}
+    {{- $port = (ternary 443 80 $isSecure) -}}
+    {{- $port = $spec.port | default $port -}}
+    {{- $path = dig "http.pathPrefix" $path ($spec.extraArgs | default dict) -}}
+  {{- end -}}
+  {{- printf "%s://%s.%s.svc:%d%s" $proto $name $ns (int $port) $path -}}
+{{- end -}}


### PR DESCRIPTION
- Added `vm.service` to construct vmoperator-managed service name
- Added `vm.url` to construct vmoperator-managed service base url
- Added `vm.name` for chart name
- Added `vm.fullname` which is actively used in resource name construction
- Added `vm.chart` to construct chart name label value
- Added `vm.labels` for common labels
- Added `vm.sa.name` for service account name
- Added `vm.metaLabels` for compatibility with most of the charts
- Added `vm.release` for release name
- Added `vm.selectorLabels` for common selector labels
- Expect built-in variables in both root and `.helm` context