### PR TITLE
vmcluster: improve components readiness check

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next release
 
+**Update note**: A default `minReadySeconds` has been added for the vmstorage statefulset, vmstorage pods will restart after the upgrade.
+**Update note**: The default probes of vminsert, vmselect, vmauth, and vmstorage have been changed, all pods will restart after the upgrade.
+
 - Remove vmstorage liveness probe, as vminsert already handles routing and retries, while liveness probes can inadvertently introduce delays, DNS instability, and unnecessary disruptions.
 - Reduce the default readiness probe interval to 5s (was 15s) and the failure threshold to 10 (was 3).
 - Add a default minReadySeconds for vmstorage, to help stabilizing service during rollout.

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Remove vmstorage readiness probe, as vminsert already handles routing and retries, while readiness probes can inadvertently introduce delays, DNS instability, and unnecessary disruptions.
+- Remove vmstorage liveness probe, as vminsert already handles routing and retries, while liveness probes can inadvertently introduce delays, DNS instability, and unnecessary disruptions.
 - Reduce the default readiness probe interval to 5s (was 15s) and the failure threshold to 10 (was 3).
 - Add a default minReadySeconds for vmstorage, to help stabilizing service during rollout.
 

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- vmstorage: reduce the default readiness probe interval to 5s (was 15s) and the failure threshold to 10 (was 3).
 
 ## 0.16.2
 

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- vmstorage: reduce the default readiness probe interval to 5s (was 15s) and the failure threshold to 10 (was 3).
+- all: reduce the default readiness probe interval to 5s (was 15s) and the failure threshold to 10 (was 3).
 
 ## 0.16.2
 

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next release
 
-- vmstorage: remove readiness probe (reason: vminsert already handles routing and retries, and readiness probes can inadvertently introduce delays, DNS instability, and unnecessary disruptions)
-- all (except vmstorage): reduce the default readiness probe interval to 5s (was 15s) and the failure threshold to 10 (was 3).
+- Remove vmstorage readiness probe, as vminsert already handles routing and retries, while readiness probes can inadvertently introduce delays, DNS instability, and unnecessary disruptions.
+- Reduce the default readiness probe interval to 5s (was 15s) and the failure threshold to 10 (was 3).
 
 ## 0.16.2
 

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Remove vmstorage readiness probe, as vminsert already handles routing and retries, while readiness probes can inadvertently introduce delays, DNS instability, and unnecessary disruptions.
 - Reduce the default readiness probe interval to 5s (was 15s) and the failure threshold to 10 (was 3).
+- Add a default minReadySeconds for vmstorage, to help stabilizing service during rollout.
 
 ## 0.16.2
 

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- all: reduce the default readiness probe interval to 5s (was 15s) and the failure threshold to 10 (was 3).
+- vmstorage: remove readiness probe (reason: vminsert already handles routing and retries, and readiness probes can inadvertently introduce delays, DNS instability, and unnecessary disruptions)
+- all (except vmstorage): reduce the default readiness probe interval to 5s (was 15s) and the failure threshold to 10 (was 3).
 
 ## 0.16.2
 

--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -1591,10 +1591,10 @@ labels: {}
     tcpSocket: {}
     timeoutSeconds: 5
 readiness:
-    failureThreshold: 3
+    failureThreshold: 10
     httpGet: {}
     initialDelaySeconds: 5
-    periodSeconds: 15
+    periodSeconds: 5
     timeoutSeconds: 5
 startup: {}
 </code>
@@ -2531,10 +2531,10 @@ labels: {}
     tcpSocket: {}
     timeoutSeconds: 5
 readiness:
-    failureThreshold: 3
+    failureThreshold: 10
     httpGet: {}
     initialDelaySeconds: 5
-    periodSeconds: 15
+    periodSeconds: 5
     timeoutSeconds: 5
 startup: {}
 </code>
@@ -3435,10 +3435,10 @@ labels: {}
     tcpSocket: {}
     timeoutSeconds: 5
 readiness:
-    failureThreshold: 3
+    failureThreshold: 10
     httpGet: {}
     initialDelaySeconds: 5
-    periodSeconds: 15
+    periodSeconds: 5
     timeoutSeconds: 5
 startup: {}
 </code>
@@ -3952,11 +3952,11 @@ loggerFormat: json
         port: manager-http
     timeoutSeconds: 5
 readiness:
-    failureThreshold: 3
+    failureThreshold: 10
     httpGet:
         port: manager-http
     initialDelaySeconds: 5
-    periodSeconds: 15
+    periodSeconds: 5
     timeoutSeconds: 5
 startup: {}
 </code>

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -250,6 +250,7 @@ spec:
         {{- end }}
         {{- include "vm.license.volume" . | nindent 8 }}
       {{- end }}
