### PR TITLE
Add support for string extraObjects

### DIFF
--- a/charts/victoria-logs-single/templates/extra-objects.yaml
+++ b/charts/victoria-logs-single/templates/extra-objects.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
 {{ tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}

--- a/charts/victoria-metrics-agent/templates/extra-objects.yaml
+++ b/charts/victoria-metrics-agent/templates/extra-objects.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
 {{ tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}

--- a/charts/victoria-metrics-alert/templates/extra-objects.yaml
+++ b/charts/victoria-metrics-alert/templates/extra-objects.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
 {{ tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}

--- a/charts/victoria-metrics-auth/templates/extra-objects.yaml
+++ b/charts/victoria-metrics-auth/templates/extra-objects.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
 {{ tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}

--- a/charts/victoria-metrics-cluster/templates/extra-objects.yaml
+++ b/charts/victoria-metrics-cluster/templates/extra-objects.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
 {{ tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}

--- a/charts/victoria-metrics-k8s-stack/templates/extra-objects.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/extra-objects.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
 {{ tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}

--- a/charts/victoria-metrics-operator/templates/extra-objects.yaml
+++ b/charts/victoria-metrics-operator/templates/extra-objects.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
 {{ tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}

--- a/charts/victoria-metrics-single/templates/extra-objects.yaml
+++ b/charts/victoria-metrics-single/templates/extra-objects.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
 {{ tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}


### PR DESCRIPTION
Currently, `extraObjects` only allows YAML inputs, which make it a pain to use templating within them. You can single quote a templated line for most cases, but this doesn't work with multiline things, such as labels.

Example:
```yaml
labels: {{ include "vm.labels" (dict "helm" . "appKey" "server" "extraLabels" .Values.server.service.labels) | nindent 4 }}
```
will template as
```yaml
labels: '
  name: abc
  label2: value'
```

As shown [in this documentation](https://docs.nautobot.com/projects/helm-charts/en/stable/advanced-features/extra-objects/), being able to pass the whole object as a string is great for templating and allows for these multiline strings.