### PR TITLE
vlogs: create vector config in a given namespace even if vector.enabled: false

### DIFF
--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Added `vector.customConfigNamespace` to force Vector configmap creation in a given namespace even if vector.enabled: false
 
 ## 0.8.4
 

--- a/charts/victoria-logs-single/README.md
+++ b/charts/victoria-logs-single/README.md
@@ -1181,6 +1181,7 @@ customConfig:
                 .log = parse_json(.message) ?? .message
                 del(.message)
             type: remap
+customConfigNamespace: ""
 dataDir: /vector-data-dir
 enabled: false
 existingConfigMaps:
@@ -1195,6 +1196,17 @@ service:
 </pre>
 </td>
       <td><p>Values for <a href="https://github.com/vectordotdev/helm-charts/tree/develop/charts/vector" target="_blank">vector helm chart</a></p>
+</td>
+    </tr>
+    <tr>
+      <td>vector.customConfigNamespace</td>
+      <td>string</td>
+      <td><pre class="helm-vars-default-value" language-yaml" lang="">
+<code class="language-yaml">""
+</code>
+</pre>
+</td>
+      <td><p>Forces custom configuration creation in a given namespace even if vector.enabled is false</p>
 </td>
     </tr>
     <tr>

--- a/charts/victoria-logs-single/templates/vector.yaml
+++ b/charts/victoria-logs-single/templates/vector.yaml
@@ -1,6 +1,7 @@
-{{- if and (.Values.vector).enabled (.Values.vector).existingConfigMaps }}
+{{- if and (or (.Values.vector).enabled (.Values.vector).customConfigNamespace) (.Values.vector).existingConfigMaps }}
 {{- $ctx := dict "helm" . "appKey" "server" "style" "plain" }}
 {{- $ns := include "vm.namespace" $ctx }}
+{{- $ns = ternary $ns ((.Values.vector).customConfigNamespace | default $ns) .Values.vector.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -10,5 +11,5 @@ metadata:
   namespace: {{ $ns }}
 data:
   {{- $tpl := toYaml (.Values.vector).customConfig | replace "<<" "{{" | replace ">>" "}}" }}
-  vector.yaml: |{{ tpl $tpl $ctx | nindent 4 }}
+  {{ include "vm.fullname" $ctx }}-vector.yaml: |{{ tpl $tpl $ctx | nindent 4 }}
 {{- end }}

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -318,11 +318,13 @@ vector:
     enabled: false
   existingConfigMaps:
     - vl-config
+  # -- Forces custom configuration creation in a given namespace even if vector.enabled is false
+  customConfigNamespace: ""
   customConfig:
     data_dir: /vector-data-dir
     api:
       enabled: false
-      address: 127.0.0.1:8686
+      address: 0.0.0.0:8686
       playground: true
     sources:
       k8s:


### PR DESCRIPTION
@Haleygo 
this can be useful to support multiple vlogs installations where only single one has vector enabled