### PR TITLE
common: removed unused fullname cases

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Removed unused cases from `vm.fullname`
 
 ## 0.0.21
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.21
+version: 0.0.22
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-distributed/templates/extra-vmagent.yaml
+++ b/charts/victoria-metrics-distributed/templates/extra-vmagent.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.extraVMAgent.enabled }}
-{{- $ctx := dict "helm" . "style" "managed" "appKey" (list "write" "global" "vmauth") "prefix" "write-global" }}
+{{- $ctx := dict "helm" . "style" "managed" "appKey" (list "write" "global" "vmauth") "alias" "vmauth-write-global" }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1

--- a/charts/victoria-metrics-distributed/templates/grafana-datasource.yaml
+++ b/charts/victoria-metrics-distributed/templates/grafana-datasource.yaml
@@ -1,5 +1,5 @@
 {{ if and .Values.read.global.vmauth.enabled (index .Values "victoria-metrics-k8s-stack" "grafana" "enabled") }}
-{{- $ctx := dict "helm" . "appKey" (list "read" "global" "vmauth") "prefix" "read-global" "style" "managed" }}
+{{- $ctx := dict "helm" . "appKey" (list "read" "global" "vmauth") "alias" "vmauth-read-global" "style" "managed" }}
 {{- $url := (printf "%s/select/0/prometheus/" (include "vm.url" $ctx)) }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-distributed/templates/per-az/vmagent.yaml
+++ b/charts/victoria-metrics-distributed/templates/per-az/vmagent.yaml
@@ -23,11 +23,10 @@ metadata:
   {{- if $rwZone.write.allow }}
     {{- $_ := set $ctx "style" "managed" }}
     {{- $_ := set $ctx "appKey" (list "availabilityZones" $i "write" "vmauth") }}
-    {{- $_ := set $ctx "prefix" "write-balancer" }}
-    {{- $url := trimSuffix "/" (include "vm.url" $ctx) }}
+    {{- $_ := set $ctx "alias" "vmauth-write-balancer" }}
     {{- $_ := unset $ctx "style" }}
-    {{- $_ := unset $ctx "prefix" }}
-    {{- $remoteWrites = append $remoteWrites (dict "url" (printf "%s/insert/%s/prometheus/api/v1/write" $url $tenant)) }}
+    {{- $_ := unset $ctx "alias" }}
+    {{- $remoteWrites = append $remoteWrites (dict "url" (printf "%s/insert/%s/prometheus/api/v1/write" (include "vm.url" $ctx) $tenant)) }}
   {{- end }}
 {{- end }}
 {{- $_ := set $spec "remoteWrite" (concat $remoteWrites ($spec.remoteWrites | default list)) }}

--- a/charts/victoria-metrics-distributed/templates/per-az/vmauth-read-proxy.yaml
+++ b/charts/victoria-metrics-distributed/templates/per-az/vmauth-read-proxy.yaml
@@ -24,14 +24,14 @@ spec: {{ toYaml (omit $spec "unauthorizedAccessConfig") | nindent 2 }}
     {{- $_ := set $ctx "style" "managed" }}
     {{- $urls := default list }}
     {{- if $zone.read.allow }}
-      {{- $_ := set $ctx "prefix" "read-balancer" }}
+      {{- $_ := set $ctx "alias" "vmauth-read-balancer" }}
       {{- $_ := set $ctx "appKey" (list "availabilityZones" $i "read" "perZone" "vmauth") }}
       {{- $urls = append $urls (include "vm.url" $ctx) }}
     {{- end }}
-    {{- $_ := set $ctx "prefix" "read-proxy" }}
+    {{- $_ := set $ctx "alias" "vmauth-read-proxy" }}
     {{- range $j, $cross := $.Values.availabilityZones }}
       {{- if and (ne $j $i) $cross.read.allow }}
-        {{- $_ := set $ctx "appKey" (list "availabilityZones" $j "read" "perZone" "vmauth") }}
+        {{- $_ := set $ctx "appKey" (list "availabilityZones" $j "read" "crossZone" "vmauth") }}
         {{- $urls = append $urls (include "vm.url" $ctx)}}
       {{- end }}
     {{- end }}
@@ -40,6 +40,6 @@ spec: {{ toYaml (omit $spec "unauthorizedAccessConfig") | nindent 2 }}
     {{- end }}
     url_prefix: {{ toYaml $urls | nindent 4 }}
     {{- $_ := unset $ctx "style" }}
-    {{- $_ := unset $ctx "prefix" }}
+    {{- $_ := unset $ctx "alias" }}
 {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
+++ b/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
@@ -23,7 +23,7 @@ spec:
     - "/select/.+"
     load_balancing_policy: first_available
     {{- $_ := set $ctx "style" "managed" }}
-    {{- $_ := set $ctx "prefix" "read-proxy" }}
+    {{- $_ := set $ctx "alias" "vmauth-read-proxy" }}
     {{- $urls := default list }}
     {{- range $i, $zone := $.Values.availabilityZones }}
       {{- $_ := set $ctx "appKey" (list "availabilityZones" $i "read" "crossZone" "vmauth") }}


### PR DESCRIPTION
- removed `global.name` and `global.<chart.name>.name` as sources of fullname prefix from `vm.fullname` template. it was required for victoria-logs-single chart before
- added `.alias` argument instead of doing `.prefix` magic