### PR TITLE
common: fixed vm.plain.fullname suffix

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fixed adding suffix for `vm.plain.fullname`
 
 ## 0.0.24
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.24
+version: 0.0.25
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_helpers.tpl
+++ b/charts/victoria-metrics-common/templates/_helpers.tpl
@@ -34,6 +34,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */ -}}
 {{- define "vm.fullname" -}}
+  {{- $appendKey := ternary .appendKey true (hasKey . "appendKey") -}}
   {{- $overrideKey := .overrideKey | default "fullnameOverride" -}}
   {{- include "vm.validate.args" . -}}
   {{- $Values := (.helm).Values | default .Values -}}
@@ -67,7 +68,7 @@ If release name contains chart name it will be used as a full name.
     {{- end -}}
   {{- end -}}
   {{- $fullname = tpl $fullname . -}}
-  {{- if ne $overrideKey "fullnameOverride" -}}
+  {{- if $appendKey -}}
     {{- with .prefix -}}
       {{- $fullname = printf "%s-%s" . $fullname -}}
     {{- end -}}
@@ -84,7 +85,9 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "vm.cr.fullname" -}}
   {{- $_ := set . "overrideKey" "name" -}}
+  {{- $_ := set . "appendKey" false -}}
   {{- include "vm.fullname" . -}}
+  {{- $_ := unset . "appendKey" }}
   {{- $_ := unset . "overrideKey" -}}
 {{- end -}}
 


### PR DESCRIPTION
release 0.0.24 breaks adding suffix for names, that are using `vm.plain.fullname` template