### PR TITLE
operator's crd: fix typo in crd field description

### DIFF
--- a/charts/victoria-metrics-operator/charts/crds/crds/crd.yaml
+++ b/charts/victoria-metrics-operator/charts/crds/crds/crd.yaml
@@ -10213,8 +10213,8 @@ spec:
                   type: string
                 type: array
               configNamespaceSelector:
-                description: |2-
-                   ConfigNamespaceSelector defines namespace selector for VMAlertmanagerConfig.
+                description: |-
+                  ConfigNamespaceSelector defines namespace selector for VMAlertmanagerConfig.
                   Works in combination with Selector.
                   NamespaceSelector nil - only objects at VMAlertmanager namespace.
                   Selector nil - only objects at NamespaceSelector namespaces.


### PR DESCRIPTION
solve the issue that prevent correct upgrade or install operator's crd