### PR TITLE
feature/VL-Msg-Field_params

### DIFF
--- a/charts/victoria-logs-collector/Chart.yaml
+++ b/charts/victoria-logs-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-logs-collector
 description: VictoriaLogs Collector - collects logs from Kubernetes containers and stores them to VictoriaLogs
-version: 0.0.2
+version: 0.0.3
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-collector/templates/configmap.yaml
+++ b/charts/victoria-logs-collector/templates/configmap.yaml
@@ -52,7 +52,7 @@ data:
             AccountID: {{ or $rw.accountID 0 | quote }}
             ProjectID: {{ or $rw.projectID 0 | quote }}
             VL-Stream-Fields: kubernetes.pod_name,kubernetes.container_name,kubernetes.pod_namespace
-            VL-Msg-Field: message
+            VL-Msg-Field: {{ join "," (concat (list "message") ($rw.msgField | default (list))) }}
             VL-Time-Field: timestamp
             {{- with $rw.extraFields }}
             VL-Extra-Fields: {{- $pairs := list -}}

--- a/charts/victoria-logs-collector/values.yaml
+++ b/charts/victoria-logs-collector/values.yaml
@@ -32,6 +32,12 @@ remoteWrite:
   #   tls:
   #     insecureSkipVerify: true
 
+  # - url: http://victoria-logs:9428
+  #   msgField:
+  #     - message._msg
+  #     - msg
+  #     - _msg
+
 # -- Environment variables (ex.: secret tokens).
 env: []
   # - name: VL_PASSWORD


### PR DESCRIPTION
### Summary
This PR makes `VL-Msg-Field` configurable in the `victoria-logs-collector` chart.

### Changes
1. **configmap.yaml**  
   - Replaced the hardcoded `VL-Msg-Field: message` with a templated expression.  
   - Now the field always includes `"message"`, but also accepts custom fields defined in `values.yaml`.

2. **values.yaml**  
   - Added a new optional parameter `msgField` under `remoteWrite`.  
   - Example fields:  
     ```yaml
     msgField:
       - message._msg
       - msg
       - _msg
     ```

### Benefits
- Provides flexibility for users who store log messages under different field names.  
- Maintains backward compatibility since `message` remains the default.  

### Version
Chart version bumped from `0.0.2` → `0.0.3`.
