### PR TITLE
vm-distributed: add `/opentelemetry/.+` and `/insert/.+` to vmauth-gl…

### DIFF
--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Add `/opentelemetry/.+` and `/insert/.+` to vmauth-global-write default `src_paths`, to allow ingestion via OpenTelemetry protocol and the [multitenancy endpoint](https://docs.victoriametrics.com/victoriametrics/vmagent/#multitenancy) by default.
 
 ## 0.20.1
 

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-distributed
 description: A Helm chart for Running VMCluster on Multiple Availability Zones
 type: application
-version: 0.20.1
+version: 0.20.2
 appVersion: v1.123.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-distributed/templates/vmauth-write.yaml
+++ b/charts/victoria-metrics-distributed/templates/vmauth-write.yaml
@@ -36,7 +36,7 @@ metadata:
   {{- if empty $urls }}
     {{- fail "No global vmauth write backend urls defined" -}}
   {{- end }}
-  {{- $defaultPaths := list "/api/v1/write" "/prometheus/api/v1/write" "/write" "/api/v1/import" "/api/v1/import/.+" }}
+  {{- $defaultPaths := list "/api/v1/write" "/prometheus/api/v1/write" "/write" "/api/v1/import" "/api/v1/import/.+" "/opentelemetry/.+" "/insert/.+"}}
   {{- $defaultUrlMapItem := dict "src_paths" $defaultPaths "url_prefix" $urls }}
   {{- $spec := deepCopy $auth.spec | default dict -}}
   {{- $accessSpec := $spec.unauthorizedUserAccessSpec | default dict }}

--- a/charts/victoria-metrics-distributed/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-metrics-distributed/tests/__snapshot__/vmauth_test.yaml.snap
@@ -125,6 +125,8 @@ vmauth should match snapshot:
               - /write
               - /api/v1/import
               - /api/v1/import/.+
+              - /opentelemetry/.+
+              - /insert/.+
             url_prefix:
               - http://vmagent-vmagent-zone-eu-1.NAMESPACE.svc.cluster.local.:8429
               - http://vmagent-vmagent-zone-us-1.NAMESPACE.svc.cluster.local.:8429


### PR DESCRIPTION
…obal-write default `src_paths`, to allow ingestion via OpenTelemetry protocol and the [multitenancy endpoint](https://docs.victoriametrics.com/victoriametrics/vmagent/#multitenancy) by default

fix https://github.com/VictoriaMetrics/helm-charts/issues/2341