### PR TITLE
charts/victoria-logs-collector: switch Vector to alpine-based build

### DIFF
--- a/charts/victoria-logs-collector/CHANGELOG.md
+++ b/charts/victoria-logs-collector/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- TODO
+- Bump Vector version to [v0.49.0](https://vector.dev/releases/0.49.0/).
+- Switch to alpine-based build. See [#2429](https://github.com/VictoriaMetrics/helm-charts/issues/2429) for details.
 
 ## 0.0.4
 

--- a/charts/victoria-logs-collector/Chart.yaml
+++ b/charts/victoria-logs-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-logs-collector
 description: VictoriaLogs Collector - collects logs from Kubernetes containers and stores them to VictoriaLogs
-version: 0.0.4
+version: 0.0.5
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-collector/templates/daemonset.yaml
+++ b/charts/victoria-logs-collector/templates/daemonset.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       containers:
         - name: victoria-logs-collector
-          image: {{ .Values.global.image.registry | default "docker.io" }}/timberio/vector:0.48.0-distroless-libc
+          image: {{ .Values.global.image.registry | default "docker.io" }}/timberio/vector:0.49.0-alpine
           imagePullPolicy: IfNotPresent
           {{- if .Values.securityContext.enabled }}
           securityContext: {{ omit .Values.securityContext "enabled" | toYaml | nindent 12 }}


### PR DESCRIPTION
Related: #2429 

The image will be smaller after these changes: 
`0.49.0-distroless-libc` image size: 229MB
`0.49.0-alpine` image size: 190MB

But there's a chance that performance may drop, since the alpine image is based on musl.