### PR TITLE
common: use <appSection>.fullnameOverride as alternative source for resource name prefix

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Allow extract name prefix from app level fullnameOverride property
 
 ## 0.0.15
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.15
+version: 0.0.16
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_helpers.tpl
+++ b/charts/victoria-metrics-common/templates/_helpers.tpl
@@ -47,6 +47,8 @@ If release name contains chart name it will be used as a full name.
       {{- end -}}
       {{- if and (kindIs "map" $values) $values.name -}}
         {{- $fullname = $values.name -}}
+      {{- else if and (kindIs "map" $values) $values.fullnameOverride -}}
+        {{- $fullname = $values.fullnameOverride -}}
       {{- else if and (kindIs "map" $global) $global.name -}}
         {{- $fullname = $global.name -}}
       {{- end -}}

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Fixed templates context issues
 
 ## 0.27.4
 

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -198,9 +198,9 @@ If release name contains chart name it will be used as a full name.
     {{- $_ := set $remotes "notifierConfigRef" $notifierConfigRef -}}
   {{- else if $Values.alertmanager.enabled -}}
     {{- $notifiers := default list -}}
-    {{- $appSecure := (not (empty (((.Values.alertmanager).spec).webConfig).tls_server_config)) -}}
-    {{- $ctx := dict "helm" . "appKey" "alertmanager" "appSecure" $appSecure "appRoute" ((.Values.alertmanager).spec).routePrefix -}}
-    {{- $alertManagerReplicas := (.Values.alertmanager.spec.replicaCount | default 1 | int) -}}
+    {{- $appSecure := (not (empty ((($Values.alertmanager).spec).webConfig).tls_server_config)) -}}
+    {{- $ctx := dict "helm" . "appKey" "alertmanager" "appSecure" $appSecure "appRoute" (($Values.alertmanager).spec).routePrefix -}}
+    {{- $alertManagerReplicas := ($Values.alertmanager.spec.replicaCount | default 1 | int) -}}
     {{- range until $alertManagerReplicas -}}
       {{- $_ := set $ctx "appIdx" . -}}
       {{- $notifiers = append $notifiers (dict "url" (include "vm.url" $ctx)) -}}
@@ -212,7 +212,7 @@ If release name contains chart name it will be used as a full name.
 
 {{- /* VMAlert templates */ -}}
 {{- define "vm.alert.templates" -}}
-  {{- $Values := (.helm).Values | default .Values}}
+  {{- $Values := (.helm).Values | default .Values -}}
   {{- $cms :=  ($Values.vmalert.spec.configMaps | default list) -}}
   {{- if $Values.vmalert.templateFiles -}}
     {{- $fullname := (include "victoria-metrics-k8s-stack.fullname" .) -}}
@@ -223,7 +223,8 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{- define "vm.license.global" -}}
-  {{- $license := (deepCopy (.Values.global).license) | default dict -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $license := (deepCopy ($Values.global).license) | default dict -}}
   {{- if $license.key -}}
     {{- if hasKey $license "keyRef" -}}
       {{- $_ := unset $license "keyRef" -}}
@@ -253,7 +254,7 @@ If release name contains chart name it will be used as a full name.
   {{- with (include "vm.license.global" .) -}}
     {{- $_ := set $spec "license" (fromYaml .) -}}
   {{- end -}}
-  {{- with concat ($vmAlertRemotes.notifiers | default list) (.Values.vmalert.spec.notifiers | default list) }}
+  {{- with concat ($vmAlertRemotes.notifiers | default list) ($Values.vmalert.spec.notifiers | default list) }}
     {{- $_ := set $vmAlertRemotes "notifiers" . }}
   {{- end }}
   {{- $spec := deepCopy (omit $Values.vmalert.spec "notifiers") | mergeOverwrite $vmAlertRemotes | mergeOverwrite $vmAlertTemplates | mergeOverwrite $spec }}
@@ -337,7 +338,7 @@ If release name contains chart name it will be used as a full name.
     {{- $templates = append $templates (dict "name" $configMap "key" "monzo.tmpl") -}}
   {{- end -}}
   {{- $configMap := (printf "%s-alertmanager-extra-tpl" $fullname) -}}
-  {{- range $key, $value := (.Values.alertmanager.templateFiles | default dict) -}}
+  {{- range $key, $value := ($Values.alertmanager.templateFiles | default dict) -}}
     {{- $templates = append $templates (dict "name" $configMap "key" $key) -}}
   {{- end -}}
   {{- $_ := set $spec "templates" $templates -}}


### PR DESCRIPTION
currenly default name prefix override can be extracted from:
- global.fullnameOverride
- global.<Chart.Name>.fullnameOverride:
- fullnameOverride
- <appSection>.name

Added `<appSection>.fullnameOverride` additionally to fix backward compatibility issue for cluster chart