### PR TITLE
common: added flag to disable name truncation

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Added ability to disable name truncation
 
 ## 0.0.19
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.19
+version: 0.0.20
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_helpers.tpl
+++ b/charts/victoria-metrics-common/templates/_helpers.tpl
@@ -20,7 +20,12 @@
   {{- include "vm.validate.args" . -}}
   {{- $Chart := (.helm).Chart | default .Chart -}}
   {{- $Values := (.helm).Values | default .Values -}}
-  {{- $Values.nameOverride | default ($Values.global).nameOverride | default $Chart.Name | trunc 63 | trimSuffix "-" }}
+  {{- $nameOverride := $Values.nameOverride | default ($Values.global).nameOverride | default $Chart.Name -}}
+  {{- if or ($Values.global).disableNameTruncation $Values.disableNameTruncation -}}
+    {{- $nameOverride -}}
+  {{- else -}}
+    {{- $nameOverride | trunc 63 | trimSuffix "-" -}}
+  {{- end -}}
 {{- end -}}
 
 {{- /*
@@ -78,7 +83,11 @@ If release name contains chart name it will be used as a full name.
   {{- with (ternary .suffix .oldSuffix $appendDefault) -}}
     {{- $fullname = printf "%s-%s" $fullname . -}}
   {{- end -}}
-  {{- $fullname | trunc 63 | trimSuffix "-" -}}
+  {{- if or ($Values.global).disableNameTruncation $Values.disableNameTruncation -}}
+    {{- $fullname -}}
+  {{- else -}}
+    {{- $fullname | trunc 63 | trimSuffix "-" -}}
+  {{- end -}}
 {{- end }}
 
 {{- define "vm.managed.fullname" -}}
@@ -124,7 +133,12 @@ If release name contains chart name it will be used as a full name.
 {{- define "vm.chart" -}}
   {{- include "vm.validate.args" . -}}
   {{- $Chart := (.helm).Chart | default .Chart -}}
-  {{- printf "%s-%s" $Chart.Name $Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  {{- $chart := printf "%s-%s" $Chart.Name $Chart.Version | replace "+" "_" -}}
+  {{- if or ($Values.global).disableNameTruncation $Values.disableNameTruncation -}}
+    {{- $chart -}}
+  {{- else -}}
+    {{- $chart | trunc 63 | trimSuffix "-" -}}
+  {{- end }}
 {{- end }}
 
 {{- /* Create the name of the service account to use */ -}}
@@ -172,7 +186,12 @@ If release name contains chart name it will be used as a full name.
   {{- include "vm.validate.args" . -}}
   {{- $Release := (.helm).Release | default .Release -}}
   {{- $Values := (.helm).Values | default .Values -}}
-  {{- default $Release.Name $Values.argocdReleaseOverride | trunc 63 | trimSuffix "-" -}}
+  {{- $release := default $Release.Name $Values.argocdReleaseOverride -}}
+  {{- if or ($Values.global).disableNameTruncation $Values.disableNameTruncation -}}
+    {{- $release -}}
+  {{- else -}}
+    {{- $release | trunc 63 | trimSuffix "-" -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "vm.app.name" -}}


### PR DESCRIPTION
made name truncation optional. can be useful for fluxcd [variable substitution](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution)