### PR TITLE
distributed: fix read vmauth retry status codes

### DIFF
--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - allow overriding vmauth unauthorizedUserAccessSpec options
+- fix read vmauth retry status codes, to cover more cases
 
 ## 0.12.1
 

--- a/charts/victoria-metrics-distributed/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-metrics-distributed/tests/__snapshot__/vmauth_test.yaml.snap
@@ -93,6 +93,8 @@ vmauth should match snapshot:
         url_map:
           - load_balancing_policy: first_available
             retry_status_codes:
+              - 500
+              - 502
               - 503
             src_paths:
               - /select/.+
@@ -127,6 +129,8 @@ vmauth should match snapshot:
         url_map:
           - load_balancing_policy: first_available
             retry_status_codes:
+              - 500
+              - 502
               - 503
             src_paths:
               - /select/.+
@@ -217,6 +221,10 @@ vmauth should match snapshot:
       unauthorizedUserAccessSpec:
         url_map:
           - load_balancing_policy: first_available
+            retry_status_codes:
+              - 500
+              - 502
+              - 503
             src_paths:
               - /select/.+
             url_prefix:

--- a/charts/victoria-metrics-distributed/values.yaml
+++ b/charts/victoria-metrics-distributed/values.yaml
@@ -59,6 +59,7 @@ read:
         unauthorizedUserAccessSpec:
           url_map:
             - load_balancing_policy: first_available
+              retry_status_codes: [500, 502, 503]
 
 # -- Default config for each availability zone components, including vmagent, vmcluster, vmsingle, vmauth etc.
 # Defines a template for each availability zone, which can be overridden for each availability zone at `availabilityZones[*]`
@@ -123,8 +124,7 @@ zoneTpl:
           unauthorizedUserAccessSpec:
             url_map:
               - load_balancing_policy: first_available
-                retry_status_codes:
-                  - 503
+                retry_status_codes: [500, 502, 503]
   # vmagent here only meant to proxy write requests to each az,
   # doesn't support customized other remote write address.
   vmagent:


### PR DESCRIPTION
Before, the read path will fail when the first zone vmselect is down, since zone vmauth will return [error code 502](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/89237a04b9de5f04957e71287a229ffe2aac9d54/app/vmauth/main.go#L288-L291)
```
< HTTP/1.1 502 Bad Gateway

remoteAddr: "10.244.2.15:40940, X-Forwarded-For: 127.0.0.1"; requestURI: /select/0; all the 2 backends for the user "" are unavailable
```

In this pull request, expand retry status codes for both global and cross-zone vmauth, to cover more cases.