### PR TITLE
Remove fixed http prefix from external Grafana url.

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -150,7 +150,7 @@
     {{- end -}}
     {{- if not (index $output.extraArgs "external.url") -}}
       {{- $grafanaHost := ternary (index (($Values.grafana).ingress).hosts 0) (($Values.external).grafana).host ($Values.grafana).enabled }}
-      {{- $_ := set $output.extraArgs "external.url" (printf "http://%s" $grafanaHost) -}}
+      {{- $_ := set $output.extraArgs "external.url" $grafanaHost -}}
     {{- end -}}
   {{- end -}}
   {{- tpl ($output | toYaml) . -}}


### PR DESCRIPTION
This patch removes the fixed http:// prefix from the external Grafana url, allowing the use of a prefix (http or https) specified as part of that url. This is also in line with how the external Grafana url is used in the dashboard link of the alerts (i.e. no prefix is prepended there).