### PR TITLE
 Fix Alertmanager Templates: Dynamic Port and Context Updates

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,36 +1,48 @@
+metrics:
+  - changed-files:
+      - any-glob-to-any-file:
+          - charts/victoria-metrics-*/**/*
+logs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - charts/victoria-logs-*/**/*
+common:
+  - changed-files:
+      - any-glob-to-any-file:
+          - charts/*-common/**/*
 agent:
   - changed-files:
       - any-glob-to-any-file:
-          - charts/victoria-metrics-agent/**/*
+          - charts/*-agent/**/*
 alert:
   - changed-files:
       - any-glob-to-any-file:
-          - charts/victoria-metrics-alert/**/*
+          - charts/*-alert/**/*
 auth:
   - changed-files:
       - any-glob-to-any-file:
-          - charts/victoria-metrics-auth/**/*
+          - charts/*-auth/**/*
 cluster:
   - changed-files:
       - any-glob-to-any-file:
-          - charts/victoria-metrics-cluster/**/*
+          - charts/*-cluster/**/*
 k8s-stack:
   - changed-files:
       - any-glob-to-any-file:
-          - charts/victoria-metrics-k8s-stack/**/*
+          - charts/*-k8s-stack/**/*
 operator:
   - changed-files:
       - any-glob-to-any-file:
-          - charts/victoria-metrics-operator/**/*
+          - charts/*-operator/**/*
 single:
   - changed-files:
       - any-glob-to-any-file:
-          - charts/victoria-metrics-single/**/*
+          - charts/*-single/**/*
 anomaly:
   - changed-files:
       - any-glob-to-any-file:
-          - charts/victoria-metrics-anomaly/**/*
-logs-single:
+          - charts/*-anomaly/**/*
+gateway:
   - changed-files:
       - any-glob-to-any-file:
-          - charts/victoria-logs-single/**/*
+          - charts/*-gateway/**/*

--- a/charts/victoria-metrics-alert/templates/alertmanager-ingress.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-ingress.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.alertmanager }}
 {{- $ingress := $app.ingress }}
 {{- if and $app.enabled $ingress.enabled  }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "appKey" "alertmanager" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: networking.k8s.io/v1

--- a/charts/victoria-metrics-alert/templates/alertmanager-service.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-service.yaml
@@ -43,7 +43,7 @@ spec:
   {{- end }}
   ports:
     - name: web
-      port: 9093
+      port: {{ $service.servicePort }}
       targetPort: web
       protocol: TCP
   selector: {{ include "vm.selectorLabels" $ctx | nindent 4 }}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -470,7 +470,7 @@ alertmanager:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 8880
+    servicePort: 9093
     # nodePort: 30000
     # -- Service type
     type: ClusterIP


### PR DESCRIPTION
This PR introduces the following improvements to the victoria-metrics-alert Helm chart:

* Improved context dictionary in alertmanager-ingress.yaml:
Added the appKey field to the context ($ctx) with the value alertmanager, enhancing the context for templating.

* Dynamic port assignment in alertmanager-service.yaml: Replaced the hardcoded port 9093 with a dynamic value using {{ $service.servicePort }}, allowing for better customization via Helm values.

These changes improve the configurability and flexibility of the Helm chart.