### PR TITLE
[victoria-metrics-distributed] align vmauth-read with vmauth-write template

### DIFF
--- a/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
+++ b/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "victoria-metrics-distributed.vmauthQueryGlobalName" . }}
   namespace: {{ include "vm.namespace" . }}
   labels: {{ include "victoria-metrics-distributed.labels" . | nindent 4 }}
+  {{- with .Values.vmauthQueryGlobal.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end  }}
 spec:
   unauthorizedAccessConfig:
     - src_paths:
@@ -14,6 +18,11 @@ spec:
 {{- range $zone := $.Values.availabilityZones }}
 {{ printf "- http://vmauth-%s:8427/" ( $zone.vmauthCrossAZQuery.name | default ( printf "vmauth-read-proxy-%s" $zone.name )) | indent 8 }}
 {{- end }}
+{{- $spec := deepCopy .Values.vmauthQueryGlobal.spec }}
+{{- $spec := unset $spec "unauthorizedAccessConfig" }}
       load_balancing_policy: first_available
+{{- if $spec }}
+{{- toYaml $spec | nindent 2 }}
+{{- end }}
 {{- end }}
 


### PR DESCRIPTION
Hello,

Align the vmauth-read template with the vmauth-write template.

It fixes for me the issue #1510 

after the patch I have the appropriate vmauth-global-read-vmdistributed-vm-distributed definition : 
```
apiVersion: operator.victoriametrics.com/v1beta1
kind: VMAuth
metadata:
  annotations:
    meta.helm.sh/release-name: vmdistributed
    meta.helm.sh/release-namespace: vm
    operator.victoriametrics/last-applied-spec: '{"image":{"repository":"docker.io/victoriametrics/vmauth","tag":"v1.103.0","pullPolicy":"IfNotPresent"},"resources":{},"unauthorizedAccessConfig":[{"src_paths":["/select/.+"],"url_prefix":["http://vmauth-vmauth-read-proxy-aisle-a:8427/","http://vmauth-vmauth-read-proxy-aisle-b:8427/"],"load_balancing_policy":"first_available"}],"ip_filters":{}}'
  creationTimestamp: "2024-09-18T08:04:36Z"
  finalizers:
  - apps.victoriametrics.com/finalizer
  generation: 5
  labels:
    app.kubernetes.io/instance: vmdistributed
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: vm-distributed
    app.kubernetes.io/version: v1.103.0
    helm.sh/chart: victoria-metrics-distributed-0.3.0
  name: vmauth-global-read-vmdistributed-vm-distributed
  namespace: vm
  resourceVersion: "200899025"
  uid: 8e60ea28-b1e6-417e-80e4-d6c4d9d8d3d5
spec:
  image:
    pullPolicy: IfNotPresent
    repository: docker.io/victoriametrics/vmauth
    tag: v1.103.0
  unauthorizedAccessConfig:
  - load_balancing_policy: first_available
    src_paths:
    - /select/.+
    url_prefix:
    - http://vmauth-vmauth-read-proxy-aisle-a:8427/
    - http://vmauth-vmauth-read-proxy-aisle-b:8427/
status:
  updateStatus: operational
```

Hope this could help.

Olivier