### PR TITLE
k8s-stack: generate vm components tag from app version by default

### DIFF
--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -290,50 +290,6 @@ name: ""
 </td>
     </tr>
     <tr>
-      <td>rbac.annotations</td>
-      <td>object</td>
-      <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">{}
-</code>
-</pre>
-</td>
-      <td><p>Role/RoleBinding annotations</p>
-</td>
-    </tr>
-    <tr>
-      <td>rbac.create</td>
-      <td>bool</td>
-      <td><pre class="helm-vars-default-value" language-yaml" lang="">
-<code class="language-yaml">true
-</code>
-</pre>
-</td>
-      <td><p>Enables Role/RoleBinding creation</p>
-</td>
-    </tr>
-    <tr>
-      <td>rbac.extraLabels</td>
-      <td>object</td>
-      <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">{}
-</code>
-</pre>
-</td>
-      <td><p>Role/RoleBinding labels</p>
-</td>
-    </tr>
-    <tr>
-      <td>rbac.namespaced</td>
-      <td>bool</td>
-      <td><pre class="helm-vars-default-value" language-yaml" lang="">
-<code class="language-yaml">false
-</code>
-</pre>
-</td>
-      <td><p>If true and <code>rbac.enabled</code>, will deploy a Role/RoleBinding instead of a ClusterRole/ClusterRoleBinding</p>
-</td>
-    </tr>
-    <tr>
       <td>serviceAccount.annotations</td>
       <td>object</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -23,19 +23,6 @@ printNotes: true
 # use SRV discovery for storageNode and selectNode flags for enterprise version
 autoDiscovery: false
 
-rbac:
-  # -- Enables Role/RoleBinding creation
-  create: true
-
-  # -- If true and `rbac.enabled`, will deploy a Role/RoleBinding instead of a ClusterRole/ClusterRoleBinding
-  namespaced: false
-
-  # -- Role/RoleBinding labels
-  extraLabels: {}
-  
-  # -- Role/RoleBinding annotations
-  annotations: {}
-
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Generate VM components tag version from chart app name by default
 
 ## 0.27.0
 

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -2164,8 +2164,6 @@ tls: []
 extraArgs:
     promscrape.dropOriginalLabels: "true"
     promscrape.streamParse: "true"
-image:
-    tag: v1.104.0
 port: "8429"
 scrapeInterval: 20s
 selectAllByDefault: true
@@ -2257,8 +2255,6 @@ tls: []
 externalLabels: {}
 extraArgs:
     http.pathPrefix: /
-image:
-    tag: v1.104.0
 port: "8080"
 selectAllByDefault: true
 </code>
@@ -2639,16 +2635,12 @@ port: "8427"
 retentionPeriod: "1"
 vminsert:
     extraArgs: {}
-    image:
-        tag: v1.104.0-cluster
     port: "8480"
     replicaCount: 2
     resources: {}
 vmselect:
     cacheMountPath: /select-cache
     extraArgs: {}
-    image:
-        tag: v1.104.0-cluster
     port: "8481"
     replicaCount: 2
     resources: {}
@@ -2659,8 +2651,6 @@ vmselect:
                     requests:
                         storage: 2Gi
 vmstorage:
-    image:
-        tag: v1.104.0-cluster
     replicaCount: 2
     resources: {}
     storage:
@@ -2813,8 +2803,6 @@ vmstorage:
       <td>object</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
 <code class="language-yaml">extraArgs: {}
-image:
-    tag: v1.104.0
 port: "8429"
 replicaCount: 1
 retentionPeriod: "1"

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -241,6 +241,7 @@ If release name contains chart name it will be used as a full name.
 {{- /* VMAlert spec */ -}}
 {{- define "vm.alert.spec" -}}
   {{- $Values := (.helm).Values | default .Values }}
+  {{- $Chart := (.helm).Chart | default .Chart }}
   {{- $extraArgs := dict "remoteWrite.disablePathAppend" "true" -}}
   {{- if $Values.vmalert.templateFiles -}}
     {{- $ruleTmpl := (printf "/etc/vm/configs/%s-vmalert-extra-tpl/*.tmpl" (include "victoria-metrics-k8s-stack.fullname" .)) -}}
