### PR TITLE
Grafana VM DS: do not check allow_loading_unsigned_plugins

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Grafana datasource: do not verify allow_loading_unsigned_plugins in k8s-stack
 
 ## 0.35.1
 

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -264,9 +264,7 @@
         {{- end }}
       {{- end }}
     {{- end }}
-    {{- $unsignedPlugins := ((index $grafana "grafana.ini").plugins).allow_loading_unsigned_plugins | default "" -}}
-    {{- $allowUnsigned := contains "victoriametrics-metrics-datasource" $unsignedPlugins -}}
-    {{- ternary "true" "" (and $isEnabled $allowUnsigned) -}}
+    {{- ternary "true" "" $isEnabled -}}
   {{- else -}}
     {{ "true" }}
   {{- end }}


### PR DESCRIPTION
VM Metrics Grafana plugin is signed, this check is obsolete. Ref: https://github.com/VictoriaMetrics/victoriametrics-datasource/commit/35e86ad39ba270b820c91778ed779419cbb8d729