### PR TITLE
Allow overriding the load balancing policy for unauth access

### DIFF
--- a/charts/victoria-metrics-distributed/templates/per-az/vmauth-read-proxy.yaml
+++ b/charts/victoria-metrics-distributed/templates/per-az/vmauth-read-proxy.yaml
@@ -25,7 +25,8 @@ spec: {{ tpl (toYaml (omit $spec "unauthorizedUserAccessSpec")) $ctx | nindent 2
     url_map:
       - src_paths:
           - "/select/.+"
-        load_balancing_policy: first_available
+        {{- $url_map := ($spec.unauthorizedUserAccessSpec).url_map }}
+        load_balancing_policy: {{ if $url_map }}{{ $url_map | first | dig "load_balancing_policy" "first_available" }}{{ else }}first_available{{ end }}
         retry_status_codes:
           - 503
         {{- $_ := set $ctx "style" "managed" }}

--- a/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
+++ b/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
@@ -25,7 +25,8 @@ spec:
     url_map:
       - src_paths:
           - "/select/.+"
-        load_balancing_policy: first_available
+        {{- $url_map := (($auth.spec).unauthorizedUserAccessSpec).url_map }}
+        load_balancing_policy: {{ if $url_map }}{{ $url_map | first | dig "load_balancing_policy" "first_available" }}{{ else }}first_available{{ end }}
         {{- $_ := set $ctx "style" "managed" }}
         {{- $urls := default list }}
         {{- range $i, $z := $.Values.availabilityZones }}


### PR DESCRIPTION
The motivation is that the hard-coded load balancing policy of `first_available` leaves half the vmselect instances unused. The change optionally overrides it when a different one is set in the spec, otherwise it continues to use the same default. It uses the same structure as in the [API ](https://docs.victoriametrics.com/operator/api/index.html#vmauthunauthorizeduseraccessspec)