### PR TITLE
Added default flag "rule" and commented subPath 

### DIFF
--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -178,6 +178,7 @@ server:
     envflag.enable: "true"
     envflag.prefix: VM_
     loggerFormat: json
+    rule: "/config/alert-rules.yaml"
 
   # -- Additional hostPath mounts
   extraHostPathMounts:
@@ -200,6 +201,8 @@ server:
     []
     # - name: example
     #   mountPath: /example
+    #   subPath: ""
+
 
   # -- Additional containers to run in the same pod
   extraContainers:


### PR DESCRIPTION
Neither of the included parameters change the current behavior so no breaking changes.

Reason to add "rule" flag:
this is already set and since almost every user would need to modify this path. So including the flag in the values.yaml is very convenient.

Reason to add subPath:
Consistency with other sections. Conveniently showing how to mount the volume as a file instead of a directory.