### PR TITLE
victoria-metrics-cluster: Add `.vminsert.terminationGracePeriodSecond…

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - updated common dependency 0.0.39 -> 0.0.42
+- add `.vminsert.terminationGracePeriodSeconds` to support changing the terminationGracePeriodSeconds for vminsert deployment
 
 ## 0.19.2
 

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Victoria Metrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.19.2
+version: 0.19.3
 appVersion: v1.113.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
@@ -145,6 +145,7 @@ spec:
       {{- with $app.topologySpreadConstraints }}
       topologySpreadConstraints: {{ toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ $app.terminationGracePeriodSeconds }}
       {{- if or (and (include "vm.license.secret.key" .) (include "vm.license.secret.name" .)) $app.extraVolumes $app.relabel.enabled }}
       volumes:
         {{- if $app.relabel.enabled }}

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vminsert_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vminsert_test.yaml.snap
@@ -59,6 +59,7 @@ deployment should match snapshot:
                 periodSeconds: 5
                 timeoutSeconds: 5
           serviceAccountName: RELEASE-NAME-victoria-metrics-cluster
+          terminationGracePeriodSeconds: 30
 deployment should match snapshot with fullnameOverride, extraLabels and podLabels:
   1: |
     apiVersion: apps/v1
@@ -122,3 +123,4 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
                 periodSeconds: 5
                 timeoutSeconds: 5
           serviceAccountName: RELEASE-NAME-victoria-metrics-cluster
+          terminationGracePeriodSeconds: 30

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -396,6 +396,7 @@ vminsert:
   extraLabels: {}
   # -- Pod’s additional labels
   podLabels: {}
+  terminationGracePeriodSeconds: 30
 
   # -- Additional environment variables (ex.: secret tokens, flags). Check [here](https://docs.victoriametrics.com/#environment-variables) for details.
   env: []


### PR DESCRIPTION
…s` to support changing the terminationGracePeriodSeconds for vminsert deployment