### PR TITLE
common: new release with templates fixes

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next release
 
-- TODO
+- Do not use image variant if custom image tag is set in `vm.image` template
+- Support multiple license flag styles, which are different for vmanomaly and other services
 
 ## 0.0.12
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.12
+version: 0.0.13
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_enterprise.tpl
+++ b/charts/victoria-metrics-common/templates/_enterprise.tpl
@@ -66,6 +66,10 @@ Return license flag if necessary.
   {{- if $licenseKey -}}
     license: {{ $licenseKey }}
   {{- else if and $licenseSecretName $licenseSecretKey -}}
-    licenseFile: /etc/vm-license-key/{{ $licenseSecretKey }}
+    {{- $flagName := "licenseFile" -}}
+    {{- if eq .flagStyle "kebab" }}
+      {{- $flagName = "license-file" -}}
+    {{- end -}}
+    {{- $flagName }}: /etc/vm-license-key/{{ $licenseSecretKey }}
   {{- end -}}
 {{- end -}}

--- a/charts/victoria-metrics-common/templates/_image.tpl
+++ b/charts/victoria-metrics-common/templates/_image.tpl
@@ -4,19 +4,22 @@ Victoria Metrics Image
 {{- define "vm.image" -}}
   {{- $Chart := (.helm).Chart | default .Chart -}}
   {{- $Values := (.helm).Values | default .Values -}}
-  {{- $image := (tpl (printf "%s:%s" .app.image.repository (.app.image.tag | default $Chart.AppVersion)) .) -}}
-  {{- $license := $Values.license | default dict }}
-  {{- $variant := .app.image.variant }}
-  {{- if and (eq (include "vm.enterprise.disabled" .) "false") (empty .app.image.tag) -}}
-    {{- if $variant }}
-      {{- $variant = printf "enterprise-%s" $variant }}
-    {{- else }}
-      {{- $variant = "enterprise" }}
-    {{- end }}
+  {{- $tag := .app.image.tag -}}
+  {{- if empty $tag }}
+    {{- $tag = $Chart.AppVersion -}}
+    {{- $variant := .app.image.variant }}
+    {{- if eq (include "vm.enterprise.disabled" .) "false" -}}
+      {{- if $variant }}
+        {{- $variant = printf "enterprise-%s" $variant }}
+      {{- else }}
+        {{- $variant = "enterprise" }}
+      {{- end }}
+    {{- end -}}
+    {{- with $variant -}}
+      {{- $tag = (printf "%s-%s" $tag .) -}}
+    {{- end -}}
   {{- end -}}
-  {{- with $variant -}}
-    {{- $image = (printf "%s-%s" $image .) -}}
-  {{- end -}}
+  {{- $image := tpl (printf "%s:%s" .app.image.repository $tag) . -}}
   {{- with .app.image.registry | default (($Values.global).image).registry | default "" -}}
     {{- $image = (printf "%s/%s" . $image) -}}
   {{- end -}}


### PR DESCRIPTION
- Do not use image variant if custom image tag is set in `vm.image` template
- Support multiple license flag styles, which are different for vmanomaly and other services