### PR TITLE
cluster bugfix and drop empty endpoints from scrape

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fixed vmstorage resources templating
 
 ## 0.13.2
 

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 appVersion: v1.103.0
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.13.2
+version: 0.13.3
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -107,7 +107,7 @@ spec:
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "startup"))) }}
           startupProbe: {{ toYaml . | nindent 12 }}
           {{- end }}
-          {{- with $app.resource }}
+          {{- with $app.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Drop empty endpoints param from scrape configuration
 
 ## 0.25.14
 

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors.yaml
@@ -96,7 +96,14 @@ metadata:
   name: {{ $fullname }}
   namespace: {{ $namespace }}
   labels: {{ $scrapeLabels | nindent 4 }}
-spec: {{ (tpl (toYaml (mergeOverwrite (deepCopy $spec) (deepCopy $sc.spec))) $) | nindent 2 }}
+{{- $emptyParamsToDrop := list "endpoints" }}
+{{- $scrapeSpec := mergeOverwrite (deepCopy $spec) (deepCopy $sc.spec) }}
+{{- range $paramToDrop := $emptyParamsToDrop }}
+  {{- if and (hasKey $scrapeSpec $paramToDrop) (empty (index $scrapeSpec $paramToDrop)) }}
+    {{- $_ := unset $scrapeSpec $paramToDrop }}
+  {{- end }}
+{{- end }}
+spec: {{ (tpl (toYaml $scrapeSpec) $) | nindent 2 }}
 
 
         {{- end }}


### PR DESCRIPTION
- fixed resources templating for vmstorage in victoria-metrics-cluster chart
- drop empty "endpoints" from spec to support switching to different scrape config types