### PR TITLE
k8s-stack: allow enabling `vmcluster` dashboard, even if vmcluster CR itself isn't enabled

### DIFF
--- a/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-cluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-cluster.yaml
@@ -49,7 +49,7 @@ annotations:
     iconColor: dark-yellow
     name: restarts
     textFormat: '{{`{{`}}job{{`}}`}} restarted'
-condition: {{ ($Values.vmcluster).enabled }}
+condition: {{ or (($Values.vmcluster).enabled) (($Values.vmcluster).dashboardEnabled) }}
 description: Overview for cluster VictoriaMetrics v1.117.0 or higher
 editable: false
 fiscalYearStartMonth: 0

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -327,6 +327,8 @@ vmsingle:
 vmcluster:
   # -- Create VMCluster CR
   enabled: false
+  # -- Include VMCluster dashboard, even if VMCluster CR is not enabled
+  dashboardEnabled: false
   # -- VMCluster annotations
   annotations: {}
   # -- Full spec for VMCluster CRD. Allowed values described [here](https://docs.victoriametrics.com/operator/api#vmclusterspec)

--- a/hack/rules-and-dashboards/sync_dashboards.py
+++ b/hack/rules-and-dashboards/sync_dashboards.py
@@ -187,7 +187,7 @@ condition_map = {
     "proxy": "$Values.kubeProxy.enabled",
     "scheduler": "$Values.kubeScheduler.enabled",
     "victoriametrics-backupmanager": "or (not (empty (((($Values).vmsingle).spec).vmBackup).destination)) (not (empty ((((($Values).vmcluster).spec).storage).vmBackup).destination))",
-    "victoriametrics-cluster": "($Values.vmcluster).enabled",
+    "victoriametrics-cluster": "or (($Values.vmcluster).enabled) (($Values.vmcluster).dashboardEnabled)",
     "victoriametrics-operator": '(index $Values "victoria-metrics-operator" "enabled")',
     "victoriametrics-single-node": "($Values.vmsingle).enabled",
     "victoriametrics-vmalert": "($Values.vmalert).enabled",


### PR DESCRIPTION
The use-case here is, due to gitops repo/tree organization, we use k8s-stack only for dashboards/rules/scrapers, while most CRs are actually deployed separately.