### PR TITLE
Fixed issue with deployment template

### DIFF
--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -91,11 +91,8 @@ spec:
               {{- end }}
             {{- end }}
             {{- range $app.extraVolumeMounts }}
-            - name: {{ .name}}
-              mountPath: {{ .mountPath }}
-              {{- with .subPath }}
-              subPath: {{ . }}
-              {{- end }}
+            - name: {{ .name }}
+              {{- toYaml (omit . "name") | nindent 14 }}
             {{- end }}
           {{- include "vm.license.mount" . | nindent 12 }}
           {{- with $app.resources }}
@@ -128,8 +125,7 @@ spec:
         {{- end }}
         {{- range $app.extraVolumes }}
         - name: {{ .name }}
-          configMap:
-            name: {{ .configMap.name }}
+          {{- toYaml (omit . "name") | nindent 10 }}
         {{- end }}
         {{- include "vm.license.volume" . | nindent 8 }}
 {{- end }}

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -90,8 +90,12 @@ spec:
               readOnly: {{ . }}
               {{- end }}
             {{- end }}
-            {{- with $app.extraVolumeMounts }}
-            {{- toYaml . | nindent 12 }}
+            {{- range $app.extraVolumeMounts }}
+            - name: {{ .name}}
+              mountPath: {{ .mountPath }}
+              {{- with .subPath }}
+              subPath: {{ . }}
+              {{- end }}
             {{- end }}
           {{- include "vm.license.mount" . | nindent 12 }}
           {{- with $app.resources }}
@@ -122,8 +126,10 @@ spec:
           hostPath:
             path: {{ .hostPath }}
         {{- end }}
-        {{- with $app.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
+        {{- range $app.extraVolumes }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap.name }}
         {{- end }}
         {{- include "vm.license.volume" . | nindent 8 }}
 {{- end }}


### PR DESCRIPTION
The current template does not render extra volumes properly with the given values



here is the section for values.yaml

```yaml

  # -- Extra Volumes for the pod
  extraVolumes:
    - name: network-alerts
      configMap:
        name: network-alerts

        
  # -- Extra Volume Mounts for the container
  extraVolumeMounts:
    - name: network-alerts
      mountPath: /rules/network-rules.yaml
      subPath: network-rules.yaml

```

here is the rendered manifest in the previous template:

```yaml
          volumeMounts:
            - name: alerts-config
              mountPath: /config
            - mountPath: /config/network-rules.yaml
              name: network-rules
            
      volumes:
        - name: alerts-config
          configMap:
            name: vmalert-stage-victoria-metrics-alert-server-alert-rules-config
        - configMap:
          - name: network-rules.yaml
          name: network-rules
```



here is the rendered version in the corrected template:

```yaml
            - name: network-rules
              mountPath: /config/network-rules.yaml
              subPath: network-rules.yaml
            
      volumes:
        - name: alerts-config
          configMap:
            name: vmalert-stage-victoria-metrics-alert-server-alert-rules-config
        - name: network-rules
          configMap: 
            name: network-rules.yaml
            
```




