### PR TITLE
Missing RBAC permission for 0.61 update to Victoria-Metrics-Operator

### DIFF
--- a/charts/victoria-metrics-operator/templates/role.yaml
+++ b/charts/victoria-metrics-operator/templates/role.yaml
@@ -74,6 +74,7 @@ rules:
   - persistentvolumeclaims
   - persistentvolumeclaims/finalizers
   - pods
+  - pods/eviction
   - secrets
   - secrets/finalizers
   - services


### PR DESCRIPTION
See
https://docs.victoriametrics.com/operator/changelog/#v0610

> Update Note 2:: This release requires an additional pods/eviction RBAC permssion for operator.

https://github.com/VictoriaMetrics/operator/commit/4af4a5b5712e6a4c0d105575d7180d53c5c8aa49