@@ -248,7 +249,7 @@ If release name contains chart name it will be used as a full name.
   {{- end -}}
   {{- $vmAlertRemotes := (include "vm.alert.remotes" . | fromYaml) -}}
   {{- $vmAlertTemplates := (include "vm.alert.templates" . | fromYaml) -}}
-  {{- $spec := dict "extraArgs" $extraArgs -}}
+  {{- $spec := dict "extraArgs" $extraArgs "image" (dict "tag" $Chart.AppVersion) -}}
   {{- with (include "vm.license.global" .) -}}
     {{- $_ := set $spec "license" (fromYaml .) -}}
   {{- end -}}
@@ -276,10 +277,12 @@ If release name contains chart name it will be used as a full name.
 {{- /* VMAgent spec */ -}}
 {{- define "vm.agent.spec" -}}
   {{- $Values := (.helm).Values | default .Values }}
+  {{- $Chart := (.helm).Chart | default .Chart }}
   {{- $spec := (include "vm.agent.remote.write" . | fromYaml) -}}
   {{- with (include "vm.license.global" .) -}}
     {{- $_ := set $spec "license" (fromYaml .) -}}
   {{- end -}}
+  {{- $_ := set $spec "image" (dict "tag" $Chart.AppVersion) -}}
   {{- tpl (deepCopy $Values.vmagent.spec | mergeOverwrite $spec | toYaml) . -}}
 {{- end }}
 
@@ -344,12 +347,13 @@ If release name contains chart name it will be used as a full name.
 {{- /* Single spec */ -}}
 {{- define "vm.single.spec" -}}
   {{- $Values := (.helm).Values | default .Values }}
+  {{- $Chart := (.helm).Chart | default .Chart }}
   {{- $extraArgs := default dict -}}
   {{- if $Values.vmalert.enabled }}
     {{- $ctx := dict "helm" . "appKey" "vmalert" -}}
     {{- $_ := set $extraArgs "vmalert.proxyURL" (include "vm.url" $ctx) -}}
   {{- end -}}
-  {{- $spec := dict "extraArgs" $extraArgs -}}
+  {{- $spec := dict "extraArgs" $extraArgs "image" (dict "tag" $Chart.AppVersion) -}}
   {{- with (include "vm.license.global" .) -}}
     {{- $_ := set $spec "license" (fromYaml .) -}}
   {{- end -}}
@@ -359,18 +363,22 @@ If release name contains chart name it will be used as a full name.
 {{- /* Cluster spec */ -}}
 {{- define "vm.select.spec" -}}
   {{- $Values := (.helm).Values | default .Values }}
+  {{- $Chart := (.helm).Chart | default .Chart }}
   {{- $extraArgs := default dict -}}
   {{- if $Values.vmalert.enabled -}}
     {{- $ctx := dict "helm" . "appKey" "vmalert" -}}
     {{- $_ := set $extraArgs "vmalert.proxyURL" (include "vm.url" $ctx) -}}
   {{- end -}}
-  {{- $spec := dict "extraArgs" $extraArgs -}}
+  {{- $spec := dict "extraArgs" $extraArgs "image" (dict "tag" (printf "%s-cluster" $Chart.AppVersion)) -}}
   {{- toYaml $spec -}}
 {{- end -}}
 
 {{- define "vm.cluster.spec" -}}
   {{- $Values := (.helm).Values | default .Values }}
+  {{- $Chart := (.helm).Chart | default .Chart }}
   {{- $spec := (include "vm.select.spec" . | fromYaml) -}}
+  {{- $_ := set $spec.vminsert.image.tag (printf "%s-cluster" $Chart.AppVersion) -}}
+  {{- $_ := set $spec.vmstorage.image.tag (printf "%s-cluster" $Chart.AppVersion) -}}
   {{- $clusterSpec := (deepCopy $Values.vmcluster.spec) -}}
   {{- with (include "vm.license.global" .) -}}
     {{- $_ := set $clusterSpec "license" (fromYaml .) -}}

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -377,8 +377,8 @@ If release name contains chart name it will be used as a full name.
   {{- $Values := (.helm).Values | default .Values }}
   {{- $Chart := (.helm).Chart | default .Chart }}
   {{- $spec := (include "vm.select.spec" . | fromYaml) -}}
