### PR TITLE
set default dns domain for all charts

### DIFF
--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Next release
 
-- Added ability to override PVC name for Deployment
-- Updated dashboards
+- added ability to override PVC name for Deployment
+- updated dashboards
+- set default DNS domain to `cluster.local.`
 
 ## 0.7.1
 

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - set default DNS domain to `cluster.local.`
+- made message, time, stream fields configurable. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1695)
 
 ## 0.7.2
 

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.40.0
 description: Victoria Logs Single version - high-performance, cost-effective and scalable logs storage
 name: victoria-logs-single
-version: 0.7.2
+version: 0.7.3
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/templates/extra-outputs.yaml
+++ b/charts/victoria-logs-single/templates/extra-outputs.yaml
@@ -25,10 +25,10 @@ data:
       uri              /insert/jsonline
       format           json_lines
       json_date_format iso8601
-      header           AccountID 0
-      header           ProjectID 0
-      header           VL-Msg-Field msg
-      header           VL-Time-Field date
-      header           VL-Stream-Fields stream,kubernetes_pod_name,kubernetes_container_name,kubernetes_namespace_name
+      header           AccountID {{ $.Values.config.accountID }}
+      header           ProjectID {{ $.Values.config.projectID }}
+      header           VL-Msg-Field {{ join "," $.Values.config.msgFields }}
+      header           VL-Time-Field {{ join "," $.Values.config.timeFields }}
+      header           VL-Stream-Fields {{ join "," $.Values.config.streamFields }}
     {{ end }}
 {{- end }}

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -300,10 +300,25 @@ server:
     # -- Service Monitor metricRelabelings
     metricRelabelings: []
 
+config:
+  streamFields:
+    - stream
+    - kubernetes_pod_name
+    - kubernetes_container_name
+    - kubernetes_namespace_name
+  accountID: 0
+  projectID: 0
+  msgFields:
+    - msg
+    - _msg
+    - message
+  timeFields:
+    - date
+
 # -- Values for [fluent-bit helm chart](https://fluent.github.io/helm-charts/)
 fluent-bit:
   # -- Enable deployment of fluent-bit
-  enabled: false
+  enabled: true
   args:
     - --workdir=/fluent-bit/etc
     - --config=/fluent-bit/etc/conf/fluent-bit.conf

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -13,6 +13,9 @@ global:
       adaptSecurityContext: "auto"
   # -- Global name override
   nameOverride: ""
+  cluster:
+    # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
+    dnsDomain: cluster.local.
 # -- Print chart notes
 printNotes: true
 

--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- Fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- set default DNS domain to `cluster.local.`
 
 ## 0.14.5
 

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -11,6 +11,9 @@ global:
   compatibility:
     openshift:
       adaptSecurityContext: "auto"
+  cluster:
+    # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
+    dnsDomain: cluster.local.
 
 # -- Replica count     
 replicaCount: 1

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- Fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- set default DNS domain to `cluster.local.`
 
 ## 0.12.4
 

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -11,6 +11,9 @@ global:
   compatibility:
     openshift:
       adaptSecurityContext: "auto"
+  cluster:
+    # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
+    dnsDomain: cluster.local.
 
 serviceAccount:
   # -- Specifies whether a service account should be created

--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - use common templates
+- set default DNS domain to `cluster.local.`
 
 ## 1.6.3
 

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -11,6 +11,9 @@ global:
   compatibility:
     openshift:
       adaptSecurityContext: "auto"
+  cluster:
+    # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
+    dnsDomain: cluster.local.
       
 image:
   # -- Victoria Metrics anomaly Docker registry

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- Fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- set default DNS domain to `cluster.local.`
 
 ## 0.7.4
 

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -11,6 +11,9 @@ global:
   compatibility:
     openshift:
       adaptSecurityContext: "auto"
+  cluster:
+    # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
+    dnsDomain: cluster.local.
       
 # -- Number of replicas of vmauth
 replicaCount: 1

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- set default DNS domain to `cluster.local.`
 
 ## 0.14.8
 

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -13,7 +13,7 @@ global:
       adaptSecurityContext: "auto"
   # -- k8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
   cluster:
-    dnsDomain: cluster.local
+    dnsDomain: cluster.local.
 
 # -- Print information after deployment
 printNotes: true

