### PR TITLE
operator: added default security context

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- Fixed minor securityContext template typo
 
 ## 0.0.37
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: Victoria Metrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.0.37
+version: 0.0.38
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_pod.tpl
+++ b/charts/victoria-metrics-common/templates/_pod.tpl
@@ -24,16 +24,13 @@ Usage:
 {{- include "vm.securityContext" (dict "securityContext" .Values.containerSecurityContext "helm" .) -}}
 */ -}}
 {{- define "vm.securityContext" -}}
-  {{- $securityContext := .securityContext -}}
+  {{- $securityContext := omit .securityContext "enabled" -}}
   {{- $Values := (.helm).Values | default .Values -}}
   {{- $adaptMode := (((($Values).global).compatibility).openshift).adaptSecurityContext | default "" -}}
   {{- if or (eq $adaptMode "force") (and (eq $adaptMode "auto") (include "vm.isOpenshift" .)) -}}
-    {{- $securityContext = omit $securityContext "fsGroup" "runAsUser" "runAsGroup" -}}
-    {{- if not $securityContext.seLinuxOptions -}}
-      {{- $securityContext = omit $securityContext "seLinuxOptions" -}}
-    {{- end -}}
+    {{- $securityContext = omit $securityContext "fsGroup" "runAsUser" "runAsGroup" "seLinuxOptions" -}}
   {{- end -}}
-  {{- omit $securityContext "enabled" | toYaml -}}
+  {{- toYaml $securityContext -}}
 {{- end -}}
 
 {{- /*

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add `.Values.defaultDatasources.grafanaOperator` section to manage datasources using Grafana operator. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1964) for details.
 
 ## 0.35.3
 

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -304,7 +304,7 @@
       {{- $datasources = append $datasources $ds -}}
     {{- end }}
   {{- end -}}
-  {{- toYaml $datasources -}}
+  {{- toYaml (dict "datasources" $datasources) -}}
 {{- end }}
 
 {{- /* VMRule name */ -}}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
@@ -1,7 +1,29 @@
 {{- if or (and .Values.grafana.enabled .Values.grafana.sidecar.datasources.enabled ) .Values.grafana.forceDeployDatasource }}
 {{- $ctx := dict "helm" . }}
+{{- $grafanaOperator := .Values.defaultDatasources.grafanaOperator }}
 {{- $fullname := include "vm.fullname" $ctx }}
-{{- with (include "vm.data.sources" .) }}
+{{- $output := include "vm.data.sources" . | fromYaml }}
+{{- if $grafanaOperator.enabled }}
+{{- range $ds := $output.datasources }}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  namespace: {{ include "vm.namespace" $ }}
+  name: {{ $fullname }}-{{ lower $ds.name }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- with $grafanaOperator.annotations }}
+  annotations:
+    {{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  datasource: {{ toYaml $ds | nindent 4 }}
+  {{- toYaml $grafanaOperator.spec | nindent 2 }}
+{{- end }}
+{{- else }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,6 +40,6 @@ metadata:
 data:
   datasource.yaml: |-
     apiVersion: 1
-    datasources: {{ . | nindent 6 }}
+    datasources: {{ toYaml $output.datasources | nindent 6 }}
 {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -802,6 +802,15 @@ vmagent:
     #      - vmagent.domain.com
 
 defaultDatasources:
+  grafanaOperator:
+    # -- Create datasources as CRDs (requires grafana-operator to be installed)
+    enabled: false
+    annotations: {}
+    spec:
+      instanceSelector:
+        matchLabels:
+          dashboards: grafana
+      allowCrossNamespaceImport: false
   victoriametrics:
     # -- Create per replica prometheus compatible datasource
     perReplica: false
@@ -834,7 +843,7 @@ defaultDatasources:
     #   basicAuthUser: daco
     #   editable: false
     #   jsonData:
-    #       tlsSkipVerify: true
+    #     tlsSkipVerify: true
     #   orgId: 1
     #   type: prometheus
     #   url: https://{{ printf "%s-prometheus.svc" .Release.Name }}:9090

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Added default values for securityContext and podSecurityContext
 
 ## 0.41.0
 

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -92,10 +92,18 @@ annotations: {}
 # -- Pod's security context. Details are [here](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 podSecurityContext:
   enabled: true
+  fsGroup: 2000
+  runAsNonRoot: true
+  runAsUser: 1000
 
 # -- Security context to be added to server pods
 securityContext:
   enabled: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
 
 operator:
   # -- By default, operator converts prometheus-operator objects.


### PR DESCRIPTION
- operator chart has `securityContext.enabled: true`, but it has no impact as it has no security context defined. adding default one. fixes https://github.com/VictoriaMetrics/helm-charts/issues/1960
- adding GrafanaDatasource support as an alternative to configMap. fixes https://github.com/VictoriaMetrics/helm-charts/issues/1964
- fixed minor issue in vm.securityContext common template