-  {{- $_ := set $spec.vminsert "image" (dict "tag" (printf "%s-cluster" $Chart.AppVersion)) -}}
-  {{- $_ := set $spec.vmstorage "image" (dict "tag" (printf "%s-cluster" $Chart.AppVersion)) -}}
+  {{- $_ := set $spec "vminsert" (dict "image" (dict "tag" (printf "%s-cluster" $Chart.AppVersion))) -}}
+  {{- $_ := set $spec "vmstorage" (dict "image" (dict "tag" (printf "%s-cluster" $Chart.AppVersion))) -}}
   {{- $clusterSpec := (deepCopy $Values.vmcluster.spec) -}}
   {{- with (include "vm.license.global" .) -}}
     {{- $_ := set $clusterSpec "license" (fromYaml .) -}}

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -377,8 +377,8 @@ If release name contains chart name it will be used as a full name.
   {{- $Values := (.helm).Values | default .Values }}
   {{- $Chart := (.helm).Chart | default .Chart }}
   {{- $spec := (include "vm.select.spec" . | fromYaml) -}}
-  {{- $_ := set $spec.vminsert.image.tag (printf "%s-cluster" $Chart.AppVersion) -}}
-  {{- $_ := set $spec.vmstorage.image.tag (printf "%s-cluster" $Chart.AppVersion) -}}
+  {{- $_ := set $spec.vminsert "image" (dict "tag" (printf "%s-cluster" $Chart.AppVersion)) -}}
+  {{- $_ := set $spec.vmstorage "image" (dict "tag" (printf "%s-cluster" $Chart.AppVersion)) -}}
   {{- $clusterSpec := (deepCopy $Values.vmcluster.spec) -}}
   {{- with (include "vm.license.global" .) -}}
     {{- $_ := set $clusterSpec "license" (fromYaml .) -}}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -261,8 +261,6 @@ vmsingle:
   # -- Full spec for VMSingle CRD. Allowed values describe [here](https://docs.victoriametrics.com/operator/api#vmsinglespec)
   spec:
     port: "8429"
-    image:
-      tag: v1.104.0
     # -- Data retention period. Possible units character: h(ours), d(ays), w(eeks), y(ears), if no unit character specified - month. The minimum retention period is 24h. See these [docs](https://docs.victoriametrics.com/single-server-victoriametrics/#retention)
     retentionPeriod: "1"
     replicaCount: 1
@@ -320,8 +318,6 @@ vmcluster:
     retentionPeriod: "1"
     replicationFactor: 2
     vmstorage:
-      image:
-        tag: v1.104.0-cluster
       replicaCount: 2
       storageDataPath: "/vm-data"
       storage:
@@ -337,8 +333,6 @@ vmcluster:
         #   memory: 1500Mi
     vmselect:
       port: "8481"
-      image:
-        tag: v1.104.0-cluster
       replicaCount: 2
       cacheMountPath: "/select-cache"
       extraArgs: {}
@@ -358,8 +352,6 @@ vmcluster:
         #   memory: "500Mi"
     vminsert:
       port: "8480"
-      image:
-        tag: v1.104.0-cluster
       replicaCount: 2
       extraArgs: {}
       resources:
@@ -667,8 +659,6 @@ vmalert:
   spec:
     port: "8080"
     selectAllByDefault: true
-    image:
-      tag: v1.104.0
     evaluationInterval: 15s
     extraArgs:
       http.pathPrefix: "/"
@@ -748,8 +738,6 @@ vmagent:
   spec:
     port: "8429"
     selectAllByDefault: true
-    image:
-      tag: v1.104.0
     scrapeInterval: 20s
     externalLabels: {}
       # For multi-cluster setups it is useful to use "cluster" label to identify the metrics source.


### PR DESCRIPTION
- generate tag name from chart appversion
- removed unused rbac values from cluster chart. fixes https://github.com/VictoriaMetrics/helm-charts/issues/1554