--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Fixed boolean args rendering
 
 ## 0.0.19
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.19
+version: 0.0.20
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_pod.tpl
+++ b/charts/victoria-metrics-common/templates/_pod.tpl
@@ -86,7 +86,7 @@ Net probe port
 {{- end -}}
 
 {{- define "vm.arg" -}}
-  {{- if empty .value }}
+  {{- if and (empty .value) (not (kindIs "bool" .value)) }}
     {{- .key -}}
   {{- else if and (kindIs "bool" .value) .value -}}
     -{{ ternary "" "-" (eq (len .key) 1) }}{{ .key }}

--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `availabilityZones[*].vmauthIngest` was moved to `availabilityZones[*].write.vmauth`
 - `availabilityZones[*].vmauthQueryPerZone` was moved to `availabilityZones[*].read.perZone.vmauth`
 - `availabilityZones[*].vmauthCrossAZQuery` was moved to `availabilityZones[*].read.crossZone.vmauth`
+- set default DNS domain to `cluster.local.`
 
 ## 0.4.2
 

--- a/charts/victoria-metrics-distributed/Chart.lock
+++ b/charts/victoria-metrics-distributed/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.0.19
 - name: victoria-metrics-k8s-stack
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.27.6
-digest: sha256:8dd1484c0cac927be9bfccc02ca5e59b8ecb6a71f856465444663f9f2cc1a88c
-generated: "2024-11-04T07:37:39.617980876Z"
+  version: 0.28.1
+digest: sha256:2b7ab95a831f427464d04a2ce8b3b7a83eec9c1b945a26d736cb34466bc32e87
+generated: "2024-11-06T09:08:51.990257+02:00"

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -33,6 +33,6 @@ dependencies:
     version: "0.0.*"
     repository: https://victoriametrics.github.io/helm-charts
   - name: victoria-metrics-k8s-stack
-    version: "0.27.*"
+    version: "0.28.*"
     repository: https://victoriametrics.github.io/helm-charts
     condition: victoria-metrics-k8s-stack.enabled

--- a/charts/victoria-metrics-distributed/values.yaml
+++ b/charts/victoria-metrics-distributed/values.yaml
@@ -5,7 +5,10 @@ nameOverride: "vm-distributed"
 fullnameOverride: ""
 
 # -- Global chart properties
-global: {}
+global:
+  cluster:
+    # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
+    dnsDomain: cluster.local.
 
 common:
   vmauth:
@@ -276,8 +279,3 @@ victoria-metrics-k8s-stack:
     enabled: false
   grafana:
     enabled: true 
-    sidecar:
-      datasources:
-        enabled: true
-  crds:
-    enabled: true

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- Fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- set default DNS domain to `cluster.local.`
 
 ## 0.5.4
 

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -11,6 +11,9 @@ global:
   compatibility:
     openshift:
       adaptSecurityContext: "auto"
+  cluster:
+    # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
+    dnsDomain: cluster.local.
 
 # -- Number of replicas of vmgateway
 replicaCount: 1

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- Updated dashboards
+- updated dashboards
+- set default DNS domain to `cluster.local.`
 
 ## 0.28.1
 

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -7,6 +7,9 @@ global:
     keyRef: {}
       # name: secret-license
       # key: license
+  cluster:
+    # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
+    dnsDomain: cluster.local.
 
 # -- Resource full name suffix override
 nameOverride: ""

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- Fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- set default DNS domain to `cluster.local.`
 
 ## 0.37.0
 

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -9,7 +9,8 @@ global:
     openshift:
       adaptSecurityContext: "auto"
   cluster:
-    dnsDomain: cluster.local
+    # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
+    dnsDomain: cluster.local.
 # Default values for victoria-metrics.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- Fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- fix Deployment/StatefulSets when `serviceAccount.name` is empty and `serviceAccount.create: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1683).
+- set default DNS domain to `cluster.local.`
 
 ## 0.12.4
 

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -11,6 +11,9 @@ global:
   compatibility:
     openshift:
       adaptSecurityContext: "auto"
+  cluster:
+    # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
+    dnsDomain: cluster.local.
 
 rbac:
   # -- Enables Role/RoleBinding creation


### PR DESCRIPTION
- set default DNS domain in all charts. fixes https://github.com/VictoriaMetrics/helm-charts/issues/1626
- common: fixed boolean args rendering
- vlogs: made fields configurable. fixes https://github.com/VictoriaMetrics/helm-charts/issues/1695