### PR TITLE
k8s-stack: removed CRDs subchart as they are already included in operator

### DIFF
--- a/charts/victoria-metrics-agent/Chart.lock
+++ b/charts/victoria-metrics-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.15
-digest: sha256:28ebee3a7c14718527f72d912db85bb53fa05a0ffce17dfaab6ea836d7b495d6
-generated: "2024-10-11T07:18:51.909855212Z"
+  version: 0.0.16
+digest: sha256:7549c73bc949e7f40e67441c4a3a151471d4e258e9d32cc1c0f879f70825cce4
+generated: "2024-10-22T13:22:55.643975002Z"

--- a/charts/victoria-metrics-alert/Chart.lock
+++ b/charts/victoria-metrics-alert/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.15
-digest: sha256:28ebee3a7c14718527f72d912db85bb53fa05a0ffce17dfaab6ea836d7b495d6
-generated: "2024-10-11T07:18:55.704052714Z"
+  version: 0.0.16
+digest: sha256:7549c73bc949e7f40e67441c4a3a151471d4e258e9d32cc1c0f879f70825cce4
+generated: "2024-10-22T13:23:00.238306671Z"

--- a/charts/victoria-metrics-anomaly/Chart.lock
+++ b/charts/victoria-metrics-anomaly/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.15
-digest: sha256:28ebee3a7c14718527f72d912db85bb53fa05a0ffce17dfaab6ea836d7b495d6
-generated: "2024-10-11T07:18:59.583480465Z"
+  version: 0.0.16
+digest: sha256:7549c73bc949e7f40e67441c4a3a151471d4e258e9d32cc1c0f879f70825cce4
+generated: "2024-10-22T13:23:04.269443839Z"

