### PR TITLE
do not truncate names of resources to prevent collision

### DIFF
--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Next release
 
 - Added ability to override deployment namespace using `namespaceOverride` and `global.namespaceOverride` variables
-- updated alertmanager args for IPv6 compatibility. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/856)
+- Updated alertmanager args for IPv6 compatibility. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/856)
+- Added ability to set init containers for alertmanager and vmalert pods
 
 ## 0.11.0
 

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-metrics-alert
 description: Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.11.0
+version: 0.11.1
 appVersion: v1.103.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -1,7 +1,7 @@
 
 # Helm Chart For Victoria Metrics Alert.
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/victoriametrics)](https://artifacthub.io/packages/helm/victoriametrics/victoria-metrics-alert)
 [![Slack](https://img.shields.io/badge/join%20slack-%23victoriametrics-brightgreen.svg)](https://slack.victoriametrics.com/)
 

--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Next release
 
 - Fixed protocol extraction with TLS enabled
+- Typo fixes
+- use appkey as `app` label by default
+- support multiple service naming styles for `vm.service`
 
 ## 0.0.9
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.9
+version: 0.0.10
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_service.tpl
+++ b/charts/victoria-metrics-common/templates/_service.tpl
@@ -2,47 +2,72 @@
 {{- define "vm.service" -}}
   {{- include "vm.validate.args" . -}}
   {{- $Values := (.helm).Values | default .Values -}}
-  {{- $name := (include "vm.fullname" .) -}}
-  {{- with .appKey -}}
-    {{- $prefix := . -}}
-    {{- $prefix := . -}}
-    {{- if kindIs "slice" $prefix }}
-      {{- $prefix = last $prefix -}}
-    {{- end -}}
-    {{- $prefix = ternary $prefix (printf "vm%s" $prefix) (hasPrefix "vm" $prefix) -}}
-    {{- $name = printf "%s-%s" $prefix $name -}}
+  {{- $nameTpl := "vm.fullname" }}
+  {{- if eq .style "managed" -}}
+    {{- $nameTpl = "vm.managed.fullname" }}
+  {{- else if eq .style "plain" -}}
+    {{- $nameTpl = "vm.plain.fullname" }}
   {{- end -}}
+  {{- include $nameTpl . -}}
+{{- end }}
+
+{{- define "vm.fqdn" -}}
+  {{- $name := (include "vm.service" .) -}}
   {{- if hasKey . "appIdx" -}}
     {{- $name = (printf "%s-%d.%s" $name .appIdx $name) -}}
   {{- end -}}
-  {{- $name -}}
-{{- end }}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $ns := (include "vm.namespace" .) -}}
+  {{- $fqdn := printf "%s.%s.svc" $name $ns -}}
+  {{- with (($Values.global).cluster).dnsDomain -}}
+    {{- $fqdn = printf "%s.%s" $fqdn . -}}
+  {{- end -}}
+  {{- $fqdn -}}
+{{- end -}}
+
+{{- define "vm.host" -}}
+  {{- $fqdn := (include "vm.fqdn" .) -}}
+  {{- $port := 80 -}}
+  {{- $isSecure := ternary false true (empty .appSecure) -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- if .appKey -}}
+    {{- $appKey := ternary (list .appKey) .appKey (kindIs "string" .appKey) -}}
+    {{- $spec := $Values -}}
+    {{- range $ak := $appKey -}}
+      {{- if index $spec $ak -}}
+        {{- $spec = (index $spec $ak) -}}
+      {{- end -}}
+      {{- if and (kindIs "map" $spec) (hasKey $spec "spec") -}}
+        {{- $spec = $spec.spec -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $isSecure = (eq ($spec.extraArgs).tls "true") | default $isSecure -}}
+    {{- $port = (ternary 443 80 $isSecure) -}}
+    {{- $port = $spec.port | default $port -}}
+  {{- end }}
+  {{- $fqdn }}:{{ $port }}
+{{- end -}}
 
 {{- define "vm.url" -}}
-  {{- $name := (include "vm.service" .) -}}
-  {{- $Release := (.helm).Release | default .Release -}}
+  {{- $host := (include "vm.host" .) -}}
   {{- $Values := (.helm).Values | default .Values -}}
-  {{- $ns := (include "vm.namespace .) -}}
   {{- $proto := "http" -}}
-  {{- $port := 80 -}}
   {{- $path := .appRoute | default "/" -}}
   {{- $isSecure := ternary false true (empty .appSecure) -}}
   {{- if .appKey -}}
     {{- $appKey := ternary (list .appKey) .appKey (kindIs "string" .appKey) -}}
     {{- $spec := $Values -}}
     {{- range $ak := $appKey -}}
-      {{- if hasKey $spec $ak -}}
+      {{- if index $spec $ak -}}
         {{- $spec = (index $spec $ak) -}}
       {{- end -}}
-      {{- if hasKey $spec "spec" -}}
+      {{- if and (kindIs "map" $spec) (hasKey $spec "spec") -}}
         {{- $spec = $spec.spec -}}
       {{- end -}}
     {{- end -}}
     {{- $isSecure = (eq ($spec.extraArgs).tls "true") | default $isSecure -}}
     {{- $proto = (ternary "https" "http" $isSecure) -}}
-    {{- $port = (ternary 443 80 $isSecure) -}}
-    {{- $port = $spec.port | default $port -}}
     {{- $path = dig "http.pathPrefix" $path ($spec.extraArgs | default dict) -}}
   {{- end -}}
-  {{- printf "%s://%s.%s.svc:%d%s" $proto $name $ns (int $port) $path -}}
+  {{- printf "%s://%s%s" $proto $host $path -}}
 {{- end -}}

--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Do not truncate datasource name
 
 ## 0.3.0
 

--- a/charts/victoria-metrics-distributed/Chart.lock
+++ b/charts/victoria-metrics-distributed/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
+- name: victoria-metrics-common
+  repository: https://victoriametrics.github.io/helm-charts
+  version: 0.0.9
 - name: victoria-metrics-k8s-stack
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.25.12
-digest: sha256:f7d99ad2a14a0505e36d6bec4daeb244000be7763e18ae49df5906c5c69a39ae
-generated: "2024-09-03T15:58:12.095677+03:00"
+  version: 0.25.15
+digest: sha256:e3de52694b1f4f429343d301af18f8c8b1a6674323c2f5bf1757874752c81a6e
+generated: "2024-09-07T09:10:18.966418+03:00"

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -29,6 +29,9 @@ annotations:
       url: https://docs.victoriametrics.com
 
 dependencies:
+  - name: victoria-metrics-common
+    version: "0.0.*"
+    repository: https://victoriametrics.github.io/helm-charts
   - name: victoria-metrics-k8s-stack
     version: "0.25.*"
     repository: https://victoriametrics.github.io/helm-charts

--- a/charts/victoria-metrics-distributed/templates/grafana-datasource.yaml
+++ b/charts/victoria-metrics-distributed/templates/grafana-datasource.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "grafana-ds" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "victoria-metrics-distributed.fullname" . }}-grafana-ds
   namespace: {{ include "vm.namespace" . }}
   labels: {{ include "victoria-metrics-distributed.labels" . | nindent 4 }}
     {{ index .Values "victoria-metrics-k8s-stack" "grafana" "sidecar" "datasources" "label" }}: "1"

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-- TODO
+- Do not truncate servicemonitor, datasources, rules, dashboard, alertmanager & vmalert templates names
+- Use service label for node-exporter instead of podLabel. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1458)
+- Added common chart to a k8s-stack. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1456)
 
 ## 0.25.15
 

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Do not truncate servicemonitor, datasources, rules, dashboard, alertmanager & vmalert templates names
 - Use service label for node-exporter instead of podLabel. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1458)
 - Added common chart to a k8s-stack. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1456)
