### PR TITLE
k8s-stack: alertmanager upgrade 0.27.0 and other minor bugfixes and improvements

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - Generate VM components tag version from chart app name by default
+- Upgraded default Alertmanager tag 0.25.0 -> 0.27.0
 
 ## 0.27.0
 

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -493,7 +493,7 @@ tls: []
 <code class="language-yaml">configSecret: ""
 externalURL: ""
 image:
-    tag: v0.25.0
+    tag: v0.27.0
 port: "9093"
 routePrefix: /
 selectAllByDefault: true

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -494,7 +494,7 @@ alertmanager:
     port: "9093"
     selectAllByDefault: true
     image:
-      tag: v0.25.0
+      tag: v0.27.0
     externalURL: ""
     routePrefix: /
 

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
 - upgraded common chart dependency
+- added configurable cleanup hook resources. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1571)
+- added ability to configure `terminationGracePeriodSeconds` and `lifecycle`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1563) for details
 
 ## 0.35.2
 

--- a/charts/victoria-metrics-operator/Chart.yaml
+++ b/charts/victoria-metrics-operator/Chart.yaml
@@ -7,7 +7,7 @@ home: https://github.com/VictoriaMetrics/operator
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
   - https://github.com/VictoriaMetrics/operator
-version: 0.35.2
+version: 0.35.3
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
 kubeVersion: '>=1.25.0-0'
 keywords:

--- a/charts/victoria-metrics-operator/README.md
+++ b/charts/victoria-metrics-operator/README.md
@@ -335,6 +335,22 @@ tag: ""
 </td>
     </tr>
     <tr>
+      <td>crd.cleanup.resources</td>
+      <td>object</td>
+      <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
+<code class="language-yaml">limits:
+    cpu: 500m
+    memory: 256Mi
+requests:
+    cpu: 100m
+    memory: 56Mi
+</code>
+</pre>
+</td>
+      <td><p>Cleanup hook resources</p>
+</td>
+    </tr>
+    <tr>
       <td>crd.create</td>
       <td>bool</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="">
@@ -567,6 +583,17 @@ variant: ""
 </pre>
 </td>
       <td><p>Secret to pull images</p>
+</td>
+    </tr>
+    <tr>
+      <td>lifecycle</td>
+      <td>object</td>
+      <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
+<code class="language-yaml">{}
+</code>
+</pre>
+</td>
+      <td><p>Operator lifecycle. See <a href="https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/" target="_blank">this article</a> for details.</p>
 </td>
     </tr>
     <tr>
@@ -979,6 +1006,17 @@ tlsConfig: {}
 </pre>
 </td>
       <td><p>Configures monitoring with serviceScrape. VMServiceScrape must be pre-installed</p>
+</td>
+    </tr>
+    <tr>
+      <td>terminationGracePeriodSeconds</td>
+      <td>int</td>
+      <td><pre class="helm-vars-default-value" language-yaml" lang="">
+<code class="language-yaml">30
+</code>
+</pre>
+</td>
+      <td><p>Graceful pod termination timeout. See <a href="https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution" target="_blank">this article</a> for details.</p>
 </td>
     </tr>
     <tr>

--- a/charts/victoria-metrics-operator/templates/deployment.yaml
+++ b/charts/victoria-metrics-operator/templates/deployment.yaml
@@ -128,6 +128,10 @@ spec:
       {{- with .Values.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.lifecycle }}
+      lifecycle: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
+++ b/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
@@ -9,6 +9,8 @@
 {{- if empty ($app.image).tag }}
   {{- $tag := (printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor) | replace "+" "" -}}
   {{- $_ := set $app.image "tag" $tag }}
+{{- else if not (kindIs "string" ($app.image).tag) }}
+  {{- fail "`crd.cleanup.image.tag` is not string, most probably you need to enquote provided value" -}}
 {{- end }}
 ---
 apiVersion: batch/v1

--- a/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
+++ b/charts/victoria-metrics-operator/templates/uninstall_hook.yaml
@@ -32,13 +32,7 @@ spec:
         - name: kubectl
           image: {{ include "vm.image" (dict "helm" . "app" $app) }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
-          resources:
-            limits:
-              cpu: "500m"
-              memory: "256Mi"
-            requests:
-              cpu: "100m"
-              memory: "56Mi"
+          resources: {{ toYaml $app.resources | nindent 12 }}
           args:
             - delete
             - {{ (keys .Values.admissionWebhooks.enabledCRDValidation) | sortAlpha | join "," }}

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -40,6 +40,14 @@ crd:
       # use image tag that matches k8s API version by default
       tag: ""
       pullPolicy: IfNotPresent
+    # -- Cleanup hook resources
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
+      requests:
+        cpu: "100m"
+        memory: "56Mi"
 
 # -- Number of operator replicas
 replicaCount: 1
@@ -141,6 +149,12 @@ podDisruptionBudget:
   # minAvailable: 1
   # maxUnavailable: 1
   labels: {}
+
+# -- Graceful pod termination timeout. See [this article](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution) for details.
+terminationGracePeriodSeconds: 30
+
+# -- Operator lifecycle. See [this article](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/) for details.
+lifecycle: {}
 
 # -- Resource object
 resources:


### PR DESCRIPTION
- alertmanaget default image upgrade. fixes https://github.com/VictoriaMetrics/helm-charts/issues/1569
- added terminationGracePeriodSeconds and licecycle. fixes https://github.com/VictoriaMetrics/helm-charts/issues/1563
- added configurable resources for operator. fixes https://github.com/VictoriaMetrics/helm-charts/issues/1571
- fail if operator cleanup image tag is not string. fixes https://github.com/VictoriaMetrics/helm-charts/issues/1566