### PR TITLE
charts/operator: allow disabling automatic token mount

### DIFF
--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - updated common dependency 0.0.32 -> 0.0.33
+- add an option to mount `ServiceAccount` token manually for security hardening reasons.
 
 ## 0.39.1
 

--- a/charts/victoria-metrics-operator/README.md.gotmpl
+++ b/charts/victoria-metrics-operator/README.md.gotmpl
@@ -93,6 +93,36 @@ admissionWebhooks:
 
 {{ include "chart.helmDocs" . }}
 
+## Disabling automatic ServiceAccount token mount
+
+There are cases when it is required to disable automatic ServiceAccount token mount due to hardening reasons. To disable it, set the following values:
+```
+serviceAccount:
+  automountServiceAccountToken: false
+
+extraVolumes:
+  - name: operator
+    projected:
+      sources:
+        - downwardAPI:
+            items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+        - configMap:
+            name: kube-root-ca.crt
+        - serviceAccountToken:
+            expirationSeconds: 7200
+            path: token
+
+extraVolumeMounts:
+  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+    name: operator
+```
+
+This configuration disables the automatic ServiceAccount token mount and mounts the token explicitly.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-operator/templates/deployment.yaml
+++ b/charts/victoria-metrics-operator/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
     spec:
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{ include "vm.securityContext" (dict "securityContext" .Values.podSecurityContext "helm" .) | nindent 8 }}
       {{- end }}

--- a/charts/victoria-metrics-operator/templates/service_account.yaml
+++ b/charts/victoria-metrics-operator/templates/service_account.yaml
@@ -13,6 +13,7 @@ metadata:
   {{- with .Values.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- if and .Values.crds.enabled .Values.crds.cleanup.enabled }}
 ---

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -120,6 +120,9 @@ serviceAccount:
   # -- The name of the service account to use. If not set and create is true, a name is generated using the fullname template
   name: ""
 
+  # -- Whether to automount the service account token. Note that token needs to be mounted manually if this is disabled.
+  automountServiceAccountToken: true
+
 service:
   # -- Service annotations
   annotations: {}


### PR DESCRIPTION
Added an option to disable automatic token mount in order to avoid issues with security hardening.