+- Fixed value of custom alertmanager configSecret. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1461)
 
 ## 0.25.15
 

--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -1,4 +1,7 @@
 dependencies:
+- name: victoria-metrics-common
+  repository: https://victoriametrics.github.io/helm-charts
+  version: 0.0.9
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts
   version: 0.34.7
@@ -17,5 +20,5 @@ dependencies:
 - name: prometheus-operator-crds
   repository: https://prometheus-community.github.io/helm-charts
   version: 11.0.0
-digest: sha256:215caad34f9852dcefe115ea4adf831f249afd642d27e1b927c3eed16647942e
-generated: "2024-09-03T08:54:50.548498217Z"
+digest: sha256:405a75f2d9fe9cdb0548df274acb4180877288243e7971503a0413e478207532
+generated: "2024-09-06T00:37:16.848156+03:00"

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.25.15
+version: 0.25.16
 appVersion: v1.102.1
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
@@ -32,6 +32,9 @@ annotations:
       url: https://docs.victoriametrics.com
 
 dependencies:
+  - name: victoria-metrics-common
+    version: "0.0.*"
+    repository: https://victoriametrics.github.io/helm-charts
   - name: victoria-metrics-operator
     version: "0.34.*"
     repository: https://victoriametrics.github.io/helm-charts

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -1,7 +1,7 @@
 
 # Helm Chart For Victoria Metrics kubernetes monitoring stack.
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.25.15](https://img.shields.io/badge/Version-0.25.15-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.25.16](https://img.shields.io/badge/Version-0.25.16-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/victoriametrics)](https://artifacthub.io/packages/helm/victoriametrics/victoria-metrics-k8s-stack)
 
 Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
@@ -398,16 +398,6 @@ templates:
 </td>
     </tr>
     <tr>
-      <td>alertmanager.configSecret</td>
-      <td>string</td>
-      <td><pre lang="">
-""
-</pre>
-</td>
-      <td><p>if this one defined, it will be used for alertmanager configuration and config parameter will be ignored</p>
-</td>
-    </tr>
-    <tr>
       <td>alertmanager.enabled</td>
       <td>bool</td>
       <td><pre lang="">
@@ -447,6 +437,7 @@ true
       <td>alertmanager.spec</td>
       <td>object</td>
       <td><pre lang="plaintext">
+configSecret: ""
 externalURL: ""
 image:
     tag: v0.25.0
@@ -456,6 +447,16 @@ selectAllByDefault: true
 </pre>
 </td>
       <td><p>full spec for VMAlertmanager CRD. Allowed values described <a href="https://docs.victoriametrics.com/operator/api#vmalertmanagerspec" target="_blank">here</a></p>
+</td>
+    </tr>
+    <tr>
+      <td>alertmanager.spec.configSecret</td>
+      <td>string</td>
+      <td><pre lang="">
+""
+</pre>
+</td>
+      <td><p>if this one defined, it will be used for alertmanager configuration and config parameter will be ignored</p>
 </td>
     </tr>
     <tr>
@@ -1793,7 +1794,7 @@ true
       <td></td>
     </tr>
     <tr>
-      <td>prometheus-node-exporter.podLabels.jobLabel</td>
+      <td>prometheus-node-exporter.service.labels.jobLabel</td>
       <td>string</td>
       <td><pre lang="">
 node-exporter

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -193,7 +193,7 @@ If release name contains chart name it will be used as a full name.
   {{- $_ := set $remotes "remoteRead" $remoteRead -}}
   {{- $_ := set $remotes "datasource" $remoteRead -}}
   {{- if $Values.vmalert.additionalNotifierConfigs }}
-    {{- $configName := ((printf "%s-vmalert-additional-notifier" $fullname) | trunc 63 | trimSuffix "-") -}}
+    {{- $configName := printf "%s-vmalert-additional-notifier" $fullname -}}
     {{- $notifierConfigRef := dict "name" $configName "key" "notifier-configs.yaml" -}}
     {{- $_ := set $remotes "notifierConfigRef" $notifierConfigRef -}}
   {{- else if $Values.alertmanager.enabled -}}
@@ -216,7 +216,7 @@ If release name contains chart name it will be used as a full name.
   {{- $cms :=  ($Values.vmalert.spec.configMaps | default list) -}}
   {{- if $Values.vmalert.templateFiles -}}
     {{- $fullname := (include "victoria-metrics-k8s-stack.fullname" .) -}}
-    {{- $cms = append $cms ((printf "%s-vmalert-extra-tpl" $fullname) | trunc 63 | trimSuffix "-") -}}
+    {{- $cms = append $cms (printf "%s-vmalert-extra-tpl" $fullname) -}}
   {{- end -}}
   {{- $output := dict "configMaps" (compact $cms) -}}
   {{- toYaml $output -}}
@@ -243,7 +243,7 @@ If release name contains chart name it will be used as a full name.
   {{- $Values := (.helm).Values | default .Values }}
   {{- $extraArgs := dict "remoteWrite.disablePathAppend" "true" -}}
   {{- if $Values.vmalert.templateFiles -}}
-    {{- $ruleTmpl := (printf "/etc/vm/configs/%s-vmalert-extra-tpl/*.tmpl" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-") -}}
+    {{- $ruleTmpl := (printf "/etc/vm/configs/%s-vmalert-extra-tpl/*.tmpl" (include "victoria-metrics-k8s-stack.fullname" .)) -}}
     {{- $_ := set $extraArgs "rule.templates" $ruleTmpl -}}
   {{- end -}}
   {{- $vmAlertRemotes := (include "vm.alert.remotes" . | fromYaml) -}}
@@ -293,10 +293,10 @@ If release name contains chart name it will be used as a full name.
   {{- end -}}
   {{- $templates := default list -}}
   {{- if $Values.alertmanager.monzoTemplate.enabled -}}
-    {{- $configMap := ((printf "%s-alertmanager-monzo-tpl" $fullname) | trunc 63 | trimSuffix "-") -}}
+    {{- $configMap := (printf "%s-alertmanager-monzo-tpl" $fullname) -}}
     {{- $templates = append $templates (dict "name" $configMap "key" "monzo.tmpl") -}}
   {{- end -}}
-  {{- $configMap := ((printf "%s-alertmanager-extra-tpl" $fullname) | trunc 63 | trimSuffix "-") -}}
+  {{- $configMap := (printf "%s-alertmanager-extra-tpl" $fullname) -}}
   {{- range $key, $value := (.Values.alertmanager.templateFiles | default dict) -}}
     {{- $templates = append $templates (dict "name" $configMap "key" $key) -}}
   {{- end -}}
@@ -397,8 +397,7 @@ If release name contains chart name it will be used as a full name.
 
 {{- /* VMRule name */ -}}
 {{- define "victoria-metrics-k8s-stack.rulegroup.name" -}}
-  {{- $id := include "victoria-metrics-k8s-stack.rulegroup.id" . -}}
-  {{- printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) $id | trunc 63 | trimSuffix "-" | trimSuffix "." -}}
+  {{- printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) (.name | replace "_" "") -}}
 {{- end -}}
 
 {{- /* VMRule labels */ -}}
@@ -413,11 +412,6 @@ If release name contains chart name it will be used as a full name.
 {{- /* VMRule key */ -}}
 {{- define "victoria-metrics-k8s-stack.rulegroup.key" -}}
   {{- without (regexSplit "[-_.]" .name -1) "exporter" "rules" | join "-" | camelcase | untitle -}}
-{{- end -}}
-
-{{- /* VMRule ID */ -}}
-{{- define "victoria-metrics-k8s-stack.rulegroup.id" -}}
-  {{- .name | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." -}}
 {{- end -}}
 
 {{- /* VMAlertmanager name */ -}}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/dashboard.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/dashboard.yaml
@@ -44,7 +44,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   namespace: {{ include "vm.namespace" $ }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) $dashboardName | replace "_" "" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) $dashboardName | replace "_" "" }}
   labels:
     app: {{ $app }}
     {{- include "victoria-metrics-k8s-stack.labels" $ | nindent 4 }}
@@ -62,7 +62,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ include "vm.namespace" $ }}
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) $dashboardName | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) $dashboardName }}
   labels:
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "1"

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "grafana-ds" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "victoria-metrics-k8s-stack.fullname" $ }}-grafana-ds
   namespace: {{ include "vm.namespace" $ }}
   {{- with $.Values.grafana.sidecar.datasources.annotations }}
   annotations: {{ toYaml $ | nindent 4 }}

