### PR TITLE
common: remove trailing slash from generated url

### DIFF
--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- TODO
+- Allow selecting multiple/all instances in a dashboard. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1699)
+- Upgraded VictoriaLogs 0.40.0 -> 0.41.0
 
 ## 0.7.3
 

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.40.0
+appVersion: v0.41.0
 description: Victoria Logs Single version - high-performance, cost-effective and scalable logs storage
 name: victoria-logs-single
 version: 0.7.3

--- a/charts/victoria-logs-single/files/dashboards/generated/victorialogs.yaml
+++ b/charts/victoria-logs-single/files/dashboards/generated/victorialogs.yaml
@@ -2147,8 +2147,8 @@ templating:
       uid: $ds
     definition: label_values(vm_app_version{job=~"$job"}, instance)
     hide: 0
-    includeAll: false
-    multi: false
+    includeAll: true
+    multi: true
     name: instance
     options: []
     query:

--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release
 
 - Added ability to disable name truncation
+- Truncate `/` from `vm.url` output
 
 ## 0.0.20
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.20
+version: 0.0.21
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_helpers.tpl
+++ b/charts/victoria-metrics-common/templates/_helpers.tpl
@@ -132,6 +132,7 @@ If release name contains chart name it will be used as a full name.
 {{- /* Create chart name and version as used by the chart label. */ -}}
 {{- define "vm.chart" -}}
   {{- include "vm.validate.args" . -}}
+  {{- $Values := (.helm).Values | default .Values -}}
   {{- $Chart := (.helm).Chart | default .Chart -}}
   {{- $chart := printf "%s-%s" $Chart.Name $Chart.Version | replace "+" "_" -}}
   {{- if or ($Values.global).disableNameTruncation $Values.disableNameTruncation -}}

--- a/charts/victoria-metrics-common/templates/_service.tpl
+++ b/charts/victoria-metrics-common/templates/_service.tpl
@@ -69,5 +69,5 @@
     {{- $proto = (ternary "https" "http" $isSecure) -}}
     {{- $path = dig "http.pathPrefix" $path ($spec.extraArgs | default dict) -}}
   {{- end -}}
-  {{- printf "%s://%s%s" $proto $host $path -}}
+  {{- printf "%s://%s%s" $proto $host (trimSuffix "/" $path) -}}
 {{- end -}}

--- a/charts/victoria-metrics-distributed/templates/extra-vmagent.yaml
+++ b/charts/victoria-metrics-distributed/templates/extra-vmagent.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ .Values.extraVMAgent.name }}
   namespace: {{ $ns }}
 {{- $spec := (deepCopy .Values.extraVMAgent.spec) }}
-{{- $remoteWrites := list (dict "url" (printf "%s/prometheus/api/v1/write" (trimSuffix "/" (include "vm.url" $ctx)))) }}
+{{- $remoteWrites := list (dict "url" (printf "%s/prometheus/api/v1/write" (include "vm.url" $ctx))) }}
 {{- $_ := set $spec "remoteWrite" (concat $remoteWrites ($spec.remoteWrite | default list)) }}
 spec: {{ tpl (toYaml $spec) . | nindent 2 }}
 {{- end }}

--- a/charts/victoria-metrics-distributed/templates/grafana-datasource.yaml
+++ b/charts/victoria-metrics-distributed/templates/grafana-datasource.yaml
@@ -1,6 +1,6 @@
 {{ if and .Values.read.global.vmauth.enabled (index .Values "victoria-metrics-k8s-stack" "grafana" "enabled") }}
 {{- $ctx := dict "helm" . "appKey" (list "read" "global" "vmauth") "prefix" "read-global" "style" "managed" }}
-{{- $url := (printf "%s/select/0/prometheus/" (trimSuffix "/" (include "vm.url" $ctx))) }}
+{{- $url := (printf "%s/select/0/prometheus/" (include "vm.url" $ctx)) }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---
 apiVersion: v1

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -3,6 +3,7 @@
 - updated dashboards
 - set default DNS domain to `cluster.local.`
 - updated common dependency 0.0.19 -> 0.0.20
+- fixed disabling recording rules in `.Values.defaultRules`
 
 ## 0.28.2
 

--- a/charts/victoria-metrics-k8s-stack/templates/rules/rule.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/rules/rule.yaml
@@ -80,7 +80,7 @@ Filter out ignore rules
 {{- $commonInGroupRule := dig "rules" (default dict) $group }}
 {{- $filteredRulesSpec := default list }}
 {{- range $_, $ruleSpec := $rulesSpec }}
-  {{- $ruleName := $ruleSpec.alert | default "" }}
+  {{- $ruleName := $ruleSpec.alert | default $ruleSpec.record | default "" }}
   {{- $ruleKey := (hasKey $ruleSpec "record" | ternary "recording" "alerting") -}}
   {{- $ruleCondition := (eq $ruleSpec.condition "true") }}
   {{- $_ := unset $ruleSpec "condition" }}


### PR DESCRIPTION
- remove training slash in `vm.url` template. related issue https://github.com/VictoriaMetrics/helm-charts/issues/1706
- updated victorialogs grafana dashboard. fixes https://github.com/VictoriaMetrics/helm-charts/issues/1699
- allow disabling recording rules using `defaultRules.rules.<ruleName>.create: false`