### PR TITLE
Fix the clusternativeListenAddr port for vmselect

### DIFF
--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -55,10 +55,10 @@ spec:
           ports:
             - name: http
               containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8481") }}
-            {{- if $app.extraArgs.clusternativeListenAddr }}
+            {{- with $app.extraArgs.clusternativeListenAddr }}
             - name: cluster-tcp
               protocol: TCP
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.clusternativeListenAddr "default" "8401") }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .) }}
             {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
             {{- if $app.extraArgs.clusternativeListenAddr }}
             - name: cluster-tcp
               protocol: TCP
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" .) }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.clusternativeListenAddr "default" "8401") }}
             {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}


### PR DESCRIPTION
 in the victoria-metrics-cluster chart.
 
 This is required otherwise rendering the chart will result in the following:
 ```
 Error: template: victoria-metrics-cluster/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml:61:32: executing "victoria-metrics-cluster/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml" at <include "vm.port.from.flag" (dict "flag" .)>: error calling include: template: victoria-metrics-cluster/charts/victoria-metrics-auth/charts/victoria-metrics-common/templates/_pod.tpl:4:44: executing "vm.port.from.flag" at <.>: wrong type for value; expected string; got chartutil.Values
```