### PR TITLE
Use rancher/kubectl for cleanup instead of bitnami/kubectl and set default tag appropriately

### DIFF
--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -30,7 +30,7 @@ victoria-metrics-operator:
     cleanup:
       enabled: true
       image:
-        repository: bitnami/kubectl
+        repository: rancher/kubectl
         pullPolicy: IfNotPresent
   serviceMonitor:
     enabled: true

--- a/charts/victoria-metrics-operator/templates/cleanup.yaml
+++ b/charts/victoria-metrics-operator/templates/cleanup.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.crds.enabled .Values.crds.cleanup.enabled }}
 {{- $app := .Values.crds.cleanup }}
 {{- if empty ($app.image).tag }}
-  {{- $tag := (printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor) | replace "+" "" -}}
+  {{- $tag := (printf "v%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor) | replace "+" "" -}}
   {{- $_ := set $app.image "tag" $tag }}
 {{- else if not (kindIs "string" ($app.image).tag) }}
   {{- fail "`crd.cleanup.image.tag` is not string, most probably you need to enquote provided value" -}}

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -43,7 +43,7 @@ crds:
     enabled: false
     # -- Image configuration for CRD cleanup Job
     image:
-      repository: bitnami/kubectl
+      repository: rancher/kubectl
       # use image tag that matches k8s API version by default
       tag: ""
       pullPolicy: IfNotPresent


### PR DESCRIPTION
Broadcom is up to more 'fun' with vmware legacy resources. Effective august 28th they intend to break the internet by *MOVING* all the current public bitnami/ images on docker hub to bitnamilegacy and stop providing any tags except `latest`. See here:
https://github.com/bitnami/charts/issues/35164

For now you can also see a similar note on the bitnami/kubectl repo here on docker hub:
https://hub.docker.com/r/bitnami/kubectl

This PR moves the victoriametrics charts from using the bitnami provided kubectl docker container to the one provided by Suse/Rancher. The rancher image includes a 'v' character at the start of it's tag, so I've updated the template that assigns the default tag from the kuberenetes apiVersion to include this character. Not sure what else is needed, but I thought I'd help get ahead of this before it becomes a problem at the end of the month.

If you want to use this image in your existing deployments, make sure you specify an image tag when using it, as the current method of calculating the image tag is not correct for `rancher/kubectl`

