### PR TITLE
charts/victoria-logs-single: add params to ServiceMonitor

### DIFF
--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Added `params` support for `ServiceMonitor`
 
 ## 0.11.8
 

--- a/charts/victoria-logs-single/templates/monitor.yaml
+++ b/charts/victoria-logs-single/templates/monitor.yaml
@@ -34,6 +34,9 @@ spec:
       {{- with $app.serviceMonitor.basicAuth }}
       basicAuth: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $app.serviceMonitor.params }}
+      params: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- with $app.serviceMonitor.scheme }}
       scheme: {{ . }}
       {{- end }}

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -178,6 +178,8 @@ server:
 
   # -- StatefulSet/Deployment additional labels
   extraLabels: {}
+  # -- StatefulSet/Deployment annotations
+  annotations: {}
   # -- Pod's additional labels
   podLabels: {}
   # -- Pod's annotations
@@ -327,6 +329,10 @@ server:
     annotations: {}
     # -- Basic auth params for Service Monitor
     basicAuth: {}
+    # -- Commented. Params to use for scraping (supports helm templates)
+#    params:
+#      authKey:
+#      - '{{ .Values.server.extraArgs.metricsAuthKey }}'
     # -- Commented. Prometheus scrape interval for server component
 #    interval: 15s
     # -- Commented. Prometheus pre-scrape timeout for server component
@@ -422,7 +428,7 @@ vector:
             VL-Msg-Field: message,msg,_msg,log.msg,log.message,log
             AccountID: "0"
             ProjectID: "0"
-      
+
 # -- Add extra specs dynamically to this chart
 extraObjects: []
 


### PR DESCRIPTION
victoria-logs-single lacks the method to add params to ServiceMonitor, this PR adds that support.

If the server is configured with:
```
server:
  extraArgs:
    metricsAuthKey: '<key>'
```
then the ServiceMonitor needs to add a param to scrape metrics.  The PR adds ServiceMonitor.parms as a template so that the authKey can be set from the provided parameter value (with a commented example added in values.yaml).

I didn't want to make the parameter included by default (in this case) in case someone wanted to set the value directly...(and would make for complex key checking in the template).

