### PR TITLE
ingress: uncommented default host values for an example

### DIFF
--- a/charts/victoria-logs-single/Chart.lock
+++ b/charts/victoria-logs-single/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.37.0
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.27
-digest: sha256:537d8bb2703e23d34910ca16b35e8c02edaf0642a0085a0d3a511a0e2a0e23f6
-generated: "2024-11-14T21:30:21.745158173Z"
+  version: 0.0.30
+digest: sha256:6d7491d33d1e6d34e3a69c40e68e06f248b527bc427cac5e7ade443de74fe8f3
+generated: "2024-11-21T10:19:10.296280383Z"

--- a/charts/victoria-logs-single/README.md
+++ b/charts/victoria-logs-single/README.md
@@ -544,7 +544,10 @@ loggerFormat: json
       <td>server.ingress.hosts</td>
       <td>list</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">[]
+<code class="language-yaml">- name: vlogs.local
+  path:
+    - /
+  port: http
 </code>
 </pre>
 </td>

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -225,12 +225,11 @@ server:
     extraLabels: {}
 
     # -- Array of host objects
-    hosts: []
-    #   - name: vmselect.local
-    #     path:
-    #       - /select
-    #       - /insert
-    #     port: http
+    hosts:
+      - name: vlogs.local
+        path:
+          - /
+        port: http
 
     # -- Array of TLS objects
     tls: []

--- a/charts/victoria-metrics-agent/Chart.lock
+++ b/charts/victoria-metrics-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.28
-digest: sha256:59a5715447ded0174e76dc54a2a8e61ea04dc9a53bb73caa32a282383d3574c4
-generated: "2024-11-14T21:33:27.170837967Z"
+  version: 0.0.30
+digest: sha256:c0bb6d5e095b1b195458e15c1f0702779e6359791b9d04f067cfd21de84785ea
+generated: "2024-11-21T10:19:14.877223718Z"

--- a/charts/victoria-metrics-agent/README.md
+++ b/charts/victoria-metrics-agent/README.md
@@ -806,7 +806,10 @@ minReplicas: 1
       <td>ingress.hosts</td>
       <td>list</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">[]
+<code class="language-yaml">- name: vmagent.local
+  path:
+    - /
+  port: http
 </code>
 </pre>
 </td>