--- a/charts/victoria-metrics-k8s-stack/templates/rules/additionalVictoriaMetricsRules.yml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/additionalVictoriaMetricsRules.yml
@@ -1,17 +1,16 @@
 {{- $app := (include "victoria-metrics-k8s-stack.name" .) }}
-{{- $fullname := ((printf "%s-additional-victoria-metrics-rules" (include "victoria-metrics-k8s-stack.fullname" .)) | trunc 63 | trimSuffix "-") }}
 {{- if .Values.additionalVictoriaMetricsMap }}
 apiVersion: v1
 kind: List
 metadata:
-  name: {{ $fullname }}
+  name: {{ include "victoria-metrics-k8s-stack.fullname" . }}-additional-victoria-metrics-rules
   namespace: {{ include "vm.namespace" . }}
 items:
 {{- range $VMRuleName, $VMRule := .Values.additionalVictoriaMetricsMap }}
   - apiVersion: operator.victoriametrics.com/v1beta1
     kind: VMRule
     metadata:
-      {{- $name := ((printf "%s-%s" $app $VMRuleName) | trunc 63 | trimSuffix "-") }}
+      {{- $name := (printf "%s-%s" $app $VMRuleName) }}
       name: {{ $name }}
       namespace: {{ include "vm.namespace" $ }}
       {{- $extraLabels := (deepCopy ($VMRule.additionalLabels | default dict)) -}}

