### PR TITLE
fix release ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,7 +141,8 @@ jobs:
           git add charts/*/README.md
           git commit -S -m "Automatic update CHANGELOGs and READMEs"
           git push origin ${VM_GIT_BRANCH_NAME}
-          gh pr create -f
+          gh pr create \
+          --head $(git branch --show-current)
         env:
           GH_TOKEN: "${{ secrets.VM_BOT_GH_TOKEN }}"
           GITHUB_TOKEN: "${{ secrets.VM_BOT_GH_TOKEN }}"


### PR DESCRIPTION
The [latest release](https://github.com/VictoriaMetrics/helm-charts/actions/runs/12687268684/job/35361372478) failed when trying to create pull request:
```
aborted: you must first push the current branch to a remote, or use the --head flag
```

It's a [known issue](https://github.com/cli/cli/issues/6485#issuecomment-2560935183) with workaround, but I don't see a fix.