### PR TITLE
charts/operator: Add option to enable hostNetwork for custom CNI deployments

### DIFF
--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add option to enable hostNetwork for custom CNI based deployments
 
 ## 0.40.1
 

--- a/charts/victoria-metrics-operator/README.md.gotmpl
+++ b/charts/victoria-metrics-operator/README.md.gotmpl
@@ -123,6 +123,15 @@ extraVolumeMounts:
 
 This configuration disables the automatic ServiceAccount token mount and mounts the token explicitly.
 
+## Enable hostNetwork on operator
+
+When running managed Kubernetes such as EKS with custom CNI solution like Cilium or Calico, EKS control plane cannot communicate with CNI's pod CIDR. 
+In that scenario, we need to run webhook service i.e operator with hostNetwork so that it can share node's network namespace.
+
+```yaml
+hostNetwork: true
+```
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-operator/templates/deployment.yaml
+++ b/charts/victoria-metrics-operator/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{ include "vm.securityContext" (dict "securityContext" .Values.podSecurityContext "helm" .) | nindent 8 }}
       {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
       {{- if or (.Values.serviceAccount).name (.Values.serviceAccount).create }}
       serviceAccountName: {{ (.Values.serviceAccount).name | default $fullname }}
       {{- end }}

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -229,6 +229,9 @@ extraContainers:
   # - name: config-reloader
   #   image: reloader-image
 
+# -- Enable hostNetwork on operator deployment
+hostNetwork: false
+
 # -- Configures resource validation
 admissionWebhooks:
   # -- Enables validation webhook.


### PR DESCRIPTION
- Add an option to enable hostNetwork on operator deployment to work with custom CNI on managed Kubernetes clusters such as EKS.