### PR TITLE
victoria-metrics-agent: add for service option to enable internalTrafficPolicy

### DIFF
--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Added `internalTrafficPolicy` option to service section to control how traffic from Kubernetes internal sources is routed to endpoints
 
 ## 0.21.0
 

--- a/charts/victoria-metrics-agent/templates/service.yaml
+++ b/charts/victoria-metrics-agent/templates/service.yaml
@@ -36,6 +36,9 @@ spec:
   {{- with $service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ . }}
   {{- end }}
+  {{- with $service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
   {{- with $service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ . }}
   {{- end }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -231,6 +231,8 @@ service:
   ipFamilies: []
   # -- Service external traffic policy. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
   externalTrafficPolicy: ""
+  # -- Service internal traffic policy. Check [here](https://kubernetes.io/docs/concepts/services-networking/service/#internal-traffic-policy) for details
+  internalTrafficPolicy: ""
   # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
   healthCheckNodePort: ""
 


### PR DESCRIPTION
Added `internalTrafficPolicy` option to service section to control how traffic from Kubernetes internal sources is routed to endpoints.