### PR TITLE
use operator's own service monitor

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Use operator's own service monitor
 
 ## 0.25.12
 

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.25.12
+version: 0.25.13
 appVersion: v1.102.1
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -1905,16 +1905,8 @@ crd:
 enabled: true
 operator:
     disable_prometheus_converter: false
-vmScrape:
-    spec:
-        endpoints:
-            - port: http
-        namespaceSelector:
-            matchNames:
-                - '{{ include "vm.namespace" . }}'
-        selector:
-            matchLabels:
-                app.kubernetes.io/name: victoria-metrics-operator
+serviceMonitor:
+    enabled: true
 </pre>
 </td>
       <td><p>also checkout here possible ENV variables to configure operator behaviour <a href="https://docs.victoriametrics.com/operator/vars" target="_blank">https://docs.victoriametrics.com/operator/vars</a></p>
@@ -1951,23 +1943,6 @@ false
 </pre>
 </td>
       <td><p>By default, operator converts prometheus-operator objects.</p>
-</td>
-    </tr>
-    <tr>
-      <td>victoria-metrics-operator.vmScrape.spec</td>
-      <td>object</td>
-      <td><pre lang="plaintext">
-endpoints:
-    - port: http
-namespaceSelector:
-    matchNames:
-        - '{{ include "vm.namespace" . }}'
-selector:
-    matchLabels:
-        app.kubernetes.io/name: victoria-metrics-operator
-</pre>
-</td>
-      <td><p>spec for VMServiceScrape crd <a href="https://docs.victoriametrics.com/operator/api.html#vmservicescrapespec" target="_blank">https://docs.victoriametrics.com/operator/api.html#vmservicescrapespec</a></p>
 </td>
     </tr>
     <tr>

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -19,6 +19,8 @@ argocdReleaseOverride: ""
 # -- also checkout here possible ENV variables to configure operator behaviour https://docs.victoriametrics.com/operator/vars
 victoria-metrics-operator:
   enabled: true
+  serviceMonitor:
+    enabled: true
   crd:
     # -- we disable crd creation by operator chart as we create them in this chart
     create: false
@@ -31,18 +33,6 @@ victoria-metrics-operator:
         # use image tag that matches k8s API version by default
         # tag: 1.29.6
         pullPolicy: IfNotPresent
-  vmScrape:
-    # -- spec for VMServiceScrape crd
-    # https://docs.victoriametrics.com/operator/api.html#vmservicescrapespec
-    spec:
-      selector:
-        matchLabels:
-          app.kubernetes.io/name: victoria-metrics-operator
-      endpoints:
-        - port: http
-      namespaceSelector:
-        matchNames:
-         - '{{ include "vm.namespace" . }}'
   operator:
     # -- By default, operator converts prometheus-operator objects.
     disable_prometheus_converter: false


### PR DESCRIPTION
can be related to https://github.com/VictoriaMetrics/helm-charts/issues/1419
do not create operator's service monitor, when it's already provided by operator's chart and just requires a `victoria-metrics-operator.serviceMonitor.enabled` toggle to be set to `true`