--- a/charts/victoria-metrics-k8s-stack/templates/servicemonitors.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/servicemonitors.yaml
@@ -5,7 +5,8 @@
 {{- range $name, $config := .Values }}
   {{- if and (kindIs "map" $config) $config.enabled (hasKey $config "vmScrape") }}
     {{- $svc := kebabcase $name }}
-    {{- $fullname := (printf "%s-%s" $prefix $svc) | trunc 63 | trimSuffix "-" }}
+    {{- $fullname := (printf "%s-%s" $prefix $svc) }}
+    {{- $fullnameLabel := $fullname | trunc 63 | trimSuffix "-" }}
     {{- $ctx := deepCopy $global }}
     {{- $ports := ($config.service).ports | default dict }}
     {{- if ($config.service).port }}
@@ -18,7 +19,7 @@ kind: Endpoints
 metadata:
   name: {{ $fullname }}
   namespace: kube-system
-  {{- $extraLabels := dict "app" $fullname "k8s-app" $svc }}
+  {{- $extraLabels := dict "app" $fullnameLabel "k8s-app" $svc }}
   {{- $_ := set $ctx "extraLabels" $extraLabels }}
   labels: {{ include "victoria-metrics-k8s-stack.labels" $ctx | nindent 4 }}
 subsets:
