### PR TITLE
add minReadySeconds option to statefulset

### DIFF
--- a/charts/victoria-metrics-cluster/README.md
+++ b/charts/victoria-metrics-cluster/README.md
@@ -3392,6 +3392,17 @@ labels: {}
 </td>
     </tr>
     <tr>
+      <td>vmstorage.minReadySeconds</td>
+      <td>int</td>
+      <td><pre class="helm-vars-default-value language-yaml" lang="">
+<code class="language-yaml">0
+</code>
+</pre>
+</td>
+      <td><p>Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available.</p>
+</td>
+    </tr>
+    <tr>
       <td>vmstorage.podSecurityContext</td>
       <td>object</td>
       <td><pre class="helm-vars-default-value language-yaml" lang="plaintext">

--- a/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-statefulset.yaml
@@ -21,6 +21,7 @@ spec:
     matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 6 }}
   replicas: {{ $app.replicaCount }}
   podManagementPolicy: {{ $app.podManagementPolicy }}
+  minReadySeconds: {{ $app.minReadySeconds }}
   template:
     metadata:
       {{- with $app.podAnnotations }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -977,7 +977,9 @@ vmstorage:
   # -- Container workdir
   containerWorkingDir: ""
   # -- Deploy order policy for StatefulSet pods
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: OrderedReady 
+  # -- Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available.
+  minReadySeconds: 0
   # -- Resource object. Details are [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources: {}
     # limits:


### PR DESCRIPTION
Add minReadySeconds to storage Statefulset to allow users to set the minimum ready time before continuing rollout.