### PR TITLE
charts/victoria-metrics-alert: remove license args for AM

### DIFF
--- a/charts/victoria-metrics-alert/templates/_helpers.tpl
+++ b/charts/victoria-metrics-alert/templates/_helpers.tpl
@@ -244,7 +244,6 @@ http://{{- include "vmalert.alertmanager.fullname" . -}}:9093{{ .Values.alertman
   {{ with $app.baseURLPrefix }}
     {{- $_ := set $args "web.route-prefix" $app.baseURLPrefix -}}
   {{- end -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}


### PR DESCRIPTION
AM does not use VictoriaMetrics' licensing flags, so remove templating of these flags.