### PR TITLE
operator: disable cleanup, when crds.enabled: false

### DIFF
--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -4,6 +4,7 @@
 - set default DNS domain to `cluster.local.`
 - updated common dependency 0.0.19 -> 0.0.23
 - added back `crds.enabled: false` option, which disables CRD creation, but due to limitation of dependencies condition it allows to disable only in combination with `crds.plain: false`
+- disabled cleanup, while `crds.enabled: false`. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1563).
 
 ## 0.37.0
 

--- a/charts/victoria-metrics-operator/templates/cleanup.yaml
+++ b/charts/victoria-metrics-operator/templates/cleanup.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crds.cleanup.enabled }}
+{{- if and .Values.crds.enabled .Values.crds.cleanup.enabled }}
 {{- $app := .Values.crds.cleanup }}
 {{- if empty ($app.image).tag }}
   {{- $tag := (printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor) | replace "+" "" -}}

--- a/charts/victoria-metrics-operator/templates/crb.yaml
+++ b/charts/victoria-metrics-operator/templates/crb.yaml
@@ -21,7 +21,7 @@ roleRef:
   name: {{ $fullname }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}
-{{- if .Values.crds.cleanup.enabled }}
+{{- if and .Values.crds.enabled .Values.crds.cleanup.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/victoria-metrics-operator/templates/role.yaml
+++ b/charts/victoria-metrics-operator/templates/role.yaml
@@ -179,7 +179,7 @@ rules:
 {{ toYaml . }}
 {{- end }}
 {{- end }}
-{{- if .Values.crds.cleanup.enabled }}
+{{- if and .Values.crds.enabled .Values.crds.cleanup.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/victoria-metrics-operator/templates/service_account.yaml
+++ b/charts/victoria-metrics-operator/templates/service_account.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
-{{- if .Values.crds.cleanup.enabled }}
+{{- if and .Values.crds.enabled .Values.crds.cleanup.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
disable cleanup hook, when crds.enabled: false. related issue https://github.com/VictoriaMetrics/helm-charts/issues/1563, alternatively we can set `victoria-metrics-operator.crds.enabled: false` in k8s-stack chart by default