### PR TITLE
fix: Add vmauth-sha256sum annotation to vmauth-server template

### DIFF
--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Add vmauth-sha256sum annotation to vmauth-server template. See [#2434](https://github.com/VictoriaMetrics/helm-charts/issues/2434) for details.
+- Add vmauth-sha256sum annotation to vmauth-server template. See [#2434](https://github.com/VictoriaMetrics/helm-charts/pull/2434) for details.
 
 ## 0.0.11
 

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Add vmauth-sha256sum annotation to vmauth-server template. See [#2434](https://github.com/VictoriaMetrics/helm-charts/issues/2434) for details.
 
 ## 0.0.11
 

--- a/charts/victoria-logs-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vmauth-server.yaml
@@ -27,8 +27,10 @@ spec:
   {{- end }}
   template:
     metadata:
+      annotations:
+        vmauth-sha256sum: {{ include (print $.Template.BasePath "/vmauth-config.yaml") . | sha256sum }}
       {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}

--- a/charts/victoria-logs-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vmauth-server.yaml
@@ -28,10 +28,10 @@ spec:
   template:
     metadata:
       annotations:
-        vmauth-sha256sum: {{ include (print $.Template.BasePath "/vmauth-config.yaml") . | sha256sum }}
-      {{- with $app.podAnnotations }}
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- with $app.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/vmauth-config.yaml") . | sha256sum }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}


### PR DESCRIPTION
This pull request introduces an improvement to the `vmauth-server.yaml` Helm template by adding a checksum annotation for the `vmauth-config.yaml` file. This ensures that changes to the config file trigger a rolling update of the deployment.

- **Helm template enhancements:**
  * Added a `vmauth-sha256sum` annotation to the pod template metadata in `vmauth-server.yaml`, which computes and stores the SHA256 hash of the `vmauth-config.yaml` file. This helps Kubernetes detect changes in the config and automatically roll out new pods when the config changes.