### PR TITLE
fix(vmagent): k8s secrets can not contain underscores

### DIFF
--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -121,7 +121,7 @@ env:
   # - name: VM_remoteWrite_basicAuth_password
   #   valueFrom:
   #     secretKeyRef:
-  #       name: auth_secret
+  #       name: auth-secret
   #       key: password
 
 # -- Specify alternative source for env variables


### PR DESCRIPTION
This simple PR fixes the defaults provided in the values to comply with Kubernetes standards for secrets names (RFC 1123). In K8S, secrets can't contain underscores (_). I found my deployment failing with the following error:

```
error: failed to create secret Secret "auth_secret" is invalid: metadata.name: Invalid value: "auth_secret": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```