### PR TITLE
sort targets of operator's cleanup job

### DIFF
--- a/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
+++ b/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
@@ -41,7 +41,7 @@ spec:
               memory: "56Mi"
           args:
             - delete
-            - {{ (keys .Values.admissionWebhooks.enabledCRDValidation) | join "," }}
+            - {{ (keys .Values.admissionWebhooks.enabledCRDValidation) | sortAlpha | join "," }}
             - --all
             - --ignore-not-found=true
       restartPolicy: OnFailure


### PR DESCRIPTION
The current implementation of the operator's cleanup job uses the Helm's `keys` function to find which custom resources should be deleted. However, the array returned by `keys` isn't in a predictable order, and may change each time a user runs a Helm command.

This commit fixes that issue by sorting the array returned by `keys` before using it. It utilizes a Helm's function `sortAlpha` for this purpose.