--- a/charts/victoria-metrics-agent/templates/ingress.yaml
+++ b/charts/victoria-metrics-agent/templates/ingress.yaml
@@ -23,17 +23,20 @@ spec:
   tls: {{ tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    {{- range $ingress.hosts }}
+    {{- range $host := $ingress.hosts }}
+    {{- $paths := ternary (list $host.path) $host.path (kindIs "string" $host.path) }}
     - host: {{ tpl .name $ }}
       http:
         paths:
-          - path: {{ .path }}
+          {{- range $path := $paths }}
+          - path: {{ $path }}
             {{- with $ingress.pathType }}
             pathType: {{ . }}
             {{- end }}
             backend:
               service:
                 name: {{ $fullname }}
-                port: {{ include "vm.ingress.port" . | nindent 18 }}
+                port: {{ include "vm.ingress.port" $host | nindent 18 }}
+          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -228,10 +228,11 @@ ingress:
   extraLabels: {}
   
   # -- Array of host objects
-  hosts: []
-  #   - name: vmagent.local
-  #     path: /
-  #     port: http
+  hosts:
+    - name: vmagent.local
+      path:
+        - / 
+      port: http
   
   # -- Array of TLS objects
   tls: []

--- a/charts/victoria-metrics-alert/Chart.lock
+++ b/charts/victoria-metrics-alert/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.28
-digest: sha256:59a5715447ded0174e76dc54a2a8e61ea04dc9a53bb73caa32a282383d3574c4
-generated: "2024-11-14T21:33:33.209678261Z"
+  version: 0.0.30
+digest: sha256:c0bb6d5e095b1b195458e15c1f0702779e6359791b9d04f067cfd21de84785ea
+generated: "2024-11-21T10:19:20.506643679Z"

--- a/charts/victoria-metrics-alert/README.md
+++ b/charts/victoria-metrics-alert/README.md
@@ -347,7 +347,10 @@ tag: v0.25.0
       <td>alertmanager.ingress.hosts</td>
       <td>list</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">[]
+<code class="language-yaml">- name: alertmanager.local
+  path:
+    - /
+  port: web
 </code>
 </pre>
 </td>
@@ -1177,7 +1180,10 @@ variant: ""
       <td>server.ingress.hosts</td>
       <td>list</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">[]
+<code class="language-yaml">- name: vmalert.local
+  path:
+    - /
+  port: http
 </code>
 </pre>
 </td>

--- a/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-deployment.yaml
@@ -46,7 +46,7 @@ spec:
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
-          image: {{ include "vm.image" (dict "helm" . "app" $app) }}
+          image: {{ include "vm.image" $ctx }}
           args: {{ include "alertmanager.args" $ctx | nindent 12 }}
           ports:
             - name: web

--- a/charts/victoria-metrics-alert/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-alert/templates/server-deployment.yaml
@@ -56,7 +56,7 @@ spec:
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
-          image: {{ include "vm.image" (dict "helm" . "app" $app) }}
+          image: {{ include "vm.image" $ctx }}
           args: {{ include "vmalert.args" $ctx | nindent 12 }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           {{- with $app.envFrom }}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -249,10 +249,11 @@ server:
     extraLabels: {}
 
     # -- Array of host objects
-    hosts: []
-    #   - name: vmselect.local
-    #     path: /select
-    #     port: http
+    hosts:
+      - name: vmalert.local
+        path:
+          - /
+        port: http
 
     # -- Array of TLS objects
     tls: []
@@ -495,10 +496,11 @@ alertmanager:
     extraLabels: {}
 
     # -- Array of host objects
-    hosts: []
-    #   - name: alertmanager.local
-    #     path: /
-    #     port: web
+    hosts:
+      - name: alertmanager.local
+        path:
+          - /
+        port: web
 
     # -- Array of TLS objects
     tls: []

--- a/charts/victoria-metrics-anomaly/Chart.lock
+++ b/charts/victoria-metrics-anomaly/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.28
-digest: sha256:59a5715447ded0174e76dc54a2a8e61ea04dc9a53bb73caa32a282383d3574c4
-generated: "2024-11-14T21:33:40.144138125Z"
+  version: 0.0.30
+digest: sha256:c0bb6d5e095b1b195458e15c1f0702779e6359791b9d04f067cfd21de84785ea
+generated: "2024-11-21T10:19:25.773712459Z"

--- a/charts/victoria-metrics-anomaly/templates/controller.yaml
+++ b/charts/victoria-metrics-anomaly/templates/controller.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
         - name: model
-          image: {{ include "vm.image" (dict "helm" . "app" .Values) }}
+          image: {{ include "vm.image" $ctx }}
           workingDir: {{ .Values.containerWorkingDir }}
           {{- if (((.Values.config).monitoring).pull).enabled }}
           {{- with (((.Values.config).monitoring).pull).port }}

--- a/charts/victoria-metrics-auth/Chart.lock
+++ b/charts/victoria-metrics-auth/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.28
-digest: sha256:59a5715447ded0174e76dc54a2a8e61ea04dc9a53bb73caa32a282383d3574c4
-generated: "2024-11-14T21:33:43.049487918Z"
+  version: 0.0.30
+digest: sha256:c0bb6d5e095b1b195458e15c1f0702779e6359791b9d04f067cfd21de84785ea
+generated: "2024-11-21T10:19:28.427488085Z"

--- a/charts/victoria-metrics-auth/README.md
+++ b/charts/victoria-metrics-auth/README.md
@@ -429,7 +429,10 @@ loggerFormat: json
       <td>ingress.hosts</td>
       <td>list</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">[]
+<code class="language-yaml">- name: vmauth.local
+  path:
+    - /
+  port: http
 </code>
 </pre>
 </td>
@@ -506,7 +509,10 @@ loggerFormat: json
       <td>ingressInternal.hosts</td>
       <td>list</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">[]
+<code class="language-yaml">- name: vmauth.local
+  path:
+    - /
+  port: http
 </code>
 </pre>
 </td>

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -157,11 +157,11 @@ ingress:
   extraLabels: {}
 
   # -- Array of host objects
-  hosts: []
-  #   - name: vmauth.local
-  #     path:
-  #       - /
-  #     port: http
+  hosts:
+    - name: vmauth.local
+      path:
+        - /
+      port: http
 
   # -- Array of TLS objects
   tls: []
@@ -188,11 +188,11 @@ ingressInternal:
   extraLabels: {}
 
   # -- Array of host objects
-  hosts: []
-  #   - name: vmauth.local
-  #     path:
-  #       - /
-  #     port: http
+  hosts:
+    - name: vmauth.local
+      path:
+        - /
+      port: http
 
   # -- Array of TLS objects
   tls: []

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Removed unsupported selectNodes SRV discovery
 
 ## 0.14.12
 

--- a/charts/victoria-metrics-cluster/Chart.lock
+++ b/charts/victoria-metrics-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.28
-digest: sha256:59a5715447ded0174e76dc54a2a8e61ea04dc9a53bb73caa32a282383d3574c4
-generated: "2024-11-14T21:33:46.094683628Z"
+  version: 0.0.30
+digest: sha256:c0bb6d5e095b1b195458e15c1f0702779e6359791b9d04f067cfd21de84785ea
+generated: "2024-11-21T10:19:31.660827129Z"

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -635,7 +635,10 @@ loggerFormat: json
       <td>vmauth.ingress.hosts</td>
       <td>list</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">[]
+<code class="language-yaml">- name: vmauth.local
+  path:
+    - /insert
+  port: http
 </code>
 </pre>
 </td>
@@ -1427,7 +1430,10 @@ loggerFormat: json
       <td>vminsert.ingress.hosts</td>
       <td>list</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">[]
+<code class="language-yaml">- name: vminsert.local
+  path:
+    - /insert
+  port: http
 </code>
 </pre>
 </td>
@@ -2275,7 +2281,10 @@ loggerFormat: json
       <td>vmselect.ingress.hosts</td>
       <td>list</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">[]
+<code class="language-yaml">- name: vmselect.local
+  path:
+    - /select
+  port: http
 </code>
 </pre>
 </td>

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -79,24 +79,16 @@
     {{- $selectNodes := default list }}
     {{- $_ := set . "appKey" "vmselect" }}
     {{- $fqdn := include "vm.fqdn" . }}
-    {{- if $Values.autoDiscovery }}
-      {{- if eq (include "vm.enterprise.disabled" . ) "true" }}
-        {{- fail "SRV autodiscovery is only supported in enterprise. Either define license or set `autoDiscovery` to `false`" }}
-      {{- end }}
-      {{- $selectNode := printf "srv+_http._tcp.%s" $fqdn }}
-      {{- $selectNodes = append $selectNodes $selectNode }}
-    {{- else }}
-      {{- $port := "8481" }}
-      {{- with $app.extraArgs.httpListenAddr }}
-        {{- $port = regexReplaceAll ".*:(\\d+)" . "${1}" }}
-      {{- end -}}
-      {{- range $i := until ($app.replicaCount | int) -}}
-        {{- $_ := set $ "appIdx" $i }}
-        {{- $selectNode := include "vm.fqdn" $ -}}
-        {{- $selectNodes = append $selectNodes (printf "%s:%s" $selectNode $port) -}}
-      {{- end -}}
-      {{- $_ := unset $ "appIdx" }}
-    {{- end }}
+    {{- $port := "8481" }}
+    {{- with $app.extraArgs.httpListenAddr }}
+      {{- $port = regexReplaceAll ".*:(\\d+)" . "${1}" }}
+    {{- end -}}
+    {{- range $i := until ($app.replicaCount | int) -}}
+      {{- $_ := set $ "appIdx" $i }}
+      {{- $selectNode := include "vm.fqdn" $ -}}
+      {{- $selectNodes = append $selectNodes (printf "%s:%s" $selectNode $port) -}}
+    {{- end -}}
+    {{- $_ := unset $ "appIdx" }}
     {{- $_ := set $args "selectNode" (concat ($args.selectNode | default list) $selectNodes) }}
   {{- end -}}
   {{- if empty $args.storageNode }}

--- a/charts/victoria-metrics-cluster/templates/vmauth-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmauth-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       containers:
         - name: vmauth
-          image: {{ include "vm.image" (dict "helm" . "app" $app) }}
+          image: {{ include "vm.image" $ctx }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           {{- with $app.containerWorkingDir }}
           workingDir: {{ . }}

--- a/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-deployment.yaml
@@ -43,7 +43,6 @@ spec:
       {{- end }}
       containers:
         - name: vminsert
-          {{- $_ := set $ctx "app" $app }}
           image: {{ include "vm.image" $ctx }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           {{- with $app.containerWorkingDir }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       containers:
         - name: vmselect
-          image: {{ include "vm.image" (dict "helm" . "app" $app) }}
+          image: {{ include "vm.image" $ctx }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           {{- with $app.containerWorkingDir }}
           workingDir: {{ . }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
         - name: vmselect
-          image: {{ include "vm.image" (dict "helm" . "app" $app) }}
+          image: {{ include "vm.image" $ctx }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           {{- with $app.containerWorkingDir }}
           workingDir: {{ . }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -44,7 +44,8 @@ spec:
         {{- if $manager.restore.onStart.enabled }}
         {{- include "vm.enterprise.only" . }}
         - name: vmbackupmanager-restore
-          image: {{ include "vm.image" (dict "helm" . "app" $manager) }}
+          {{- $_ := set $ctx "appKey" (list "vmstorage" "vmbackupmanager") }}
+          image: {{ include "vm.image" $ctx }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
@@ -80,7 +81,8 @@ spec:
       {{- end }}
       containers:
         - name: vmstorage
-          image: {{ include "vm.image" (dict "helm" . "app" $app) }}
+          {{- $_ := set $ctx "appKey" "vmstorage" }}
+          image: {{ include "vm.image" $ctx }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           {{- with $app.containerWorkingDir }}
           workingDir: {{ . }}
@@ -159,7 +161,8 @@ spec:
         {{- if $manager.enabled }}
         {{- include "vm.enterprise.only" . }}
         - name: vmbackupmanager
-          image: {{ include "vm.image" (dict "helm" . "app" $manager) }}
+          {{- $_ := set $ctx "appKey" (list "vmstorage" "vmbackupmanager") }}
+          image: {{ include "vm.image" $ctx }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/hpa_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/hpa_test.yaml.snap
@@ -8,7 +8,6 @@ hpa should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: authExtraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmauth
@@ -30,7 +29,6 @@ hpa should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: insertExtraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vminsert
@@ -52,7 +50,6 @@ hpa should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: selectExtraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmselect
@@ -74,7 +71,6 @@ hpa should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: storageExtraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmstorage
@@ -100,7 +96,6 @@ hpa should match snapshot with fullnameOverride and extraLabels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: authExtraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vmauth-node
@@ -122,7 +117,6 @@ hpa should match snapshot with fullnameOverride and extraLabels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: insertExtraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vminsert-node
@@ -144,7 +138,6 @@ hpa should match snapshot with fullnameOverride and extraLabels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: selectExtraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vmselect-node
@@ -166,7 +159,6 @@ hpa should match snapshot with fullnameOverride and extraLabels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: storageExtraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vmstorage-node

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/ingress_test.yaml.snap
@@ -42,7 +42,17 @@ ingress should match snapshot:
       name: RELEASE-NAME-victoria-metrics-cluster-vminsert
       namespace: NAMESPACE
     spec:
-      rules: null
+      rules:
+        - host: vminsert.local
+          http:
+            paths:
+              - backend:
+                  service:
+                    name: RELEASE-NAME-victoria-metrics-cluster-vminsert
+                    port:
+                      name: http
+                path: /insert
+                pathType: Prefix
       tls:
         - hosts:
             - insert.local
@@ -63,4 +73,14 @@ ingress should match snapshot:
       name: RELEASE-NAME-victoria-metrics-cluster-vmselect
       namespace: NAMESPACE
     spec:
-      rules: null
+      rules:
+        - host: vmselect.local
+          http:
+            paths:
+              - backend:
+                  service:
+                    name: RELEASE-NAME-victoria-metrics-cluster-vmselect
+                    port:
+                      name: http
+                path: /select
+                pathType: Prefix

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/ingress_test.yaml.snap
@@ -10,7 +10,6 @@ ingress should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmauth
       namespace: NAMESPACE
@@ -37,7 +36,6 @@ ingress should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vminsert
       namespace: NAMESPACE
@@ -68,7 +66,6 @@ ingress should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmselect
       namespace: NAMESPACE

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/service_test.yaml.snap
@@ -8,7 +8,6 @@ service should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmauth
       namespace: NAMESPACE
@@ -32,7 +31,6 @@ service should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vminsert
       namespace: NAMESPACE
@@ -56,7 +54,6 @@ service should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmselect
       namespace: NAMESPACE
@@ -80,7 +77,6 @@ service should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmstorage
       namespace: NAMESPACE
@@ -114,7 +110,6 @@ service should match snapshot with fullnameOverride and extraLabels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraServiceLabelName: authExtraServiceLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vmauth-node
@@ -139,7 +134,6 @@ service should match snapshot with fullnameOverride and extraLabels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraServiceLabelName: insertExtraServiceLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vminsert-node
@@ -164,7 +158,6 @@ service should match snapshot with fullnameOverride and extraLabels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraServiceLabelName: selectExtraServiceLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vmselect-node
@@ -189,7 +182,6 @@ service should match snapshot with fullnameOverride and extraLabels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraServiceLabelName: storageExtraServiceLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vmstorage-node

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmauth_test.yaml.snap
@@ -8,7 +8,6 @@ deployment should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmauth
       namespace: NAMESPACE
@@ -74,7 +73,6 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: extraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vmauth-node

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vminsert_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vminsert_test.yaml.snap
@@ -8,7 +8,6 @@ deployment should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vminsert
       namespace: NAMESPACE
@@ -68,7 +67,6 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: extraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vminsert-node

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmselect_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmselect_test.yaml.snap
@@ -8,7 +8,6 @@ deployment should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmselect
       namespace: NAMESPACE
@@ -77,7 +76,6 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: extraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vmselect-node
@@ -148,7 +146,6 @@ statefulset should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmselect
       namespace: NAMESPACE
@@ -221,7 +218,6 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: extraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vmselect-node

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
@@ -8,7 +8,6 @@ statefulset should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: RELEASE-NAME-victoria-metrics-cluster-vmstorage
       namespace: NAMESPACE
@@ -89,7 +88,6 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
-        app.kubernetes.io/version: 0.1.0
         extraLabelName: extraLabelValue
         helm.sh/chart: victoria-metrics-cluster-0.1.1
       name: vmstorage-node

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -255,11 +255,11 @@ vmselect:
     extraLabels: {}
 
     # -- Array of host objects
-    hosts: []
-    #   - name: vmselect.local
-    #     path:
-    #       - /select
-    #     port: http
+    hosts:
+      - name: vmselect.local
+        path:
+          - /select
+        port: http
 
     # -- Array of TLS objects
     tls: []
@@ -529,11 +529,11 @@ vminsert:
     extraLabels: {}
 
     # -- Array of host objects
-    hosts: []
-    # - name: vminsert.local
-    #   path:
-    #     - /insert
-    #   port: http
+    hosts:
+      - name: vminsert.local
+        path:
+          - /insert
+        port: http
 
     # -- Array of TLS objects
     tls: []
@@ -772,11 +772,11 @@ vmauth:
     #   kubernetes.io/tls-acme: 'true'
     extraLabels: {}
     # -- Array of host objects
-    hosts: []
-    # - name: vmauth.local
-    #   path:
-    #     - /insert
-    #   port: http
+    hosts:
+      - name: vmauth.local
+        path:
+          - /insert
+        port: http
     # -- Array of TLS objects
     tls: []
     #   - secretName: vmauth-ingress-tls

--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- fixed minor typo in vm.labels
 
 ## 0.0.30
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.30
+version: 0.0.31
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_helpers.tpl
+++ b/charts/victoria-metrics-common/templates/_helpers.tpl
@@ -195,9 +195,8 @@ If release name contains chart name it will be used as a full name.
   {{- include "vm.validate.args" . -}}
   {{- $labels := fromYaml (include "vm.selectorLabels" .) -}}
   {{- $labels = mergeOverwrite $labels (fromYaml (include "vm.metaLabels" .)) -}}
-  {{- $tag := include "vm.image.tag" . -}}
-  {{- if .app }}
-    {{- $_ := set $labels "app.kubernetes.io/version" $tag -}}
+  {{- with (include "vm.image.tag" .) }}
+    {{- $_ := set $labels "app.kubernetes.io/version" . -}}
   {{- end -}}
   {{- toYaml $labels -}}
 {{- end -}}

--- a/charts/victoria-metrics-distributed/Chart.lock
+++ b/charts/victoria-metrics-distributed/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.28
+  version: 0.0.30
 - name: victoria-metrics-k8s-stack
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.28.3
-digest: sha256:d58a2d941ecffb36a87ab8ac274124659d60b2cd1e7fee289bcc999746088335
-generated: "2024-11-14T21:33:49.180762046Z"
+  version: 0.28.4
+digest: sha256:681225b86ea89e8a32399e83dfd439fce7f5c7f7f6f75a5ce3c111400d3a5128
+generated: "2024-11-21T10:19:34.265402463Z"

--- a/charts/victoria-metrics-distributed/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-metrics-distributed/tests/__snapshot__/vmauth_test.yaml.snap
@@ -7,7 +7,6 @@ vmauth should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-distributed-0.1.1
       name: vmauth-read-balancer-zone-eu-1
       namespace: NAMESPACE
@@ -35,7 +34,6 @@ vmauth should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-distributed-0.1.1
       name: vmauth-read-balancer-zone-us-1
       namespace: NAMESPACE
@@ -63,7 +61,6 @@ vmauth should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-distributed-0.1.1
       name: vmauth-read-proxy-zone-eu-1
       namespace: NAMESPACE
@@ -93,7 +90,6 @@ vmauth should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-distributed-0.1.1
       name: vmauth-read-proxy-zone-us-1
       namespace: NAMESPACE
@@ -123,7 +119,6 @@ vmauth should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-distributed-0.1.1
       name: vmauth-write-balancer-zone-eu-1
       namespace: NAMESPACE
@@ -151,7 +146,6 @@ vmauth should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-distributed-0.1.1
       name: vmauth-write-balancer-zone-us-1
       namespace: NAMESPACE
@@ -179,7 +173,6 @@ vmauth should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-distributed-0.1.1
       name: vmauth-global-read-RELEASE-NAME-vm-distributed
       namespace: NAMESPACE
@@ -200,7 +193,6 @@ vmauth should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed
-        app.kubernetes.io/version: 0.1.0
         helm.sh/chart: victoria-metrics-distributed-0.1.1
       name: vmauth-global-write-RELEASE-NAME-vm-distributed
       namespace: NAMESPACE

--- a/charts/victoria-metrics-gateway/Chart.lock
+++ b/charts/victoria-metrics-gateway/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.28
-digest: sha256:59a5715447ded0174e76dc54a2a8e61ea04dc9a53bb73caa32a282383d3574c4
-generated: "2024-11-14T21:33:53.043881756Z"
+  version: 0.0.30
+digest: sha256:c0bb6d5e095b1b195458e15c1f0702779e6359791b9d04f067cfd21de84785ea
+generated: "2024-11-21T10:19:37.957264215Z"

--- a/charts/victoria-metrics-gateway/README.md
+++ b/charts/victoria-metrics-gateway/README.md
@@ -519,7 +519,10 @@ loggerFormat: json
       <td>ingress.hosts</td>
       <td>list</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">[]
+<code class="language-yaml">- name: vmgateway.local
+  path:
+    - /
+  port: http
 </code>
 </pre>
 </td>

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -155,11 +155,11 @@ ingress:
   extraLabels: {}
 
   # -- Array of host objects
-  hosts: []
-  #   - name: vmgateway.local
-  #     path:
-  #       - /
-  #     port: http
+  hosts:
+    - name: vmgateway.local
+      path:
+        - /
+      port: http
 
   # -- Array of TLS objects
   tls: []

--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.28
+  version: 0.0.30
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts
   version: 0.37.0
@@ -17,5 +17,5 @@ dependencies:
 - name: prometheus-operator-crds
   repository: https://prometheus-community.github.io/helm-charts
   version: 15.0.0
-digest: sha256:ecaa5f6cbf59d4ce94e210b6cded48367d8fe4b3fa8457e4fc3fa99bd17b947f
-generated: "2024-11-14T21:33:56.575792008Z"
+digest: sha256:365a8ca24c71cf1657afc762a89ccfacb22c2568e3cf202645f7ea8e2ebd281b
+generated: "2024-11-21T10:19:41.692298175Z"

--- a/charts/victoria-metrics-operator/Chart.lock
+++ b/charts/victoria-metrics-operator/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.28
+  version: 0.0.30
 - name: crds
   repository: ""
   version: 0.0.*
-digest: sha256:a4358d86066e05ca05ea66854535157ece71c53ef11d2ececaa6ef5ae801fb5f
-generated: "2024-11-14T21:34:04.913883345Z"
+digest: sha256:c672ce7fad64abf813e9636c8189752a056fb25c58ab4f1f4dab8648293541d1
+generated: "2024-11-21T10:19:49.798484054Z"

--- a/charts/victoria-metrics-operator/templates/cleanup.yaml
+++ b/charts/victoria-metrics-operator/templates/cleanup.yaml
@@ -29,7 +29,8 @@ spec:
       {{- end }}
       containers:
         - name: kubectl
-          image: {{ include "vm.image" (dict "helm" . "app" $app) }}
+          {{- $_ := set $ctx "appKey" (list "crds" "cleanup") }}
+          image: {{ include "vm.image" $ctx }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           resources: {{ toYaml $app.resources | nindent 12 }}
           args:

--- a/charts/victoria-metrics-operator/templates/deployment.yaml
+++ b/charts/victoria-metrics-operator/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: operator
-          image: {{ include "vm.image" (dict "helm" . "app" .Values ) }}
+          image: {{ include "vm.image" $ctx }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-metrics-single/Chart.lock
+++ b/charts/victoria-metrics-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.28
-digest: sha256:59a5715447ded0174e76dc54a2a8e61ea04dc9a53bb73caa32a282383d3574c4
-generated: "2024-11-14T21:34:07.34291243Z"
+  version: 0.0.30
+digest: sha256:c0bb6d5e095b1b195458e15c1f0702779e6359791b9d04f067cfd21de84785ea
+generated: "2024-11-21T10:19:52.036601472Z"

--- a/charts/victoria-metrics-single/README.md
+++ b/charts/victoria-metrics-single/README.md
@@ -559,7 +559,10 @@ loggerFormat: json
       <td>server.ingress.hosts</td>
       <td>list</td>
       <td><pre class="helm-vars-default-value" language-yaml" lang="plaintext">
-<code class="language-yaml">[]
+<code class="language-yaml">- name: vmsingle.local
+  path:
+    - /
+  port: http
 </code>
 </pre>
 </td>

--- a/charts/victoria-metrics-single/templates/server-deployment.yaml
+++ b/charts/victoria-metrics-single/templates/server-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- if $manager.restore.onStart.enabled }}
       {{- include "vm.enterprise.only" . }}
       - name: vmbackupmanager-restore
-        {{- $_ := set $ctx "app" "manager" }}
+        {{- $_ := set $ctx "appKey" (list "server" "vmbackupmanager") }}
         image: {{ include "vm.image" $ctx }}
         imagePullPolicy: {{ $app.image.pullPolicy }}
         {{- with $app.podSecurityContext }}
@@ -86,7 +86,7 @@ spec:
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
-          {{- $_ := set $ctx "app" $app }}
+          {{- $_ := set $ctx "appKey" "server" }}
           image: {{ include "vm.image" $ctx }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           {{- if $app.containerWorkingDir }}
@@ -196,7 +196,7 @@ spec:
         {{- if $manager.enabled }}
         {{- include "vm.enterprise.only" . }}
         - name: vmbackupmanager
-          {{- $_ := set $ctx "app" $manager }}
+          {{- $_ := set $ctx "appKey" (list "server" "vmbackupmanager") }}
           image: {{ include "vm.image" $ctx }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           args: {{ include "vmbackupmanager.args" $ctx | nindent 12 }}

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -252,11 +252,11 @@ server:
     # -- Ingress extra labels
     extraLabels: {}
     # -- Array of host objects
-    hosts: []
-    #   - name: vmselect.local
-    #     path:
-    #       - /select
-    #     port: http
+    hosts:
+      - name: vmsingle.local
+        path:
+          - /
+        port: http
 
     # -- Array of TLS objects
     tls: []


### PR DESCRIPTION
uncommented default ingress.hosts value to show them in documentation. fixes https://github.com/VictoriaMetrics/helm-charts/issues/1779
removed unsupported selectNode discovery functionality from victoria-metrics-cluster chart
fixed typo in common chart vm.labels template
updated common chart everywhere, which will be mentioned in a changelog in the next PR