### PR TITLE
log charts: add `-http.shutdownDelay=15s` cmd-line flag to the server…

### DIFF
--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Reduce components readiness probe failureThreshold from 10 to 3 and add `-http.shutdownDelay=15s` cmd-line flag, for graceful shutdown during rolling restarts.
 
 ## 0.0.2
 

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vlinsert_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vlinsert_test.yaml.snap
@@ -30,6 +30,7 @@ deployment should match snapshot:
           containers:
             - args:
                 - --envflag.enable
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:9481
                 - --loggerFormat=json
                 - --storageNode=RELEASE-NAME-victoria-logs-cluster-vlstorage-0.RELEASE-NAME-victoria-logs-cluster-vlstorage.NAMESPACE.svc.cluster.local.:9491
@@ -48,7 +49,7 @@ deployment should match snapshot:
                 - containerPort: 9481
                   name: http
               readinessProbe:
-                failureThreshold: 10
+                failureThreshold: 3
                 httpGet:
                   path: /health
                   port: http
@@ -97,6 +98,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
           containers:
             - args:
                 - --envflag.enable
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:9481
                 - --loggerFormat=json
                 - --storageNode=RELEASE-NAME-victoria-logs-cluster-vlstorage-0.RELEASE-NAME-victoria-logs-cluster-vlstorage.NAMESPACE.svc.cluster.local.:9492
@@ -115,7 +117,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
                 - containerPort: 9481
                   name: http
               readinessProbe:
-                failureThreshold: 10
+                failureThreshold: 3
                 httpGet:
                   path: /health
                   port: http

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vlselect_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vlselect_test.yaml.snap
@@ -30,6 +30,7 @@ deployment should match snapshot:
           containers:
             - args:
                 - --envflag.enable
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:9471
                 - --loggerFormat=json
                 - --storageNode=RELEASE-NAME-victoria-logs-cluster-vlstorage-0.RELEASE-NAME-victoria-logs-cluster-vlstorage.NAMESPACE.svc.cluster.local.:9491
@@ -48,7 +49,7 @@ deployment should match snapshot:
                 - containerPort: 9471
                   name: http
               readinessProbe:
-                failureThreshold: 10
+                failureThreshold: 3
                 httpGet:
                   path: /health
                   port: http
@@ -97,6 +98,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
           containers:
             - args:
                 - --envflag.enable
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:9471
                 - --loggerFormat=json
                 - --storageNode=RELEASE-NAME-victoria-logs-cluster-vlstorage-0.RELEASE-NAME-victoria-logs-cluster-vlstorage.NAMESPACE.svc.cluster.local.:9492
@@ -115,7 +117,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
                 - containerPort: 9471
                   name: http
               readinessProbe:
-                failureThreshold: 10
+                failureThreshold: 3
                 httpGet:
                   path: /health
                   port: http

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vlstorage_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vlstorage_test.yaml.snap
@@ -33,6 +33,7 @@ statefulset should match snapshot:
           containers:
             - args:
                 - --envflag.enable
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:9491
                 - --loggerFormat=json
                 - --retentionPeriod=7d
@@ -44,7 +45,7 @@ statefulset should match snapshot:
                 - containerPort: 9491
                   name: http
               readinessProbe:
-                failureThreshold: 10
+                failureThreshold: 3
                 httpGet:
                   path: /health
                   port: http
@@ -110,6 +111,7 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
           containers:
             - args:
                 - --envflag.enable
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:9492
                 - --loggerFormat=json
                 - --retention.maxDiskSpaceUsageBytes=100GiB
@@ -122,7 +124,7 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
                 - containerPort: 9492
                   name: http
               readinessProbe:
-                failureThreshold: 10
+                failureThreshold: 3
                 httpGet:
                   path: /health
                   port: http

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vmauth_test.yaml.snap
@@ -31,6 +31,7 @@ deployment should match snapshot:
             - args:
                 - --auth.config=/config/auth.yml
                 - --envflag.enable
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:8427
                 - --loggerFormat=json
               image: victoriametrics/vmauth:v1.116.0
@@ -47,7 +48,7 @@ deployment should match snapshot:
                 - containerPort: 8427
                   name: http
               readinessProbe:
-                failureThreshold: 10
+                failureThreshold: 3
                 httpGet:
                   path: /health
                   port: http
@@ -103,6 +104,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
             - args:
                 - --auth.config=/config/auth.yml
                 - --envflag.enable
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:8427
                 - --loggerFormat=json
               image: victoriametrics/vmauth:v1.116.0
@@ -119,7 +121,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
                 - containerPort: 8427
                   name: http
               readinessProbe:
-                failureThreshold: 10
+                failureThreshold: 3
                 httpGet:
                   path: /health
                   port: http

--- a/charts/victoria-logs-cluster/values.yaml
+++ b/charts/victoria-logs-cluster/values.yaml
@@ -84,6 +84,7 @@ vlselect:
     envflag.enable: true
     loggerFormat: json
     httpListenAddr: :9471