--- a/charts/victoria-metrics-anomaly/README.md
+++ b/charts/victoria-metrics-anomaly/README.md
@@ -1,4 +1,4 @@
-![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square)
+![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/victoriametrics)](https://artifacthub.io/packages/helm/victoriametrics/victoria-metrics-anomaly)
 [![Slack](https://img.shields.io/badge/join%20slack-%23victoriametrics-brightgreen.svg)](https://slack.victoriametrics.com/)
 [![GitHub license](https://img.shields.io/github/license/VictoriaMetrics/VictoriaMetrics.svg)](https://github.com/VictoriaMetrics/helm-charts/blob/master/LICENSE)

--- a/charts/victoria-metrics-auth/Chart.lock
+++ b/charts/victoria-metrics-auth/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.15
-digest: sha256:28ebee3a7c14718527f72d912db85bb53fa05a0ffce17dfaab6ea836d7b495d6
-generated: "2024-10-11T07:19:01.539036675Z"
+  version: 0.0.16
+digest: sha256:7549c73bc949e7f40e67441c4a3a151471d4e258e9d32cc1c0f879f70825cce4
+generated: "2024-10-22T13:23:06.368121132Z"

--- a/charts/victoria-metrics-distributed/Chart.lock
+++ b/charts/victoria-metrics-distributed/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.15
+  version: 0.0.16
 - name: victoria-metrics-k8s-stack
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.27.3
-digest: sha256:cb5ddbf0a0dee410ad452097f8bcb77b7f51270c0b52e5ca6a231b93659bfbc8
-generated: "2024-10-11T08:51:56.905198589Z"
+  version: 0.27.6
+digest: sha256:35e992e38dd712f0c98aa56b98d84cb1613efa6950fd1c43f8f4ee2bd1bd6972
+generated: "2024-10-22T13:23:10.723007759Z"

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Removed crds subchart as it's now included in operator
 
 ## 0.27.6
 

--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.15
+  version: 0.0.16
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.35.4
+  version: 0.36.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.25.1
@@ -13,12 +13,9 @@ dependencies:
   version: 4.39.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 8.5.5
-- name: crds
-  repository: ""
-  version: 0.0.0
+  version: 8.5.8
 - name: prometheus-operator-crds
   repository: https://prometheus-community.github.io/helm-charts
   version: 15.0.0
-digest: sha256:9eeaa9d107f06033e015e016c6847ae873584a22bac3957bc60c1d0814095a93
-generated: "2024-10-15T19:50:06.034925+02:00"
+digest: sha256:8f53996503e6d48afd01a374c1c795794de6c22e42488c3250a271a388971fb0
+generated: "2024-10-22T13:28:09.37622905Z"

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     version: "0.0.*"
     repository: https://victoriametrics.github.io/helm-charts
   - name: victoria-metrics-operator
-    version: "0.35.*"
+    version: "0.36.*"
     repository: https://victoriametrics.github.io/helm-charts
     condition: victoria-metrics-operator.enabled
   - name: kube-state-metrics
@@ -51,9 +51,6 @@ dependencies:
     version: "8.5.*"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
-  - name: crds
-    version: "0.0.0"
-    condition: crds.enabled
   - name: prometheus-operator-crds
     version: "15.0.*"
     repository: https://prometheus-community.github.io/helm-charts

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -641,17 +641,6 @@ selectAllByDefault: true
 </td>
     </tr>
     <tr>
-      <td>crds</td>
-      <td>object</td>
-      <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">enabled: true
-</code>
-</pre>
-</td>
-      <td><p>Install VM operator CRDs</p>
-</td>
-    </tr>
-    <tr>
       <td>defaultDashboards.dashboards</td>
       <td>object</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
@@ -2114,13 +2103,13 @@ selector:
       <td>victoria-metrics-operator</td>
       <td>object</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">crd:
+<code class="language-yaml">crds:
     cleanup:
         enabled: true
         image:
             pullPolicy: IfNotPresent
             repository: bitnami/kubectl
-    create: false
+    plain: true
 enabled: true
 operator:
     disable_prometheus_converter: false
@@ -2130,6 +2119,17 @@ serviceMonitor:
 </pre>
 </td>
       <td><p>VictoriaMetrics Operator dependency chart configuration. More values can be found <a href="https://docs.victoriametrics.com/helm/victoriametrics-operator#parameters" target="_blank">here</a>. Also checkout <a href="https://docs.victoriametrics.com/operator/vars" target="_blank">here</a> possible ENV variables to configure operator behaviour</p>
+</td>
+    </tr>
+    <tr>
+      <td>victoria-metrics-operator.crds.plain</td>
+      <td>bool</td>
+      <td><pre class="helm-vars-default-value" language-yaml" lang="">
+<code class="language-yaml">true
+</code>
+</pre>
+</td>
+      <td><p>added temporary, till new operator version released</p>
 </td>
     </tr>
     <tr>

--- a/charts/victoria-metrics-k8s-stack/charts/crds
+++ b/charts/victoria-metrics-k8s-stack/charts/crds
@@ -1,1 +1,0 @@
-../../victoria-metrics-operator/charts/crds

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -22,15 +22,16 @@ argocdReleaseOverride: ""
 # -- VictoriaMetrics Operator dependency chart configuration. More values can be found [here](https://docs.victoriametrics.com/helm/victoriametrics-operator#parameters). Also checkout [here](https://docs.victoriametrics.com/operator/vars) possible ENV variables to configure operator behaviour
 victoria-metrics-operator:
   enabled: true
-  serviceMonitor:
-    enabled: true
-  crd:
-    create: false
+  crds:
+    # -- added temporary, till new operator version released
+    plain: true
     cleanup:
       enabled: true
       image:
         repository: bitnami/kubectl
         pullPolicy: IfNotPresent
+  serviceMonitor:
+    enabled: true
   operator:
     # -- By default, operator converts prometheus-operator objects.
     disable_prometheus_converter: false
@@ -1211,10 +1212,6 @@ kubeProxy:
           scheme: https
           tlsConfig:
             caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-
-# --  Install VM operator CRDs
-crds:
-  enabled: true
 
 # -- Install prometheus operator CRDs
 prometheus-operator-crds:

--- a/charts/victoria-metrics-operator/README.md
+++ b/charts/victoria-metrics-operator/README.md
@@ -1,4 +1,4 @@
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.35.5](https://img.shields.io/badge/Version-0.35.5-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.36.0](https://img.shields.io/badge/Version-0.36.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/victoriametrics)](https://artifacthub.io/packages/helm/victoriametrics/victoria-metrics-operator)
 
 Victoria Metrics Operator
@@ -311,7 +311,7 @@ issuer: {}
 </td>
     </tr>
     <tr>
-      <td>crd.cleanup.enabled</td>
+      <td>crds.cleanup.enabled</td>
       <td>bool</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="">
 <code class="language-yaml">false
@@ -322,7 +322,7 @@ issuer: {}
 </td>
     </tr>
     <tr>
-      <td>crd.cleanup.image</td>
+      <td>crds.cleanup.image</td>
       <td>object</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
 <code class="language-yaml">pullPolicy: IfNotPresent
@@ -335,7 +335,7 @@ tag: ""
 </td>
     </tr>
     <tr>
-      <td>crd.cleanup.resources</td>
+      <td>crds.cleanup.resources</td>
       <td>object</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
 <code class="language-yaml">limits:
@@ -351,14 +351,14 @@ requests:
 </td>
     </tr>
     <tr>
-      <td>crd.create</td>
+      <td>crds.plain</td>
       <td>bool</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="">
-<code class="language-yaml">true
+<code class="language-yaml">false
 </code>
 </pre>
 </td>
-      <td><p>Enables CRD creation and management. With this option, if you remove this chart, all CRD resources will be deleted with it.</p>
+      <td><p>check if plain or templated CRDs should be created. with this option set to <code>false</code>, all CRDs will be rendered from templates. with this option set to <code>true</code>, all CRDs are immutable and require manual upgrade.</p>
 </td>
     </tr>
     <tr>

--- a/charts/victoria-metrics-single/Chart.lock
+++ b/charts/victoria-metrics-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.15
-digest: sha256:28ebee3a7c14718527f72d912db85bb53fa05a0ffce17dfaab6ea836d7b495d6
-generated: "2024-10-11T07:19:14.341845Z"
+  version: 0.0.16
+digest: sha256:7549c73bc949e7f40e67441c4a3a151471d4e258e9d32cc1c0f879f70825cce4
+generated: "2024-10-22T13:23:25.744247085Z"


### PR DESCRIPTION
moved CRDs to operators `crds` folder to avoid importing them in both k8s-stack and operator charts