### PR TITLE
k8s-stack: added workaround for DiskRunsOutOfSpace alerts for cases, when storage.minFreeDiskSpaceBytes is more than 20% of disk storage

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - synced rules
+- added workaround for DiskRunsOutOfSpace alerts. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1809)
 
 ## 0.29.1
 

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vmcluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vmcluster.yaml
@@ -35,7 +35,8 @@ rules:
     sum(vm_data_size_bytes) by (job,instance,{{ $clusterLabel }}) /
     (
      sum(vm_free_disk_space_bytes) by (job,instance,{{ $clusterLabel }}) +
-     sum(vm_data_size_bytes) by (job,instance,{{ $clusterLabel }})
+     sum(vm_data_size_bytes) by (job,instance,{{ $clusterLabel }}) -
+     sum(label_value(flag{name="storage.minFreeDiskSpaceBytes"}, "value")) by (job,instance,{{ $clusterLabel }})
     ) > 0.8
   for: 30m
   labels:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vmsingle.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vmsingle.yaml
@@ -35,7 +35,8 @@ rules:
     sum(vm_data_size_bytes) by (job,instance,{{ $clusterLabel }}) /
     (
      sum(vm_free_disk_space_bytes) by (job,instance,{{ $clusterLabel }}) +
-     sum(vm_data_size_bytes) by (job,instance,{{ $clusterLabel }})
+     sum(vm_data_size_bytes) by (job,instance,{{ $clusterLabel }}) -
+     sum(label_value(flag{name="storage.minFreeDiskSpaceBytes"}, "value")) by (job,instance,{{ $clusterLabel }})
     ) > 0.8
   for: 30m
   labels:

--- a/hack/rules-and-dashboards/sync_rules.py
+++ b/hack/rules-and-dashboards/sync_rules.py
@@ -166,6 +166,10 @@ def cluster_label_var(mo):
 
 
 replacement_map = {
+    "( |\n|\r)+\\) > 0.8": {
+        "replacement": ' -\n     sum(label_value(flag{name="storage.minFreeDiskSpaceBytes"}, "value")) by (job, instance)\n    ) > 0.8',
+        "limitGroup": ["vmsingle", "vmcluster"],
+    },
     "https://runbooks.prometheus-operator.dev/runbooks": {
         "replacement": "[[ $runbookUrl ]]",
     },


### PR DESCRIPTION
as we don't want to break compatibility with prometheus for dashboards at VictoriaMetrics repo, added hack that takes into an account `storage.minFreeDiskSpaceBytes` flag value
fixes https://github.com/VictoriaMetrics/helm-charts/issues/1809
