### PR TITLE
common: added more templates

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Next release
 
-- TODO
+- Allow `appKey` argument to be a list to support deeply nested objects
+- Added `vm.namespace`, which returns `namespaceOverride` or `global.namespaceOverride` or `Release.Namespace` as a default
+- Added `vm.managed.fullname`, which returns default fullname prefixed by `appKey`
+- Added `vm.plain.fullname`, which returns default fullname suffixed by `appKey`
 
 ## 0.0.8
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.8
+version: 0.0.9
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"


### PR DESCRIPTION
- Allow `appKey` argument to be a list to support deeply nested objects
- Added `vm.namespace`, which returns `namespaceOverride` or `global.namespaceOverride` or `Release.Namespace` as a default. See [related issue](https://github.com/VictoriaMetrics/helm-charts/issues/569)
- Added `vm.managed.fullname`, which returns default fullname prefixed by `appKey`
- Added `vm.plain.fullname`, which returns default fullname suffixed by `appKey`