@@ -43,7 +44,7 @@ subsets:
     {{- end }}
     {{- $selector := default dict }}
     {{- if and ($config.service).enabled (empty (index $.Subcharts $name)) }}
-      {{- $extraLabels := dict "app" $fullname "jobLabel" $svc }}
+      {{- $extraLabels := dict "app" $fullnameLabel "jobLabel" $svc }}
       {{- $_ := set $ctx "extraLabels" $extraLabels }}
       {{- $selector = dict "matchLabels" (fromYaml (include "victoria-metrics-k8s-stack.selectorLabels" $ctx)) }}
 ---
@@ -88,7 +89,7 @@ spec:
       {{- range $scrapeName, $scrapeConfig := $scrapes }}
         {{- $sc := mergeOverwrite (deepCopy $defaultScrape) (deepCopy $scrapeConfig) }}
         {{- if or (not (hasKey $sc "enabled")) $sc.enabled }}
-          {{- $fullname = (printf "%s-%s" $prefix $scrapeName) | trunc 63 | trimSuffix "-" }}
+          {{- $fullname = (printf "%s-%s" $prefix $scrapeName) }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: {{ ternary "VMServiceScrape" $sc.kind (empty $sc.kind) }}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/custom-templates.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/custom-templates.yaml
@@ -2,7 +2,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" $) "alertmanager-extra-tpl" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "victoria-metrics-k8s-stack.fullname" . }}-alertmanager-extra-tpl
   namespace: {{ include "vm.namespace" . }}
   labels: 
     app.kubernetes.io/component: {{ include "victoria-metrics-k8s-stack.name" $ }}-alertmanager

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/monzo-template.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/monzo-template.yaml
@@ -2,7 +2,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "alertmanager-monzo-tpl" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "victoria-metrics-k8s-stack.fullname" . }}-alertmanager-monzo-tpl
   namespace: {{ include "vm.namespace" . }}
   labels: 
     app.kubernetes.io/component: {{ include "victoria-metrics-k8s-stack.name" $ }}-alertmanager

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/custom-templates.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/custom-templates.yaml
@@ -2,7 +2,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "vmalert-extra-tpl" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "victoria-metrics-k8s-stack.fullname" . }}-vmalert-extra-tpl
   namespace: {{ include "vm.namespace" . }}
   labels: 
     app.kubernetes.io/component: {{ include "victoria-metrics-k8s-stack.name" . }}-vmalert

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/notifiers.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/notifiers.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" (include "victoria-metrics-k8s-stack.fullname" .) "vmalert-additional-notifier" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "victoria-metrics-k8s-stack.fullname" . }}-vmalert-additional-notifier
   namespace: {{ include "vm.namespace" . }}
   labels:
     app.kubernetes.io/component: {{ include "victoria-metrics-k8s-stack.name" . }}-vmalert

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -488,8 +488,8 @@ alertmanager:
     externalURL: ""
     routePrefix: /
 
