### PR TITLE
single: revert serviceName removal from statefulSet mode

### DIFF
--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Reverted serviceName removal, which was done in 0.9.0 release
 
 ## 0.9.1
 

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 appVersion: v1.14.0
 description: Victoria Logs Single version - high-performance, cost-effective and scalable logs storage
 name: victoria-logs-single
-version: 0.9.1
+version: 0.9.2
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/templates/server.yaml
+++ b/charts/victoria-logs-single/templates/server.yaml
@@ -24,6 +24,9 @@ spec:
   {{- toYaml . | nindent 2 }}
   {{- end }}
   replicas: {{ $app.replicaCount }}
+  {{- if eq $mode "statefulSet" }}
+  serviceName: {{ $fullname }}
+  {{- end }}
   selector:
     matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 6 }}
   template:

--- a/charts/victoria-logs-single/tests/__snapshot__/server_test.yaml.snap
+++ b/charts/victoria-logs-single/tests/__snapshot__/server_test.yaml.snap
@@ -20,6 +20,7 @@ deployment should match snapshot:
           app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
+      serviceName: RELEASE-NAME-victoria-logs-single-server
       template:
         metadata:
           labels:
@@ -98,6 +99,7 @@ deployment with volume should match snapshot:
           app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
+      serviceName: RELEASE-NAME-victoria-logs-single-server
       template:
         metadata:
           labels:
@@ -176,6 +178,7 @@ statefulset should match snapshot:
           app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
+      serviceName: RELEASE-NAME-victoria-logs-single-server
       template:
         metadata:
           labels:
@@ -254,6 +257,7 @@ statefulset with volume should match snapshot:
           app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
+      serviceName: RELEASE-NAME-victoria-logs-single-server
       template:
         metadata:
           labels:

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Reverted serviceName removal, which was done in 0.14.0 release
 
 ## 0.14.1
 

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Victoria Metrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.14.1
+version: 0.14.2
 appVersion: v1.112.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-single/templates/server.yaml
+++ b/charts/victoria-metrics-single/templates/server.yaml
@@ -21,6 +21,9 @@ spec:
   {{- toYaml . | nindent 2 }}
   {{- end }}
   replicas: {{ $app.replicaCount }}
+  {{- if eq $mode "statefulSet" }}
+  serviceName: {{ $fullname }}
+  {{- end }}
   selector:
     matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 6 }}
   template:


### PR DESCRIPTION
serviceName removal makes smooth upgrade impossible and requires statefulset recreation. reverting it back