### PR TITLE
set default nameOverride to avoid hitting resource name limit for new setups

### DIFF
--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update note 1**: set default `.Values.nameOverride` to `vl-cluster`, which impacts default resource naming and can lead to resources recreation. For existing setups it's recommended to set `.Values.nameOverride: victoria-logs-cluster` to avoid resource recreation if it wasn't previously set.
+
+- set `.Values.nameOverride` to `vl-cluster` to avoid hitting k8s resource name limit.
 
 ## 0.0.9
 

--- a/charts/victoria-logs-cluster/values.yaml
+++ b/charts/victoria-logs-cluster/values.yaml
@@ -41,7 +41,7 @@ serviceAccount:
   automountToken: true
 
 # -- Override chart name
-nameOverride: ""
+nameOverride: vl-cluster
 
 # -- Add extra specs dynamically to this chart
 extraObjects: []

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update note 1**: set default `.Values.nameOverride` to `vl-single`, which impacts default resource naming and can lead to resources recreation. For existing setups it's recommended to set `.Values.nameOverride: victoria-logs-single` to avoid resource recreation if it wasn't previously set.
+
+- set `.Values.nameOverride` to `vl-single` to avoid hitting k8s resource name limit.
 
 ## 0.11.6
 

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -16,7 +16,7 @@ global:
     dnsDomain: cluster.local.
 
 # -- Override chart name
-nameOverride: ""
+nameOverride: vl-single
 
 # -- Print chart notes
 printNotes: true

--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update note 1**: set default `.Values.nameOverride` to `vm-agent`, which impacts default resource naming and can lead to resources recreation. For existing setups it's recommended to set `.Values.nameOverride: victoria-metrics-agent` to avoid resource recreation if it wasn't previously set.
+
+- set `.Values.nameOverride` to `vm-agent` to avoid hitting k8s resource name limit.
 
 ## 0.25.1
 

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -70,7 +70,7 @@ image:
 imagePullSecrets: []
 
 # -- Override chart name
-nameOverride: ""
+nameOverride: vm-agent
 
 # -- Override resources fullname
 fullnameOverride: ""

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next release
 
+**Update note 1**: set default `.Values.nameOverride` to `vm-alert`, which impacts default resource naming and can lead to resources recreation. For existing setups it's recommended to set `.Values.nameOverride: victoria-metrics-alert` to avoid resource recreation if it wasn't previously set.
+
+- set `.Values.nameOverride` to `vm-alert` to avoid hitting k8s resource name limit.
 - Support alertmanager statefulset mode using `.Values.alertmanager.mode: statefulSet`
 - Support alertmanager in HA mode when `.Values.alertmanager.mode: statefulSet` and `.Values.alertmanager.replicaCount` is greater than 1.
 

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -27,7 +27,7 @@ serviceAccount:
   automountToken: true
 
 # -- Override chart name
-nameOverride: ""
+nameOverride: vm-alert
 
 server:
   # -- Override default `app` label name

--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update note 1**: set default `.Values.nameOverride` to `vm-anomaly`, which impacts default resource naming and can lead to resources recreation. For existing setups it's recommended to set `.Values.nameOverride: victoria-metrics-anomaly` to avoid resource recreation if it wasn't previously set.
+
+- set `.Values.nameOverride` to `vm-anomaly` to avoid hitting k8s resource name limit.
 
 ## 1.11.2
 

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -28,7 +28,7 @@ image:
 # -- Image pull secrets
 imagePullSecrets: []
 # -- Override chart name
-nameOverride: ""
+nameOverride: vm-anomaly
 # -- Override resources fullname
 fullnameOverride: ""
 # -- Override chart name

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update note 1**: set default `.Values.nameOverride` to `vm-auth`, which impacts default resource naming and can lead to resources recreation. For existing setups it's recommended to set `.Values.nameOverride: victoria-metrics-auth` to avoid resource recreation if it wasn't previously set.
+
+- set `.Values.nameOverride` to `vm-auth` to avoid hitting k8s resource name limit.
 
 ## 0.19.1
 

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -37,7 +37,7 @@ image:
 # -- Image pull secrets
 imagePullSecrets: []
 # -- Override chart name