+  minReadySeconds: {{ $app.minReadySeconds }}
   {{- if and $app.persistentVolume.enabled (not $app.persistentVolume.existingClaim) }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmauth_test.yaml.snap
@@ -49,13 +49,13 @@ deployment should match snapshot:
                 - containerPort: 8427
                   name: http
               readinessProbe:
-                failureThreshold: 3
+                failureThreshold: 10
                 httpGet:
                   path: /health
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
               volumeMounts:
                 - mountPath: /config
@@ -118,13 +118,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
                 - containerPort: 8427
                   name: http
               readinessProbe:
-                failureThreshold: 3
+                failureThreshold: 10
                 httpGet:
                   path: /health
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
               volumeMounts:
                 - mountPath: /config

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vminsert_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vminsert_test.yaml.snap
@@ -50,13 +50,13 @@ deployment should match snapshot:
                 - containerPort: 8480
                   name: http
               readinessProbe:
-                failureThreshold: 3
+                failureThreshold: 10
                 httpGet:
                   path: /health
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
           serviceAccountName: RELEASE-NAME-victoria-metrics-cluster
 deployment should match snapshot with fullnameOverride, extraLabels and podLabels:
@@ -113,12 +113,12 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
                 - containerPort: 8480
                   name: http
               readinessProbe:
-                failureThreshold: 3
+                failureThreshold: 10
                 httpGet:
                   path: /health
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
           serviceAccountName: RELEASE-NAME-victoria-metrics-cluster

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmselect_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmselect_test.yaml.snap
@@ -51,13 +51,13 @@ deployment should match snapshot:
                 - containerPort: 8481
                   name: http
               readinessProbe:
-                failureThreshold: 3
+                failureThreshold: 10
                 httpGet:
                   path: /health
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
               securityContext: {}
               volumeMounts:
@@ -123,13 +123,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
                 - containerPort: 8481
                   name: http
               readinessProbe:
-                failureThreshold: 3
+                failureThreshold: 10
                 httpGet:
                   path: /health
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
               securityContext: {}
               volumeMounts:
@@ -197,13 +197,13 @@ statefulset should match snapshot:
                 - containerPort: 8481
                   name: http
               readinessProbe:
-                failureThreshold: 3
+                failureThreshold: 10
                 httpGet:
                   path: /health
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
               securityContext: {}
               volumeMounts:
@@ -273,13 +273,13 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
                 - containerPort: 8481
                   name: http
               readinessProbe:
-                failureThreshold: 3
+                failureThreshold: 10
                 httpGet:
                   path: /health
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
               securityContext: {}
               volumeMounts:

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
@@ -40,13 +40,6 @@ statefulset should match snapshot:
                 - --storageDataPath=/storage
               image: victoriametrics/vmstorage:0.1.0-cluster
               imagePullPolicy: IfNotPresent
-              livenessProbe:
-                failureThreshold: 10
-                initialDelaySeconds: 30
-                periodSeconds: 30
-                tcpSocket:
-                  port: http
-                timeoutSeconds: 5
               name: vmstorage
               ports:
                 - containerPort: 8482
@@ -55,6 +48,15 @@ statefulset should match snapshot:
                   name: vminsert
                 - containerPort: 8401
                   name: vmselect
+              readinessProbe:
+                failureThreshold: 10
+                httpGet:
+                  path: /health
+                  port: http
+                  scheme: HTTP
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                timeoutSeconds: 5
               volumeMounts:
                 - mountPath: /storage
                   name: vmstorage-volume
@@ -115,13 +117,6 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
                 - --storageDataPath=/storage
               image: victoriametrics/vmstorage:0.1.0-cluster
               imagePullPolicy: IfNotPresent
-              livenessProbe:
-                failureThreshold: 10
-                initialDelaySeconds: 30
-                periodSeconds: 30
-                tcpSocket:
-                  port: http
-                timeoutSeconds: 5
               name: vmstorage
               ports:
                 - containerPort: 8482
@@ -130,6 +125,15 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
                   name: vminsert
                 - containerPort: 8401
                   name: vmselect
+              readinessProbe:
+                failureThreshold: 10
+                httpGet:
+                  path: /health
+                  port: http
+                  scheme: HTTP
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                timeoutSeconds: 5
               volumeMounts:
                 - mountPath: /storage
                   name: vmstorage-volume

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
@@ -13,6 +13,7 @@ statefulset should match snapshot:
       name: RELEASE-NAME-victoria-metrics-cluster-vmstorage
       namespace: NAMESPACE
     spec:
+      minReadySeconds: 5
       podManagementPolicy: OrderedReady
       replicas: 2
       selector:
@@ -89,6 +90,7 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
       name: vmstorage-node
       namespace: NAMESPACE
     spec:
+      minReadySeconds: 5
       podManagementPolicy: OrderedReady
       replicas: 2
       selector:

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
@@ -55,15 +55,6 @@ statefulset should match snapshot:
                   name: vminsert
                 - containerPort: 8401
                   name: vmselect
-              readinessProbe:
-                failureThreshold: 3
-                httpGet:
-                  path: /health
-                  port: http
-                  scheme: HTTP
-                initialDelaySeconds: 5
-                periodSeconds: 15
-                timeoutSeconds: 5
               volumeMounts:
                 - mountPath: /storage
                   name: vmstorage-volume
@@ -139,15 +130,6 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
                   name: vminsert
                 - containerPort: 8401
                   name: vmselect
-              readinessProbe:
-                failureThreshold: 3
-                httpGet:
-                  path: /health
-                  port: http
-                  scheme: HTTP
-                initialDelaySeconds: 5
-                periodSeconds: 15
-                timeoutSeconds: 5
               volumeMounts:
                 - mountPath: /storage
                   name: vmstorage-volume

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -1027,9 +1027,9 @@ vmstorage:
     readiness:
       httpGet: {}
       initialDelaySeconds: 5
-      periodSeconds: 15
+      periodSeconds: 5
       timeoutSeconds: 5
-      failureThreshold: 3
+      failureThreshold: 10
     # -- VMStorage liveness probe
     liveness:
       tcpSocket: {}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -1024,12 +1024,7 @@ vmstorage:
   # -- Readiness & Liveness probes
   probe:
     # -- VMStorage readiness probe
-    readiness:
-      httpGet: {}
-      initialDelaySeconds: 5
-      periodSeconds: 5
-      timeoutSeconds: 5
-      failureThreshold: 10
+    readiness: {}
     # -- VMStorage liveness probe
     liveness:
       tcpSocket: {}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -1021,7 +1021,8 @@ vmstorage:
     ipFamilies: []
   # -- Pod's termination grace period in seconds
   terminationGracePeriodSeconds: 60
-  # -- Readiness & Liveness probes
+  minReadySeconds: 5
+  # -- Readiness probes
   probe:
     # -- VMStorage readiness probe
     readiness:

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -1024,12 +1024,10 @@ vmstorage:
   # -- Readiness & Liveness probes
   probe:
     # -- VMStorage readiness probe
-    readiness: {}
-    # -- VMStorage liveness probe
-    liveness:
-      tcpSocket: {}
-      initialDelaySeconds: 30
-      periodSeconds: 30
+    readiness:
+      httpGet: {}
+      initialDelaySeconds: 5
+      periodSeconds: 5
       timeoutSeconds: 5
       failureThreshold: 10
     # -- VMStorage startup probe

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -109,9 +109,9 @@ vmselect:
     readiness:
       httpGet: {}
       initialDelaySeconds: 5
-      periodSeconds: 15
+      periodSeconds: 5
       timeoutSeconds: 5
-      failureThreshold: 3
+      failureThreshold: 10
     # -- VMSelect liveness probe
     liveness:
       tcpSocket: {}
@@ -389,9 +389,9 @@ vminsert:
     readiness:
       httpGet: {}
       initialDelaySeconds: 5
-      periodSeconds: 15
+      periodSeconds: 5
       timeoutSeconds: 5
-      failureThreshold: 3
+      failureThreshold: 10
     # -- VMInsert liveness probe
     liveness:
       tcpSocket: {}
@@ -639,9 +639,9 @@ vmauth:
     readiness:
       httpGet: {}
       initialDelaySeconds: 5
-      periodSeconds: 15
+      periodSeconds: 5
       timeoutSeconds: 5
-      failureThreshold: 3
+      failureThreshold: 10
     # -- VMAuth liveness probe
     liveness:
       tcpSocket: {}
@@ -1108,9 +1108,9 @@ vmstorage:
         httpGet:
           port: manager-http
         initialDelaySeconds: 5
-        periodSeconds: 15
+        periodSeconds: 5
         timeoutSeconds: 5
-        failureThreshold: 3
+        failureThreshold: 10
       # -- VMBackupManager liveness probe
       liveness:
         tcpSocket:


### PR DESCRIPTION
- Remove vmstorage liveness probe, as vminsert already handles routing and retries, while liveness probes can inadvertently introduce delays, DNS instability, and unnecessary disruptions.
- Reduce the default readiness probe interval to 5s (was 15s) and the failure threshold to 10 (was 3).
- Add a default minReadySeconds for vmstorage, to help stabilizing service during rollout.