-  # -- (string) if this one defined, it will be used for alertmanager configuration and config parameter will be ignored
-  configSecret: ""
+    # -- (string) if this one defined, it will be used for alertmanager configuration and config parameter will be ignored
+    configSecret: ""
   # -- (object) alertmanager configuration
   config:
     templates:

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -896,10 +896,11 @@ prometheus-node-exporter:
   enabled: true
 
   # all values for prometheus-node-exporter helm chart can be specified here
-  podLabels:
+  service:
     ## Add the 'node-exporter' label to be used by serviceMonitor to match standard common usage in rules and grafana dashboards
     ##
-    jobLabel: node-exporter
+    labels:
+      jobLabel: node-exporter
   extraArgs:
     - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
     - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Next release
 
 - Added ability to override deployment namespace using `namespaceOverride` and `global.namespaceOverride` variables
+- Fixed template for cert-manager certificates
+- Removed cluster role disabling, when operator watches self namespace
 
 ## 0.34.7
 

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Added ability to override deployment namespace using `namespaceOverride` and `global.namespaceOverride` variables
 - Fixed template for cert-manager certificates
-- Removed cluster role disabling, when operator watches self namespace
+- Fixed operator Role creation when only watching own namespace using `watchNamespaces`
 - Changed webhook service port from 443 to 9443
 
 ## 0.34.7

--- a/charts/victoria-metrics-operator/templates/_helpers.tpl
+++ b/charts/victoria-metrics-operator/templates/_helpers.tpl
@@ -91,7 +91,7 @@ meta.helm.sh/release-name: {{ $Release.Name }}
 Create the name of service account and clusterRole for cleanup-hook
 */}}
 {{- define "vm-operator.cleanupHookName" -}}
