### PR TITLE
feat: Add posibility to template ingress annotations

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/ingress.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   {{- $_ := set $ctx "extraLabels" $ingress.labels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- with $ingress.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- with $ingress.ingressClassName }}


### PR DESCRIPTION
Annotations templating can be useful to template some variables like cluster name in some controller used annotation like externalDns