### PR TITLE
charts/victoria-metrics-k8s-stack: fix templating of image.tag for vmagent

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Fix incorrect configuration of `image.tag` for `VMAgent` component.
 
 ## 0.50.0
 

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.50.0
+version: 0.50.1
 appVersion: v1.118.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -178,7 +178,7 @@
   {{- end -}}
   {{- $image := dict "tag" (include "vm.image.tag" .) }}
   {{- $_ := set $spec "image" $image -}}
-  {{- tpl (mergeOverwrite (deepCopy $Values.vmagent.spec) (deepCopy $spec) | toYaml) . -}}
+  {{- tpl (mergeOverwrite (deepCopy $spec) (deepCopy $Values.vmagent.spec) | toYaml) . -}}
 {{- end }}
 
 {{- /* VMAuth spec */ -}}


### PR DESCRIPTION
fba36ed incorrectly changed order of merge for vmagent spec which resulted in global `$spec` taking over `$Values.vmagent.spec`. As the result `spec` from previous component would override vmagent config. For example, tag would be set to `v1.118.0-enterprise-cluster` with the following config;
```yaml
vmcluster:
...
  spec:
    clusterVersion: "v1.118.0-enterprise-cluster"
...
    vminsert:
      image:
        tag: v1.118.0-enterprise-cluster
    vmstorage:
      image:
        tag: v1.118.0-enterprise-cluster
   vmselect:
     image:
       tag: v1.118.0-enterprise-cluster
```