### PR TITLE
Enable to add annotations to vmanomaly  configMap

### DIFF
--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Added the ability to add annotations to the configMap using `values.configMapAnnotations`
 
 ## 1.4.5
 

--- a/charts/victoria-metrics-anomaly/README.md
+++ b/charts/victoria-metrics-anomaly/README.md
@@ -149,7 +149,6 @@ Change the values according to the need of the environment in ``victoria-metrics
       <td>config</td>
       <td>object</td>
       <td><pre lang="plaintext">
-annotations: {}
 models: {}
 preset: ""
 reader:
@@ -302,6 +301,16 @@ vm
 </pre>
 </td>
       <td><p>For VictoriaMetrics Cluster version only, tenants are identified by accountID or accountID:projectID. See VictoriaMetrics Cluster multitenancy docs</p>
+</td>
+    </tr>
+    <tr>
+      <td>configMapAnnotations</td>
+      <td>object</td>
+      <td><pre lang="plaintext">
+{}
+</pre>
+</td>
+      <td><p>Annotations to be added to configMap</p>
 </td>
     </tr>
     <tr>

--- a/charts/victoria-metrics-anomaly/README.md
+++ b/charts/victoria-metrics-anomaly/README.md
@@ -149,6 +149,7 @@ Change the values according to the need of the environment in ``victoria-metrics
       <td>config</td>
       <td>object</td>
       <td><pre lang="plaintext">
+annotations: {}
 models: {}
 preset: ""
 reader:

--- a/charts/victoria-metrics-anomaly/templates/configmap.yaml
+++ b/charts/victoria-metrics-anomaly/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "chart.fullname" . }}
   namespace: {{ include "vm.namespace" . }}
   labels: {{- include "chart.labels" . | nindent 4 }}
-  {{- with .Values.config.annotations }}
+  {{- with .Values.configMapAnnotations }}
   annotations: {{ toYaml . | nindent 10 }}
   {{- end }}
 data:

--- a/charts/victoria-metrics-anomaly/templates/configmap.yaml
+++ b/charts/victoria-metrics-anomaly/templates/configmap.yaml
@@ -4,5 +4,8 @@ metadata:
   name: {{ include "chart.fullname" . }}
   namespace: {{ include "vm.namespace" . }}
   labels: {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.config.annotations }}
+  annotations: {{ toYaml . | nindent 10 }}
+  {{- end }}
 data:
   config.yml: |{{ toYaml (.Values.config | default dict) | nindent 4 }}

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -101,6 +101,9 @@ annotations: {}
 # -- Annotations to be added to pod
 podAnnotations: {}
 
+# -- Annotations to be added to configMap
+configMapAnnotations: {}
+
 # -- NodeSelector configurations. Details are [here](https://kubernetes.io/docs/user-guide/node-selection/)
 nodeSelector: {}
 
@@ -161,8 +164,6 @@ config:
     datasource_url: ""
     # -- For VictoriaMetrics Cluster version only, tenants are identified by accountID or accountID:projectID. See VictoriaMetrics Cluster multitenancy docs
     tenant_id: ""
-    # -- ConfigMap annotations
-  annotations: {}
 
 emptyDir: {}
 # -- Persistence to store models on disk.

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -161,6 +161,8 @@ config:
     datasource_url: ""
     # -- For VictoriaMetrics Cluster version only, tenants are identified by accountID or accountID:projectID. See VictoriaMetrics Cluster multitenancy docs
     tenant_id: ""
+    # -- ConfigMap annotations
+  annotations: {}
 
 emptyDir: {}
 # -- Persistence to store models on disk.


### PR DESCRIPTION

**Description**

This pull request introduces the ability to add annotations to the anomaly ConfigMap. Annotations are crucial for integrating the ConfigMap with tools like Vault, among others. By allowing annotations, this change enhances the flexibility of the ConfigMap, enabling seamless integrations with external systems that rely on metadata