### PR TITLE
vlogs: use service url for single replica and deployment

### DIFF
--- a/charts/victoria-logs-single/templates/extra-outputs.yaml
+++ b/charts/victoria-logs-single/templates/extra-outputs.yaml
@@ -9,9 +9,12 @@ metadata:
   namespace: {{ include "vm.namespace" . }}
   labels: {{- include "vm.labels" $ctx | nindent 4 }}
 data:
-  output_vlogs.conf: |
-    {{- range $i := until (int .Values.server.replicaCount) }}
+  output_vl.conf: |
+    {{- $replicaCount := ternary (int .Values.server.replicaCount) 1 .Values.server.statefulSet.enabled }}
+    {{- range $i := until $replicaCount }}
+    {{- if gt $replicaCount 1 }}
     {{- $_ := set $ctx "appIdx" $i }}
+    {{- end }}
     [OUTPUT]
       Name             http
       Match            kube.*
@@ -26,5 +29,5 @@ data:
       header           VL-Msg-Field log
       header           VL-Time-Field date
       header           VL-Stream-Fields stream,kubernetes_pod_name,kubernetes_container_name,kubernetes_namespace_name
-    {{- end }}
+    {{ end }}
 {{- end }}

--- a/charts/victoria-logs-single/templates/extra-outputs.yaml
+++ b/charts/victoria-logs-single/templates/extra-outputs.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: victorialogs-outputs
+  name: vl-outputs
   namespace: {{ include "vm.namespace" . }}
   labels: {{- include "vm.labels" $ctx | nindent 4 }}
 data:

--- a/charts/victoria-logs-single/templates/server-deployment.yaml
+++ b/charts/victoria-logs-single/templates/server-deployment.yaml
@@ -2,6 +2,9 @@
 {{- $ctx := dict "helm" . "appKey" "server" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- if and $app.enabled (not $app.statefulSet.enabled) -}}
+{{- if gt (int $app.replicaCount) 1 }}
+  {{- fail "VictoriaLogs HA mode is not supported for Deployment. Consider switching to statefulset instead using `server.statefulSet.enabled: true`" -}}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -296,6 +296,23 @@ server:
 fluent-bit:
   # -- Enable deployment of fluent-bit
   enabled: false
+  args:
+    - --workdir=/fluent-bit/etc
+    - --config=/fluent-bit/etc/conf/fluent-bit.conf
+    - --enable-hot-reload
+
+  extraContainers: |
+    - name: reloader
+      image: {{ include "fluent-bit.image" .Values.hotReload.image }}
+      args:
+        - {{ printf "-webhook-url=http://localhost:%s/api/v2/reload" (toString .Values.metricsPort) }}
+        - -volume-dir=/watch/config
+        - -volume-dir=/watch/outputs
+      volumeMounts:
+        - name: config
+          mountPath: /watch/config
+        - name: vl-outputs
+          mountPath: /watch/outputs
 
   daemonSetVolumes:
     - name: varlog
@@ -304,9 +321,9 @@ fluent-bit:
     - name: varlibdockercontainers
       hostPath:
         path: /var/lib/docker/containers
-    - name: victorialogs-outputs
+    - name: vl-outputs
       configMap:
-        name: victorialogs-outputs
+        name: vl-outputs
 
   daemonSetVolumeMounts:
     - name: varlog
@@ -314,7 +331,7 @@ fluent-bit:
     - name: varlibdockercontainers
       mountPath: /var/lib/docker/containers
       readOnly: true
-    - name: victorialogs-outputs
+    - name: vl-outputs
       mountPath: /fluent-bit/etc/conf/vl
 
   resources: {}


### PR DESCRIPTION
use k8s service url while using deployments for vlogs or replica count == 1
fixed fluent-bit hot-reload when victorialogs relicacount changes
added temporary workaround till https://github.com/fluent/helm-charts/pull/561 is merged