### PR TITLE
k8s-stack: fix plugins section in GrafanaDatasource

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add plugin version while using GrafanaDatasource CRD
 
 ## 0.46.0
 

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.46.0
+version: 0.46.1
 appVersion: v1.116.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
@@ -22,7 +22,7 @@ metadata:
   {{- $_ := set $spec "datasource" $ds }}
   {{- $_ := set $ctx "ds" $ds }}
   {{- if eq (include "vm.data.source.enabled" $ctx) "false" -}}
-    {{- $_ := set $spec "plugins" (list $ds.type) }}
+    {{- $_ := set $spec "plugins" (list (dict "name" $ds.type "version" $ds.pluginVersion)) }}
   {{- end }}
 spec: {{ toYaml $spec | nindent 2 }}
 {{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
@@ -22,8 +22,9 @@ metadata:
   {{- $_ := set $spec "datasource" $ds }}
   {{- $_ := set $ctx "ds" $ds }}
   {{- if eq (include "vm.data.source.enabled" $ctx) "false" -}}
-    {{- $_ := set $spec "plugins" (list (dict "name" $ds.type "version" $ds.pluginVersion)) }}
+    {{- $_ := set $spec "plugins" (list (dict "name" $ds.type "version" $ds.version)) }}
   {{- end }}
+  {{- $_ := unset $ds "version" }}
 spec: {{ toYaml $spec | nindent 2 }}
 {{- end }}
 {{- else }}
@@ -31,6 +32,7 @@ spec: {{ toYaml $spec | nindent 2 }}
   {{- range $ds := $output.datasources }}
     {{- $_ := set $ctx "ds" $ds }}
     {{- if eq (include "vm.data.source.enabled" $ctx) "true" -}}
+      {{- $_ := unset $ds "version" }}
       {{- $datasources = append $datasources $ds }}
     {{- end -}}
   {{- end }}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -845,7 +845,7 @@ defaultDatasources:
         isDefault: false
         access: proxy
         type: victoriametrics-metrics-datasource
-        pluginVersion: "0.14.0"
+        version: "0.14.0"
   # -- List of alertmanager datasources.
   # Alertmanager generated `url` will be added to each datasource in template if alertmanager is enabled
   alertmanager:

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -845,6 +845,7 @@ defaultDatasources:
         isDefault: false
         access: proxy
         type: victoriametrics-metrics-datasource
+        pluginVersion: "0.14.0"
   # -- List of alertmanager datasources.
   # Alertmanager generated `url` will be added to each datasource in template if alertmanager is enabled
   alertmanager:


### PR DESCRIPTION
Fixed the following error:

> Error: UPGRADE FAILED: release vmks failed, and has been rolled back due to atomic being set: cannot patch "vmks-victoria-metrics-k8s-stack-victoriametrics-ds" with kind GrafanaDatasource: GrafanaDatasource.grafana.integreatly.org "vmks-victoria-metrics-k8s-stack-victoriametrics-ds" is invalid: [spec.plugins[0]: Invalid value: "string": spec.plugins[0] in body must be of type object: "string", <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]

[Grafana Operator API Reference - GrafanaDashboard.spec.plugins[index]](https://grafana.github.io/grafana-operator/docs/api/#grafanadashboardspecpluginsindex)
![2025-05-12-22-29-05](https://github.com/user-attachments/assets/831bd350-6848-49d8-8ff6-dd64906fa818)

Related Issue: #2168
Related Commit: https://github.com/VictoriaMetrics/helm-charts/commit/492341fcb66de9bef12ca75575283977e57821f5