### PR TITLE
victoria-metrics-cluster: allow excluding vmstorage node from vminsert's storage node list

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Next release
 
 - Support extra storageNodes. Fail if no storageNodes set
-- Support enabling automatic discovery of vmstorage addresses using DNS SRV records in enterprise version.
+- Support enabling automatic discovery of vmstorage addresses using DNS SRV records in enterprise version
 - Added HPA with scaledown disabled by default
+- Allow excluding vmstorage nodes from vminsert. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1549)
 
 ## 0.14.0
 

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -1257,6 +1257,17 @@ timeoutSeconds: 5
 </td>
     </tr>
     <tr>
+      <td>vminsert.excludeStorageIDs</td>
+      <td>list</td>
+      <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
+<code class="language-yaml">[]
+</code>
+</pre>
+</td>
+      <td><p>IDs of vmstorage nodes to exclude from writing</p>
+</td>
+    </tr>
+    <tr>
       <td>vminsert.extraArgs</td>
       <td>object</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
@@ -2374,7 +2385,7 @@ loggerFormat: json
       <td>vmselect.name</td>
       <td>string</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="">
-<code class="language-yaml">vmselect
+<code class="language-yaml">""
 </code>
 </pre>
 </td>

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -109,9 +109,11 @@ app: {{ $Values.vmauth.name | default "vmauth" }}
     {{- else }}
       {{- $port := "8400" }}
       {{- range $i := until ($storage.replicaCount | int) -}}
-        {{- $_ := set $ "appIdx" $i }}
-        {{- $storageNode := include "vm.fqdn" $ -}}
-        {{- $storageNodes = append $storageNodes (printf "%s:%s" $storageNode $port) -}}
+        {{- if not (has (float64 $i) $app.excludeStorageIDs) -}}
+          {{- $_ := set $ "appIdx" $i }}
+          {{- $storageNode := include "vm.fqdn" $ -}}
+          {{- $storageNodes = append $storageNodes (printf "%s:%s" $storageNode $port) -}}
+        {{- end -}}
       {{- end -}}
       {{- $_ := unset $ "appIdx" }}
     {{- end }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -342,6 +342,8 @@ vmselect:
 vminsert:
   # -- Enable deployment of vminsert component. Deployment is used
   enabled: true
+  # -- IDs of vmstorage nodes to exclude from writing
+  excludeStorageIDs: []
   # -- VMInsert name
   name: ""
   # -- VMInsert strategy


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/helm-charts/issues/1549
Added `vminsert.excludeStorageIDs` list param, which allows to specify storage nodes, that will be excluded from vminsert storage nodes list