### PR TITLE
charts/vmcluster: Add trafficDistribution for services in vmcluster chart

### DIFF
--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.24.0
+version: 0.24.1
 appVersion: v1.119.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-cluster/templates/service.yaml
+++ b/charts/victoria-metrics-cluster/templates/service.yaml
@@ -48,6 +48,9 @@ spec:
   {{- with $service.ipFamilies }}
   ipFamilies: {{ toYaml . | nindent 4 }}
   {{- end }}
+  {{- with $service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   {{- $portsTpl := printf "%s.ports" $name }}
   {{- with include $portsTpl $app }}
   ports: {{ . | nindent 4 }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -252,6 +252,8 @@ vmselect:
     ipFamilyPolicy: ""
     # -- List of service IP families. Check [here](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) for details.
     ipFamilies: []
+    # -- Traffic Distribution. Check [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution)
+    trafficDistribution: ""
   ingress:
     # -- Enable deployment of ingress for vmselect component
     enabled: false
@@ -548,7 +550,8 @@ vminsert:
     ipFamilyPolicy: ""
     # -- List of service IP families. Check [here](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) for details.
     ipFamilies: []
-
+    # -- Traffic Distribution. Check [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution)
+    trafficDistribution: ""
 
 
 
@@ -814,6 +817,8 @@ vmauth:
     ipFamilyPolicy: ""
     # -- List of service IP families. Check [here](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) for details.
     ipFamilies: []
+    # -- Traffic Distribution. Check [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution)
+    trafficDistribution: ""
   ingress:
     # -- Enable deployment of ingress for vmauth component
     enabled: false
@@ -1068,6 +1073,8 @@ vmstorage:
     ipFamilyPolicy: ""
     # -- List of service IP families. Check [here](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) for details.
     ipFamilies: []
+    # -- Traffic Distribution. Check [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution)
+    trafficDistribution: ""
   # -- Pod's termination grace period in seconds
   terminationGracePeriodSeconds: 60
   minReadySeconds: 5


### PR DESCRIPTION
Based on https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
Minimum Kubernetes needed is v1.31, but full functionality can be achieved in Kubernetes v1.33