### PR TITLE
[k8s-stack] chore(deps): upgrade node-exporter chart to v4.45.x

### DIFF
--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.42.0
+version: 0.43.0
 appVersion: v1.115.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
@@ -45,7 +45,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-state-metrics.enabled
   - name: prometheus-node-exporter
-    version: "4.44.*"
+    version: "4.45.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-node-exporter.enabled
   - name: grafana


### PR DESCRIPTION
This will upgrade the [node-exporter docker image](quay.io/prometheus/node-exporter) to the latest available v1.9.1 (as of date)
