### PR TITLE
distributed: support substituting VMAuth with k8s Service

### DIFF
--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Support ability to substitute VMAuth load balancers with k8s Service for setups, which support custom load balancing.
 
 ## 0.13.0
 

--- a/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
+++ b/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
@@ -1,13 +1,43 @@
 {{- $ctx := dict "helm" . }}
 {{- $urlCtx := dict "helm" . }}
 {{- $fullname := include "vm.fullname" . }}
+{{- $_ := set $ctx "fullname" $fullname }}
+{{- $commonAuth := dict "spec" ((((.Values).common).vmauth).spec | default dict) }}
+{{- $auth := mergeOverwrite (deepCopy $commonAuth) (deepCopy ((((.Values).read).global).vmauth | default dict)) }}
+
+{{- $_ := set $ctx "style" "managed" }}
+{{- $urls := default list }}
+{{- $components := default list }}
+{{- range $i, $z := $.Values.availabilityZones }}
+  {{- $zone := mergeOverwrite (deepCopy $.Values.zoneTpl) $z }}
+  {{- if (((($.Values).read).global).vmauth).enabled }}
+    {{- if $zone.read.vmauth.enabled -}}
+      {{- $authSpec := (($zone.read).vmauth).spec | default dict }}
+      {{- $_ := set $zone.read.vmauth "spec" (mergeOverwrite (deepCopy $commonAuth.spec) $authSpec) }}
+      {{- $_ := set $ctx "zone" $zone }}
+      {{- $_ := set $ctx "appKey" (list "zone" "read" "vmauth" "spec") }}
+      {{- $urls = append $urls (include "vm.url" $ctx) }}
+    {{- end -}}
+  {{- else -}}
+    {{- if $zone.read.vmauth.enabled }}
+      {{- fail "Cross zone VMAuth is not expected to be enabled, when global read balancer is disabled" }}
+    {{- end }}
+    {{- if $zone.vmcluster.enabled }}
+      {{- $clusterName := tpl $zone.vmcluster.name (dict "zone" $z) }}
+      {{- $components = append $components (printf "vmselect-%s" $clusterName) }}
+    {{- else if $zone.vmsingle.enabled }}
+      {{- $singleName := tpl $zone.vmsingle.name (dict "zone" $z) }}
+      {{- $components = append $components (printf "vmsingle-%s" $singleName) }}
+    {{- end -}}
+  {{- end -}}
+{{- end }}
+{{- $_ := unset $ctx "style" }}
+
+{{- $_ := set $ctx "appKey" (list "vmauth" "spec") }}
+{{- $_ := set $ctx "fullname" $fullname }}
+{{- $_ := set $ctx "vmauth" $auth }}
+
 {{- if ((((.Values).read).global).vmauth).enabled }}
-  {{- $commonAuth := dict "spec" ((((.Values).common).vmauth).spec | default dict) }}
-  {{- $auth := .Values.read.global.vmauth | default dict }}
-  {{- $auth = mergeOverwrite (deepCopy $commonAuth) (deepCopy $auth) }}
-  {{- $_ := set $ctx "appKey" (list "vmauth" "spec") }}
-  {{- $_ := set $ctx "fullname" $fullname }}
-  {{- $_ := set $ctx "vmauth" $auth }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAuth
@@ -43,5 +73,25 @@ metadata:
   {{- $_ := set $accessSpec "url_map" (prepend (slice $urlMap 1) $firstUrlMapItem) }}
   {{- $_ := set $spec "unauthorizedUserAccessSpec" $accessSpec }}
 spec: {{ tpl (toYaml $spec) $ctx | nindent 2 }}
+{{- else -}}
+{{- if empty $components }}
+  {{- fail "Failed to setup global service. No clusters enabled" -}}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vm.cr.fullname" $ctx }}
+  namespace: {{ include "vm.namespace" $ctx }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+spec:
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values: {{ toJson $components }}
+  ports:
+    - protocol: TCP
+      port: {{ $auth.spec.port }}
+      targetPort: http
 {{- end }}
 

--- a/charts/victoria-metrics-distributed/templates/vmauth-write.yaml
+++ b/charts/victoria-metrics-distributed/templates/vmauth-write.yaml
@@ -1,13 +1,32 @@
 {{- $ctx := dict "helm" . }}
 {{- $urlCtx := dict "helm" . }}
 {{- $fullname := include "vm.fullname" . }}
+{{- $_ := set $ctx "fullname" $fullname }}
+{{- $commonAuth := dict "spec" ((((.Values).common).vmauth).spec | default dict) }}
+{{- $auth := mergeOverwrite (deepCopy $commonAuth) (deepCopy ((((.Values).write).global).vmauth | default dict)) }}
+
+{{- $_ := set $ctx "style" "managed" }}
+{{- $urls := default list }}
+{{- $components := default list }}
+{{- $commonAgentSpec := (((.Values).common).vmagent).spec | default dict }}
+{{- range $i, $z := $.Values.availabilityZones }}
+  {{- $zone := mergeOverwrite (deepCopy $.Values.zoneTpl) $z }}
+  {{- if $zone.vmagent.enabled -}}
+    {{- $agentSpec := $zone.vmagent.spec | default dict }}
+    {{- $components = append $components (printf "vmagent-%s" (tpl $zone.vmagent.name (dict "zone" $z))) }}
+    {{- $_ := set $zone.vmagent "spec" (mergeOverwrite (deepCopy $commonAgentSpec) $agentSpec) }}
+    {{- $_ := set $ctx "zone" $zone }}
+    {{- $_ := set $ctx "appKey" (list "zone" "vmagent" "spec") }}
+    {{- $urls = append $urls (include "vm.url" $ctx) }}
+  {{- end -}}
+{{- end }}
+{{- $_ := unset $ctx "style" }}
+
+{{- $_ := set $ctx "appKey" (list "vmauth" "spec") }}
+{{- $_ := set $ctx "fullname" $fullname }}
+{{- $_ := set $ctx "vmauth" $auth }}
+
 {{- if ((((.Values).write).global).vmauth).enabled }}
-  {{- $commonAuth := dict "spec" ((((.Values).common).vmauth).spec | default dict) }}
-  {{- $auth := .Values.write.global.vmauth | default dict }}
-  {{- $auth = mergeOverwrite (deepCopy $commonAuth) (deepCopy $auth) }}
-  {{- $_ := set $ctx "appKey" (list "vmauth" "spec") }}
-  {{- $_ := set $ctx "fullname" $fullname }}
-  {{- $_ := set $ctx "vmauth" $auth }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAuth
@@ -45,4 +64,24 @@ metadata:
   {{- $_ := set $accessSpec "url_map" (prepend (slice $urlMap 1) $firstUrlMapItem) }}
   {{- $_ := set $spec "unauthorizedUserAccessSpec" $accessSpec }}
 spec: {{ tpl (toYaml $spec) $ctx | nindent 2 }}
+{{- else -}}
+{{- if empty $components }}
+  {{- fail "Failed to setup global service. No clusters enabled" -}}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vm.cr.fullname" $ctx }}
+  namespace: {{ include "vm.namespace" $ctx }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+spec:
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values: {{ toJson $components }}
+  ports:
+    - protocol: TCP
+      port: {{ $auth.spec.port }}
+      targetPort: http
 {{- end }}


### PR DESCRIPTION
may be useful for setups which have built-in load balancing, e.g: istio
In this setup k8s services are placed instead of global read and write load balancers, which target VMSelects and VMAgents respectively, cross zone balancer should be disabled