### PR TITLE
charts/vmagent: Add trafficDistribution for service in vmagent chart

### DIFF
--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-metrics-agent
 description: VictoriaMetrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
-version: 0.22.0
+version: 0.22.1
 appVersion: v1.119.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-agent/templates/service.yaml
+++ b/charts/victoria-metrics-agent/templates/service.yaml
@@ -45,6 +45,9 @@ spec:
   {{- with $service.ipFamilies }}
   ipFamilies: {{ toYaml . | nindent 4 }}
   {{- end }}
+  {{- with $service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ports:
     - name: http
       port: {{ $service.servicePort }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -235,6 +235,8 @@ service:
   internalTrafficPolicy: ""
   # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
   healthCheckNodePort: ""
+  # -- Traffic Distribution. Check [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution)
+  trafficDistribution: ""
 
 ingress:
   # -- Enable deployment of ingress for agent


### PR DESCRIPTION
Based on https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
Minimum Kubernetes needed is v1.31, but full functionality can be achieved in Kubernetes v1.33