### PR TITLE
common: find app key in a context root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode/
 charts/*/charts/**
 test-charts/*/charts/**
+test-charts/*/Chart.lock
 .cr-release-packages
 .cr-release-packages/**
 !charts/*/charts/crds

--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next release
 
-- TODO
+- fail fullname templates if data for appKey is not found
+- find by appKey in Values and context root
 
 ## 0.0.26
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.26
+version: 0.0.27
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_helpers.tpl
+++ b/charts/victoria-metrics-common/templates/_helpers.tpl
@@ -128,13 +128,18 @@ If release name contains chart name it will be used as a full name.
   {{- $fullname := "" -}}
   {{- if .appKey -}}
     {{- $appKey := ternary (list .appKey) .appKey (kindIs "string" .appKey) -}}
+    {{- $ctx := . -}}
     {{- $values := $Values -}}
     {{- range $ak := $appKey }}
-      {{- if $values -}}
-        {{- $values = (index $values $ak) | default dict -}}
-        {{- if and (kindIs "map" $values) (index $values $overrideKey) -}}
-          {{- $fullname = index $values $overrideKey -}}
-        {{- end -}}
+      {{- $values = ternary (default dict) (index $values $ak | default dict) (empty $values) -}}
+      {{- $ctx = ternary (default dict) (index $ctx $ak | default dict) (empty $ctx) -}}
+      {{- if and (empty $values) (empty $ctx) -}}
+        {{- fail (printf "No data for appKey %s" (join "->" $appKey)) -}}
+      {{- end -}}
+      {{- if and (kindIs "map" $values) (index $values $overrideKey) -}}
+        {{- $fullname = index $values $overrideKey -}}
+      {{- else if and (kindIs "map" $ctx) (index $ctx $overrideKey) -}}
+        {{- $fullname = index $ctx $overrideKey -}}
       {{- end -}}
     {{- end }}
   {{- end -}}

--- a/test-charts/victoria-metrics-common/Chart.lock
+++ b/test-charts/victoria-metrics-common/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: victoria-metrics-common
-  repository: file://../../charts/victoria-metrics-common
-  version: 0.0.26
-digest: sha256:4e5472b6c2c1a9c880950fd940467b409f3333ee50328a732ed2a8ae988183b3
-generated: "2024-11-13T15:14:16.641807+02:00"

--- a/test-charts/victoria-metrics-common/tests/helpers_test.yaml
+++ b/test-charts/victoria-metrics-common/tests/helpers_test.yaml
@@ -183,3 +183,52 @@ tests:
       - equal:
           path: vm.sa.name
           value: global
+  - it: with appKey in ctx and values
+    set:
+      ctx:
+        appKey:
+         - test
+         - single
+        test:
+          single:
+            name: override-1
+      test:
+        single:
+          name: override-2
+      fullnameOverride: global
+    asserts:
+      - equal:
+          path: vm.fullname
+          value: global
+      - equal:
+          path: vm.plain.fullname
+          value: global-single
+      - equal:
+          path: vm.managed.fullname
+          value: vmsingle-override-2
+      - equal:
+          path: vm.cr.fullname
+          value: override-2
+      - equal:
+          path: vm.namespace
+          value: NAMESPACE
+      - equal:
+          path: vm.sa.name
+          value: global
+  - it: with appKey but no data for a key
+    set:
+      ctx:
+        appKey:
+         - test
+         - single
+         - absent
+        test:
+          single:
+            name: override-1
+      test:
+        single:
+          name: override-2
+      fullnameOverride: global
+    asserts:
+      - failedTemplate:
+          errorMessage: No data for appKey test->single->absent


### PR DESCRIPTION
allow looking for component data not only in `.Values` but also in `.`. Useful for distributed chart to allow defining a single template for all availability zones