### PR TITLE
victoria-metrics-distributed: fix typo

### DIFF
--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-distributed
 description: A Helm chart for Running VMCluster on Multiple Availability Zones
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: "v1.108.1"
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-distributed/templates/per-az/vmagent.yaml
+++ b/charts/victoria-metrics-distributed/templates/per-az/vmagent.yaml
@@ -39,7 +39,8 @@ metadata:
 {{- end }}
 {{- $_ := set $zone.vmagent.spec "remoteWrite" (concat $remoteWrites ($zone.vmagent.spec.remoteWrites | default list)) }}
 {{- if $isMultitenant }}
-  {{- $_ := set $zone.vmagent.spec "remoteWriteSettings" (dict "useMultitenantMode" true) }}
+  {{- $remoteWriteSettings := (dict "useMultiTenantMode" true) }}
+  {{- $_ := set $zone.vmagent.spec "remoteWriteSettings" (mergeOverwrite (deepcopy ($zone.vmagent.spec.remoteWriteSettings | default dict)) $remoteWriteSettings) }}
 {{- end }}
 spec: {{ tpl (toYaml $zone.vmagent.spec) $ctx | nindent 2 }}
 {{- end }}

--- a/charts/victoria-metrics-distributed/templates/per-az/vmagent.yaml
+++ b/charts/victoria-metrics-distributed/templates/per-az/vmagent.yaml
@@ -40,7 +40,7 @@ metadata:
 {{- $_ := set $zone.vmagent.spec "remoteWrite" (concat $remoteWrites ($zone.vmagent.spec.remoteWrites | default list)) }}
 {{- if $isMultitenant }}
   {{- $remoteWriteSettings := (dict "useMultiTenantMode" true) }}
-  {{- $_ := set $zone.vmagent.spec "remoteWriteSettings" (mergeOverwrite (deepcopy ($zone.vmagent.spec.remoteWriteSettings | default dict)) $remoteWriteSettings) }}
+  {{- $_ := set $zone.vmagent.spec "remoteWriteSettings" (mergeOverwrite (deepCopy ($zone.vmagent.spec.remoteWriteSettings | default dict)) $remoteWriteSettings) }}
 {{- end }}
 spec: {{ tpl (toYaml $zone.vmagent.spec) $ctx | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
- Fix typo `useMultitenantMode` -> `useMultiTenantMode` in remotewrite settings 
  https://docs.victoriametrics.com/operator/api/#vmagentremotewritesettings
- Allow passing additional remotewrite setings