### PR TITLE
charts/vm-anomaly: allow using VMPodScrape for monitoring configuration

### DIFF
--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - Support `.Values.topologySpreadConstraints` property. See [#2219](https://github.com/VictoriaMetrics/helm-charts/issues/2219)
+- Add support of using [`VMPodScrape`](https://docs.victoriametrics.com/operator/resources/vmpodscrape/) for monitoring configuration. See `.Values.podMonitor.vmPodScrape`. 
 
 ## 1.10.1
 

--- a/charts/victoria-metrics-anomaly/Chart.yaml
+++ b/charts/victoria-metrics-anomaly/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-metrics-anomaly
 description: VictoriaMetrics Anomaly Detection - a service that continuously scans Victoria Metrics time series and detects unexpected changes within data patterns in real-time.
-version: 1.10.1
+version: 1.10.2
 appVersion: v1.24.1
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-anomaly/templates/monitor.yaml
+++ b/charts/victoria-metrics-anomaly/templates/monitor.yaml
@@ -7,8 +7,13 @@
 {{- $ctx := dict "helm" . }}
 {{- $fullname := include "vm.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
+{{- if $podMonitor.vmPodScrape }}
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+{{- else }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
+{{- end }}
 metadata:
   {{- with $podMonitor.annotations }}
   annotations: {{ toYaml . | nindent 4 }}

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -145,6 +145,8 @@ podMonitor:
   extraLabels: {}
   # -- PodMonitor annotations
   annotations: {}
+  # -- Whether to use [VMPodScrape](https://docs.victoriametrics.com/operator/resources/vmpodscrape/) from VM operator instead of PodMonitor
+  vmPodScrape: false
 
 # -- Full [vmanomaly config section](https://docs.victoriametrics.com/anomaly-detection/components/)
 config:


### PR DESCRIPTION
This allows to avoid installing Prometheus operator CRDs if VictoriaMetrics operator is already present.