### PR TITLE
vlogs charts: upgrade version and minor fix

### DIFF
--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- TODO
+- Disable vlinsert HPA by default.
+- Bump VictoriaLogs version to [v1.21.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.21.0-victorialogs).
 
 ## 0.0.1
 

--- a/charts/victoria-logs-cluster/Chart.yaml
+++ b/charts/victoria-logs-cluster/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 type: application
-appVersion: v1.20.0
+appVersion: v1.21.0
 description: VictoriaLogs cluster version - high-performance, cost-effective and scalable logs storage
 name: victoria-logs-cluster
-version: 0.0.1
+version: 0.0.2
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-cluster/README.md
+++ b/charts/victoria-logs-cluster/README.md
@@ -1,6 +1,6 @@
 
 
-![Version](https://img.shields.io/badge/0.0.1-gray?logo=Helm&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fhelm%2Fvictoria-logs-cluster%2Fchangelog%2F%23001)
+![Version](https://img.shields.io/badge/0.0.2-gray?logo=Helm&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fhelm%2Fvictoria-logs-cluster%2Fchangelog%2F%23002)
 ![ArtifactHub](https://img.shields.io/badge/ArtifactHub-informational?logoColor=white&color=417598&logo=artifacthub&link=https%3A%2F%2Fartifacthub.io%2Fpackages%2Fhelm%2Fvictoriametrics%2Fvictoria-logs-cluster)
 ![License](https://img.shields.io/github/license/VictoriaMetrics/helm-charts?labelColor=green&label=&link=https%3A%2F%2Fgithub.com%2FVictoriaMetrics%2Fhelm-charts%2Fblob%2Fmaster%2FLICENSE)
 ![Slack](https://img.shields.io/badge/Join-4A154B?logo=slack&link=https%3A%2F%2Fslack.victoriametrics.com)
@@ -393,7 +393,7 @@ Change the values according to the need of the environment in ``victoria-logs-cl
 </td>
     </tr>
     <tr id="vlinsert-horizontalpodautoscaler-enabled">
-      <td><a href="#vlinsert-horizontalpodautoscaler-enabled"><pre class="chroma"><code><span class="line"><span class="cl"><span class="nt">vlinsert.horizontalPodAutoscaler.enabled</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span></span></span></code></pre>
+      <td><a href="#vlinsert-horizontalpodautoscaler-enabled"><pre class="chroma"><code><span class="line"><span class="cl"><span class="nt">vlinsert.horizontalPodAutoscaler.enabled</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span></span></span></code></pre>
 </a></td>
       <td><em><code>(bool)</code></em><p>Use HPA for vlinsert component</p>
 </td>

--- a/charts/victoria-logs-cluster/tests/__snapshot__/hpa_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/hpa_test.yaml.snap
@@ -4,27 +4,6 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: vlinsert
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: victoria-logs-cluster
-        app.kubernetes.io/version: 0.1.0-victorialogs
-        helm.sh/chart: victoria-logs-cluster-0.1.1
-      name: RELEASE-NAME-victoria-logs-cluster-vlinsert
-      namespace: NAMESPACE
-    spec:
-      maxReplicas: 10
-      metrics: []
-      minReplicas: 2
-      scaleTargetRef:
-        apiVersion: apps/v1
-        kind: Deployment
-        name: RELEASE-NAME-victoria-logs-cluster-vlinsert
-  2: |
-    apiVersion: autoscaling/v2
-    kind: HorizontalPodAutoscaler
-    metadata:
-      labels:
         app: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -44,27 +23,6 @@ hpa should match snapshot:
         name: RELEASE-NAME-victoria-logs-cluster-vmauth
 hpa should match snapshot with fullnameOverride and extraLabels:
   1: |
-    apiVersion: autoscaling/v2
-    kind: HorizontalPodAutoscaler
-    metadata:
-      labels:
-        app: vlinsert
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: victoria-logs-cluster
-        app.kubernetes.io/version: 0.1.0-victorialogs
-        helm.sh/chart: victoria-logs-cluster-0.1.1
-      name: RELEASE-NAME-victoria-logs-cluster-vlinsert
-      namespace: NAMESPACE
-    spec:
-      maxReplicas: 10
-      metrics: []
-      minReplicas: 2
-      scaleTargetRef:
-        apiVersion: apps/v1
-        kind: Deployment
-        name: RELEASE-NAME-victoria-logs-cluster-vlinsert
-  2: |
     apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     metadata:

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vlinsert_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vlinsert_test.yaml.snap
@@ -13,6 +13,7 @@ deployment should match snapshot:
       name: RELEASE-NAME-victoria-logs-cluster-vlinsert
       namespace: NAMESPACE
     spec:
+      replicas: 2
       selector:
         matchLabels:
           app: vlinsert
@@ -78,6 +79,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       name: vlinsert-node
       namespace: NAMESPACE
     spec:
+      replicas: 2
       selector:
         matchLabels:
           app: insert

--- a/charts/victoria-logs-cluster/values.yaml
+++ b/charts/victoria-logs-cluster/values.yaml
@@ -371,7 +371,7 @@ vlinsert:
 # Horizontal Pod Autoscaling
   horizontalPodAutoscaler:
     # -- Use HPA for vlinsert component
-    enabled: true
+    enabled: false
     # -- Maximum replicas for HPA to use to to scale the vlinsert component
     maxReplicas: 10
     # -- Minimum replicas for HPA to use to scale the vlinsert component

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Bumped VictoriaLogs version to [v1.21.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.21.0-victorialogs).
 
 ## 0.9.7
 

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 type: application
-appVersion: v1.20.0
+appVersion: v1.21.0
 description: Victoria Logs Single version - high-performance, cost-effective and scalable logs storage
 name: victoria-logs-single
-version: 0.9.7
+version: 0.9.8
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/README.md
+++ b/charts/victoria-logs-single/README.md
@@ -1,6 +1,6 @@
 
 
-![Version](https://img.shields.io/badge/0.9.7-gray?logo=Helm&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fhelm%2Fvictoria-logs-single%2Fchangelog%2F%23097)
+![Version](https://img.shields.io/badge/0.9.8-gray?logo=Helm&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fhelm%2Fvictoria-logs-single%2Fchangelog%2F%23098)
 ![ArtifactHub](https://img.shields.io/badge/ArtifactHub-informational?logoColor=white&color=417598&logo=artifacthub&link=https%3A%2F%2Fartifacthub.io%2Fpackages%2Fhelm%2Fvictoriametrics%2Fvictoria-logs-single)
 ![License](https://img.shields.io/github/license/VictoriaMetrics/helm-charts?labelColor=green&label=&link=https%3A%2F%2Fgithub.com%2FVictoriaMetrics%2Fhelm-charts%2Fblob%2Fmaster%2FLICENSE)
 ![Slack](https://img.shields.io/badge/Join-4A154B?logo=slack&link=https%3A%2F%2Fslack.victoriametrics.com)


### PR DESCRIPTION
- Disable vlinsert HPA by default.
- Bump VictoriaLogs version to [v1.21.0]