### PR TITLE
k8s-stack: added ability to use VMAlertmanagerConfig instead of plain k8s Secret. 

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Added .Values.alertmanager.useManagedConfig to switch storing Alertmanager config in VMAlertmanagerConfig CR instead of k8s Secret. See [this issue](https://github.com/VictoriaMetrics/helm-charts/issues/1968).
 
 ## 0.35.6
 

--- a/charts/victoria-metrics-k8s-stack/README.md
+++ b/charts/victoria-metrics-k8s-stack/README.md
@@ -515,8 +515,6 @@ Change the values according to the need of the environment in ``victoria-metrics
     - name: blackhole
 route:
     receiver: blackhole
-templates:
-    - /etc/vm/configs/**/*.tmpl
 </code>
 </pre>
 </td>
@@ -613,6 +611,17 @@ selectAllByDefault: true
 </pre>
 </td>
       <td><p>Extra alert templates</p>
+</td>
+    </tr>
+    <tr>
+      <td>alertmanager.useManagedConfig</td>
+      <td>bool</td>
+      <td><pre class="helm-vars-default-value language-yaml" lang="">
+<code class="language-yaml">false
+</code>
+</pre>
+</td>
+      <td><p>enable storing .Values.alertmanager.config in VMAlertmanagerConfig instead of k8s Secret</p>
 </td>
     </tr>
     <tr>

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -190,7 +190,7 @@
   {{- $Values := (.helm).Values | default .Values }}
   {{- $fullname := include "vm.managed.fullname" . -}}
   {{- $spec := $Values.alertmanager.spec -}}
-  {{- if and (not $Values.alertmanager.spec.configRawYaml) (not $Values.alertmanager.spec.configSecret) -}}
+  {{- if and (not $spec.configRawYaml) (not $spec.configSecret) (not $Values.alertmanager.useManagedConfig) -}}
     {{- $_ := set $spec "configSecret" $fullname -}}
   {{- end -}}
   {{- $templates := default list -}}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/vmalertmanager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/alertmanager/vmalertmanager.yaml
@@ -5,7 +5,18 @@
   {{- if and $app.spec.configRawYaml $app.config }}
     {{- fail "ERROR: Both .Values.alertmanager.spec.configRawYaml and .Values.alertmanager.config are set, but only one is allowed." }}
   {{- end }}
+  {{- $fullname := include "vm.cr.fullname" $ctx }}
   {{- if and (not $app.spec.configSecret) (not $app.spec.configRawYaml) }}
+  {{- if $app.useManagedConfig }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMAlertmanagerConfig
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+spec: {{ toYaml .Values.alertmanager.config | nindent 2 }}
+  {{- else }}
 ---
 apiVersion: v1
 kind: Secret
@@ -15,6 +26,9 @@ metadata:
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
 stringData:
   alertmanager.yaml: |{{ toYaml .Values.alertmanager.config | nindent 4 }}
+    templates:
+      - "/etc/vm/configs/**/*.tmpl"
+  {{- end }}
   {{- end }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
@@ -23,7 +37,7 @@ metadata:
   {{- with .Values.alertmanager.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end  }}
-  name: {{ include "vm.cr.fullname" $ctx }}
+  name: {{ $fullname }}
   namespace: {{ $ns }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
 spec: {{ include "vm.alertmanager.spec" $ctx | nindent 2 }}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -514,33 +514,33 @@ alertmanager:
 
     # -- (string) If this one defined, it will be used for alertmanager configuration and config parameter will be ignored
     configSecret: ""
+  # -- enable storing .Values.alertmanager.config in VMAlertmanagerConfig instead of k8s Secret
+  useManagedConfig: false
   # -- (object) Alertmanager configuration
   config:
-    templates:
-      - "/etc/vm/configs/**/*.tmpl"
     route:
-      # group_by: ["alertgroup", "job"]
-      # group_wait: 30s
-      # group_interval: 5m
-      # repeat_interval: 12h
       receiver: "blackhole"
-      ## routes:
-        ###################################################
-        ## Duplicate code_owner routes to teams
-        ## These will send alerts to team channels but continue
-        ## processing through the rest of the tree to handled by on-call
-        # - matchers:
-        #     - code_owner_channel!=""
-        #     - severity=~"info|warning|critical"
-        #   group_by: ["code_owner_channel", "alertgroup", "job"]
-        #   receiver: slack-code-owners
-        # ###################################################
-        # ## Standard on-call routes
-        # - matchers:
-        #     - severity=~"info|warning|critical"
-        #   receiver: slack-monitoring
-        #   continue: true
-
+    #   group_by: ["alertgroup", "job"]
+    #   group_wait: 30s
+    #   group_interval: 5m
+    #   repeat_interval: 12h
+    #   routes:
+    #
+    #     # Duplicate code_owner routes to teams
+    #     # These will send alerts to team channels but continue
+    #     # processing through the rest of the tree to handled by on-call
+    #     - matchers:
+    #         - code_owner_channel!=""
+    #         - severity=~"info|warning|critical"
+    #       group_by: ["code_owner_channel", "alertgroup", "job"]
+    #       receiver: slack-code-owners
+    #
+    #     # Standard on-call routes
+    #     - matchers:
+    #         - severity=~"info|warning|critical"
+    #       receiver: slack-monitoring
+    #       continue: true
+    #
     # inhibit_rules:
     #   - target_matchers:
     #       - severity=~"warning|info"
@@ -568,55 +568,55 @@ alertmanager:
 
     receivers:
       - name: blackhole
-      # - name: "slack-monitoring"
-      #   slack_configs:
-      #     - channel: "#channel"
-      #       send_resolved: true
-      #       title: '{{ template "slack.monzo.title" . }}'
-      #       icon_emoji: '{{ template "slack.monzo.icon_emoji" . }}'
-      #       color: '{{ template "slack.monzo.color" . }}'
-      #       text: '{{ template "slack.monzo.text" . }}'
-      #       actions:
-      #         - type: button
-      #           text: "Runbook :green_book:"
-      #           url: "{{ (index .Alerts 0).Annotations.runbook_url }}"
-      #         - type: button
-      #           text: "Query :mag:"
-      #           url: "{{ (index .Alerts 0).GeneratorURL }}"
-      #         - type: button
-      #           text: "Dashboard :grafana:"
-      #           url: "{{ (index .Alerts 0).Annotations.dashboard }}"
-      #         - type: button
-      #           text: "Silence :no_bell:"
-      #           url: '{{ template "__alert_silence_link" . }}'
-      #         - type: button
-      #           text: '{{ template "slack.monzo.link_button_text" . }}'
-      #           url: "{{ .CommonAnnotations.link_url }}"
-      # - name: slack-code-owners
-      #   slack_configs:
-      #     - channel: "#{{ .CommonLabels.code_owner_channel }}"
-      #       send_resolved: true
-      #       title: '{{ template "slack.monzo.title" . }}'
-      #       icon_emoji: '{{ template "slack.monzo.icon_emoji" . }}'
-      #       color: '{{ template "slack.monzo.color" . }}'
-      #       text: '{{ template "slack.monzo.text" . }}'
-      #       actions:
-      #         - type: button
-      #           text: "Runbook :green_book:"
-      #           url: "{{ (index .Alerts 0).Annotations.runbook }}"
-      #         - type: button
-      #           text: "Query :mag:"
-      #           url: "{{ (index .Alerts 0).GeneratorURL }}"
-      #         - type: button
-      #           text: "Dashboard :grafana:"
-      #           url: "{{ (index .Alerts 0).Annotations.dashboard }}"
-      #         - type: button
-      #           text: "Silence :no_bell:"
-      #           url: '{{ template "__alert_silence_link" . }}'
-      #         - type: button
-      #           text: '{{ template "slack.monzo.link_button_text" . }}'
-      #           url: "{{ .CommonAnnotations.link_url }}"
-      #
+    # - name: "slack-monitoring"
+    #   slack_configs:
+    #     - channel: "#channel"
+    #       send_resolved: true
+    #       title: '{{ template "slack.monzo.title" . }}'
+    #       icon_emoji: '{{ template "slack.monzo.icon_emoji" . }}'
+    #       color: '{{ template "slack.monzo.color" . }}'
+    #       text: '{{ template "slack.monzo.text" . }}'
+    #       actions:
+    #         - type: button
+    #           text: "Runbook :green_book:"
+    #           url: "{{ (index .Alerts 0).Annotations.runbook_url }}"
+    #         - type: button
+    #           text: "Query :mag:"
+    #           url: "{{ (index .Alerts 0).GeneratorURL }}"
+    #         - type: button
+    #           text: "Dashboard :grafana:"
+    #           url: "{{ (index .Alerts 0).Annotations.dashboard }}"
+    #         - type: button
+    #           text: "Silence :no_bell:"
+    #           url: '{{ template "__alert_silence_link" . }}'
+    #         - type: button
+    #           text: '{{ template "slack.monzo.link_button_text" . }}'
+    #           url: "{{ .CommonAnnotations.link_url }}"
+    # - name: slack-code-owners
+    #   slack_configs:
+    #     - channel: "#{{ .CommonLabels.code_owner_channel }}"
+    #       send_resolved: true
+    #       title: '{{ template "slack.monzo.title" . }}'
+    #       icon_emoji: '{{ template "slack.monzo.icon_emoji" . }}'
+    #       color: '{{ template "slack.monzo.color" . }}'
+    #       text: '{{ template "slack.monzo.text" . }}'
+    #       actions:
+    #         - type: button
+    #           text: "Runbook :green_book:"
+    #           url: "{{ (index .Alerts 0).Annotations.runbook }}"
+    #         - type: button
+    #           text: "Query :mag:"
+    #           url: "{{ (index .Alerts 0).GeneratorURL }}"
+    #         - type: button
+    #           text: "Dashboard :grafana:"
+    #           url: "{{ (index .Alerts 0).Annotations.dashboard }}"
+    #         - type: button
+    #           text: "Silence :no_bell:"
+    #           url: '{{ template "__alert_silence_link" . }}'
+    #         - type: button
+    #           text: '{{ template "slack.monzo.link_button_text" . }}'
+    #           url: "{{ .CommonAnnotations.link_url }}"
+    #
   # -- Better alert templates for [slack source](https://gist.github.com/milesbxf/e2744fc90e9c41b47aa47925f8ff6512)
   monzoTemplate:
     enabled: true


### PR DESCRIPTION
Disabled by default as it requires migration for existing setups
Fixes #1968