+    http.shutdownDelay: 15s
   # -- Pod's termination grace period in seconds
   terminationGracePeriodSeconds: 60
   # -- Deployment annotations
@@ -109,7 +110,7 @@ vlselect:
       initialDelaySeconds: 5
       periodSeconds: 5
       timeoutSeconds: 5
-      failureThreshold: 10
+      failureThreshold: 3
     # -- vlselect liveness probe
     liveness:
       tcpSocket: {}
@@ -327,6 +328,7 @@ vlinsert:
     envflag.enable: true
     loggerFormat: json
     httpListenAddr: :9481
+    http.shutdownDelay: 15s
   # -- Deployment annotations
   annotations: {}
   # -- Deployment additional labels
@@ -357,7 +359,7 @@ vlinsert:
       initialDelaySeconds: 5
       periodSeconds: 5
       timeoutSeconds: 5
-      failureThreshold: 10
+      failureThreshold: 3
     # -- vlinsert liveness probe
     liveness:
       tcpSocket: {}
@@ -584,7 +586,7 @@ vlstorage:
     envflag.enable: true
     loggerFormat: json
     httpListenAddr: :9491
-
+    http.shutdownDelay: 15s
   # -- Extra Volumes for the pod
   extraVolumes:
     []
@@ -727,7 +729,7 @@ vlstorage:
       initialDelaySeconds: 5
       periodSeconds: 5
       timeoutSeconds: 5
-      failureThreshold: 10
+      failureThreshold: 3
     # -- vlstorage startup probe
     startup: {}
 
@@ -809,6 +811,7 @@ vmauth:
     envflag.enable: true
     loggerFormat: json
     httpListenAddr: :8427
+    http.shutdownDelay: 15s
   # -- VMAuth annotations
   annotations: {}
   # -- VMAuth additional labels
@@ -832,7 +835,7 @@ vmauth:
       initialDelaySeconds: 5
       periodSeconds: 5
       timeoutSeconds: 5
-      failureThreshold: 10
+      failureThreshold: 3
     # -- VMAuth liveness probe
     liveness:
       tcpSocket: {}

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Updated alerting rules
 - VictoriaLogs upgrade 1.21.0 -> 1.22.2
+- Reduce server readiness probe periodSeconds from 15 to 5 and add `-http.shutdownDelay=15s` cmd-line flag, for graceful shutdown during rolling restarts.
 
 ## 0.9.8
 

--- a/charts/victoria-logs-single/tests/__snapshot__/server_test.yaml.snap
+++ b/charts/victoria-logs-single/tests/__snapshot__/server_test.yaml.snap
@@ -33,6 +33,7 @@ deployment should match snapshot:
             - args:
                 - --envflag.enable
                 - --envflag.prefix=VM_
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:9428
                 - --loggerFormat=json
                 - --retentionPeriod=1
@@ -57,7 +58,7 @@ deployment should match snapshot:
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
               securityContext:
                 allowPrivilegeEscalation: false
@@ -112,6 +113,7 @@ deployment with volume should match snapshot:
             - args:
                 - --envflag.enable
                 - --envflag.prefix=VM_
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:9428
                 - --loggerFormat=json
                 - --retentionPeriod=1
@@ -136,7 +138,7 @@ deployment with volume should match snapshot:
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
               securityContext:
                 allowPrivilegeEscalation: false
@@ -191,6 +193,7 @@ statefulset should match snapshot:
             - args:
                 - --envflag.enable
                 - --envflag.prefix=VM_
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:9428
                 - --loggerFormat=json
                 - --retentionPeriod=1
@@ -215,7 +218,7 @@ statefulset should match snapshot:
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
               securityContext:
                 allowPrivilegeEscalation: false
@@ -279,6 +282,7 @@ statefulset with volume should match snapshot:
             - args:
                 - --envflag.enable
                 - --envflag.prefix=VM_
+                - --http.shutdownDelay=15s
                 - --httpListenAddr=:9428
                 - --loggerFormat=json
                 - --retentionPeriod=1
@@ -303,7 +307,7 @@ statefulset with volume should match snapshot:
                   port: http
                   scheme: HTTP
                 initialDelaySeconds: 5
-                periodSeconds: 15
+                periodSeconds: 5
                 timeoutSeconds: 5
               securityContext:
                 allowPrivilegeEscalation: false

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -78,7 +78,7 @@ server:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :9428
-
+    http.shutdownDelay: 15s
   # -- Specify pod lifecycle
   lifecycle: {}
 
@@ -198,7 +198,7 @@ server:
     readiness:
       httpGet: {}
       initialDelaySeconds: 5
-      periodSeconds: 15
+      periodSeconds: 5
       timeoutSeconds: 5
       failureThreshold: 3
 


### PR DESCRIPTION
… for graceful shutdown during rolling restarts

see discussion in https://github.com/VictoriaMetrics/vmsite/pull/370#discussion_r2066751675.
Applying this change to victoriametrics charts could lead to server restarts, and it seems not worthy.