### PR TITLE
charts/k8s-stack: fix templating of the labels for VMAlertmanager

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -269,7 +269,7 @@
 ![AppVersion: v1.102.1](https://img.shields.io/static/v1?label=AppVersion&message=v1.102.1&color=success&logo=)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-- TODO
+- Fix templating of labels for `VMAlertmanager` CRD.
 
 ## 0.25.4
 

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.28.0
+version: 0.28.1
 appVersion: v1.106.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/custom-templates.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/custom-templates.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 metadata:
   name: {{ $fullname }}-extra-tpl
   namespace: {{ $ns }}
-  labels: {{ include "vm.labels" $ctx | indent 4 }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
 data:
 {{- range $file, $template := $app.templateFiles }}
   {{ $file }}: |-


### PR DESCRIPTION
`indent` does not add a new line char, which results into templating labels right after `labels`:
```
labels: app.kubernetes...
```
`nindent` adds a new line so labels are properly templated starting from the next line.