### PR TITLE
vmagent: fixed statefulset variable name typo, new releases for vmalert and vmagent

### DIFF
--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 - set default DNS domain to `cluster.local.`
 - updated common dependency 0.0.19 -> 0.0.23
 - added template for configmap name
+- fixed statefulset variable name typo
 
 ## 0.14.6
 

--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-metrics-agent
 description: Victoria Metrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
-version: 0.14.6
+version: 0.14.7
 appVersion: v1.106.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-agent/templates/hpa.yaml
+++ b/charts/victoria-metrics-agent/templates/hpa.yaml
@@ -16,7 +16,7 @@ spec:
   minReplicas: {{ $hpa.minReplicas }}
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: {{ ternary "StatefulSet" "Deployment" (.Values.statefulset).enabled }}
+    kind: {{ ternary "StatefulSet" "Deployment" (.Values.statefulSet).enabled }}
     name: {{ $fullname }}
   metrics: {{ toYaml $hpa.metrics | nindent 4 }}
   {{- with $hpa.behavior }}

--- a/charts/victoria-metrics-agent/templates/statefulset.yaml
+++ b/charts/victoria-metrics-agent/templates/statefulset.yaml
@@ -18,7 +18,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   serviceName: {{ $fullname }}
-  {{- with .Values.statefulset.updateStrategy }}
+  {{- with .Values.statefulSet.updateStrategy }}
   updateStrategy: {{ toYaml . | nindent 4 }}
   {{- end }}
   selector:
@@ -88,9 +88,9 @@ spec:
           {{- with .Values.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.env .Values.statefulset.clusterMode }}
+          {{- if or .Values.env .Values.statefulSet.clusterMode }}
           env:
-            {{- if .Values.statefulset.clusterMode }}
+            {{- if .Values.statefulSet.clusterMode }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-metrics-alert
 description: Victoria Metrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.12.4
+version: 0.12.5
 appVersion: v1.106.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts


### PR DESCRIPTION
new vmalert and vmagent chart releases, fixed `.Values.statefulSet` variable name in templates