### PR TITLE
make: fix reference to config file

### DIFF
--- a/.github/ci/ct.yaml
+++ b/.github/ci/ct.yaml
@@ -1,4 +1,4 @@
-chart-yaml-schema: .ci/chart_schema.yaml
+chart-yaml-schema: .github/ci/chart_schema.yaml
 lint-conf: .github/ci/lintconf.yaml
 
 remote: origin


### PR DESCRIPTION
Fixes `make lint-ct` configuration reference to chart schema file.