### PR TITLE
charts/victoria-logs-single: fix service not being rendered

### DIFF
--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- fix service not being deployed with default `.Values` configuration.
 
 ## 0.9.0
 

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 appVersion: v1.14.0
 description: Victoria Logs Single version - high-performance, cost-effective and scalable logs storage
 name: victoria-logs-single
-version: 0.9.0
+version: 0.9.1
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/templates/server-service.yaml
+++ b/charts/victoria-logs-single/templates/server-service.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $mode := $app.mode }}
 {{- $service := $app.service }}
-{{- if and $app.enabled $service.enabled -}}
+{{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "server" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}


### PR DESCRIPTION
`.Values.server.service.enabled` option does not exist, so the check is always failing. This leads to service being deleted after the upgrade.