-nameOverride: ""
+nameOverride: vm-auth
 # -- Override resources fullname
 fullnameOverride: ""
 

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update note 1**: set default `.Values.nameOverride` to `vm-cluster`, which impacts default resource naming and can lead to resources recreation. For existing setups it's recommended to set `.Values.nameOverride: victoria-metrics-cluster` to avoid resource recreation if it wasn't previously set.
+
+- set `.Values.nameOverride` to `vm-cluster` to avoid hitting k8s resource name limit.
 
 ## 0.27.1
 

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -47,7 +47,7 @@ serviceAccount:
   automountToken: true
 
 # -- Override chart name
-nameOverride: ""
+nameOverride: vm-cluster
 
 extraSecrets:
   []

--- a/charts/victoria-metrics-distributed/values.yaml
+++ b/charts/victoria-metrics-distributed/values.yaml
@@ -1,5 +1,5 @@
 # -- Overrides the chart's name
-nameOverride: "vm-distributed"
+nameOverride: vm-distributed
 
 # -- Overrides the chart's computed fullname.
 fullnameOverride: ""

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update note 1**: set default `.Values.nameOverride` to `vm-gateway`, which impacts default resource naming and can lead to resources recreation. For existing setups it's recommended to set `.Values.nameOverride: victoria-metrics-gateway` to avoid resource recreation if it wasn't previously set.
+
+- set `.Values.nameOverride` to `vm-gateway` to avoid hitting k8s resource name limit.
 
 ## 0.17.2
 

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -35,7 +35,7 @@ image:
 # -- Image pull secrets
 imagePullSecrets: []
 # -- Override chart name
-nameOverride: ""
+nameOverride: vm-gateway
 # -- Override resources fullname
 fullnameOverride: ""
 

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## Next release
 
+**Update note 1**: set default `.Values.nameOverride` to `vm-k8s-stack`, which impacts default resource naming and can lead to resources recreation. For existing setups it's recommended to set `.Values.nameOverride: victoria-metrics-k8s-stack` to avoid resource recreation if it wasn't previously set.
+
 - vmcluster: set chart's app version to spec.clusterVersion instead of setting tag for each component. See [#2348](https://github.com/VictoriaMetrics/helm-charts/issues/2348).
 - fixed bug, when explicitly defined tag for vminsert appears in vmagent spec. See [#2349](https://github.com/VictoriaMetrics/helm-charts/issues/2349).
 - updated dashboards and rules
 - use `.Values.prometheus-node-exporter.service.labels.jobLabel` as a value for `job` label in node exporter rules. See [#2340](https://github.com/VictoriaMetrics/helm-charts/pull/2340).
+- set `.Values.nameOverride` to `vm-k8s-stack` to avoid hitting k8s resource name limit.
 
 ## 0.58.3
 

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -12,7 +12,7 @@ global:
     dnsDomain: cluster.local.
 
 # -- Override chart name
-nameOverride: ""
+nameOverride: vm-k8s-stack
 # -- Resource full name override
 fullnameOverride: ""
 # -- Tenant to use for Grafana datasources and remote write

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Next release
 
+**Update note 1**: set default `.Values.nameOverride` to `vm-operator`, which impacts default resource naming and can lead to resources recreation. For existing setups it's recommended to set `.Values.nameOverride: victoria-metrics-operator` to avoid resource recreation if it wasn't previously set.
+
 - Include patch version while building default cleanup image tag. See [#2339](https://github.com/VictoriaMetrics/helm-charts/issues/2339).
+- set `.Values.nameOverride` to `vm-operator` to avoid hitting k8s resource name limit.
 
 ## 0.51.4
 

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -63,7 +63,7 @@ replicaCount: 1
 imagePullSecrets: []
 
 # -- Override chart name
-nameOverride: ""
+nameOverride: vm-operator
 
 # -- Overrides the full name of server component resources
 fullnameOverride: ""

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update note 1**: set default `.Values.nameOverride` to `vm-single`, which impacts default resource naming and can lead to resources recreation. For existing setups it's recommended to set `.Values.nameOverride: victoria-metrics-single` to avoid resource recreation if it wasn't previously set.
+
+- set `.Values.nameOverride` to `vm-single` to avoid hitting k8s resource name limit.
 
 ## 0.24.2
 

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -28,6 +28,9 @@ rbac:
   # -- Role/RoleBinding annotations
   annotations: {}
 
+# -- Override chart name
+nameOverride: vm-single
+
 # -- Print chart notes
 printNotes: true
 


### PR DESCRIPTION
updated default nameOverride for all charts to avoid hitting 63 chars limit in a future
makes sense to bump a major version during the next release