### PR TITLE
charts/operator: fix cleanup hook does not use global imagePullSecrets

### DIFF
--- a/charts/victoria-metrics-operator/templates/cleanup.yaml
+++ b/charts/victoria-metrics-operator/templates/cleanup.yaml
@@ -24,7 +24,7 @@ spec:
       labels: {{ include "vm.labels" $ctx | nindent 8 }}
     spec:
       serviceAccountName: {{ $fullname }}-cleanup-hook
-      {{- with .Values.imagePullSecrets }}
+      {{- with (.Values.imagePullSecrets | default .Values.global.imagePullSecrets) }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
       {{- end }}
       containers:


### PR DESCRIPTION
`.Values.global.imagePullSecrets` is ignored during cleanup hook creation, causing issue when fetching image from private registry + using global value

Fixes #2002