-  {{- printf "%s-%s" (include "vm-operator.fullname" .) "cleanup-hook" | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  {{- include "vm-operator.fullname" . }}-cleanup-hook
 {{- end }}
 
 {{/*

--- a/charts/victoria-metrics-operator/templates/crb.yaml
+++ b/charts/victoria-metrics-operator/templates/crb.yaml
@@ -1,8 +1,4 @@
-{{- $watchNamespaces := (fromYaml (tpl (toYaml (dict "ns" .Values.watchNamespaces)) .)).ns }}
-{{- $selfNamespace := (include "vm.namespace" .) }}
-{{- $watchSelfNamespace := (and (eq (len $watchNamespaces) 1) (eq (first $watchNamespaces) $selfNamespace)) }}
-
-{{- if and .Values.rbac.create (not $watchSelfNamespace) }}
+{{- if .Values.rbac.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,7 +17,7 @@ roleRef:
   name: {{ include "vm-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}
-{{- if or .Values.cleanupCRD .Values.crd.cleanup.enabled }}
+{{- if .Values.crd.cleanup.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/victoria-metrics-operator/templates/role.yaml
+++ b/charts/victoria-metrics-operator/templates/role.yaml
@@ -33,33 +33,6 @@ metadata:
   namespace: {{ include "vm.namespace" . }}
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
   - coordination.k8s.io
   verbs:
   - create
@@ -67,6 +40,11 @@ rules:
   - update
   resources:
   - leases
+
+{{- $watchNamespaces := (fromYaml (tpl (toYaml (dict "ns" .Values.watchNamespaces)) .)).ns }}
+{{- $selfNamespace := (include "vm.namespace" .) }}
+{{- $watchSelfNamespace := (and (eq (len $watchNamespaces) 1) (eq (first $watchNamespaces) $selfNamespace)) }}
+{{- if not $watchSelfNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -78,6 +56,14 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 rules:
+- nonResourceURLs:
+  - /metrics
+  - /metrics/resources
+  verbs:
+  - get
+  - watch
+  - list
+{{- end }}
 - apiGroups:
   - ""
   resources:
@@ -125,13 +111,6 @@ rules:
   - "*"
   verbs:
   - "*"
-- nonResourceURLs:
-  - /metrics
-  - /metrics/resources
-  verbs:
-  - get
-  - watch
-  - list
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/charts/victoria-metrics-operator/templates/role.yaml
+++ b/charts/victoria-metrics-operator/templates/role.yaml
@@ -67,11 +67,6 @@ rules:
   - update
   resources:
   - leases
-
-{{- $watchNamespaces := (fromYaml (tpl (toYaml (dict "ns" .Values.watchNamespaces)) .)).ns }}
-{{- $selfNamespace := (include "vm.namespace" .) }}
-{{- $watchSelfNamespace := (and (eq (len $watchNamespaces) 1) (eq (first $watchNamespaces) $selfNamespace)) }}
-{{- if not $watchSelfNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -83,7 +78,6 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 rules:
-{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/victoria-metrics-operator/templates/webhook.yaml
+++ b/charts/victoria-metrics-operator/templates/webhook.yaml
@@ -7,8 +7,8 @@ metadata:
   name:  {{ include "vm-operator.fullname" . }}-admission
   {{- if .Values.admissionWebhooks.certManager.enabled }}
   annotations:
-    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-validation" include "vm.namespace" . ( include "vm-operator.fullname" .) | quote }}
-    cert-manager.io/inject-ca-from: {{ printf "%s/%s-validation" include "vm.namespace" . (include "vm-operator.fullname" .) | quote }}
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-validation" (include "vm.namespace" .) ( include "vm-operator.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-validation" (include "vm.namespace" .) (include "vm-operator.fullname" .) | quote }}
   {{- end }}
   {{- $ctx := dict "helm" . "extraLabels" .Values.extraLabels }}
   labels: {{ include "vm-operator.labels" $ctx | nindent 4 }}


### PR DESCRIPTION
- do not truncate datasource, dashboard, rule, config, alert template names
- some typo fixes in common chart
- append global.cluster.dnsDomain to domain in common chart. related issue https://github.com/VictoriaMetrics/helm-charts/issues/1455
- added common chart to k8s-stack directly, related issue https://github.com/VictoriaMetrics/helm-charts/issues/1456
- fixed jobLabel for node-exporter, related issue https://github.com/VictoriaMetrics/helm-charts/issues/1458
- fix operator Role creation when only watching own namespace using `watchNamespaces`