### PR TITLE
Update to new grafana schema

### DIFF
--- a/charts/victoria-metrics-k8s-stack/_index.md.gotmpl
+++ b/charts/victoria-metrics-k8s-stack/_index.md.gotmpl
@@ -163,7 +163,7 @@ grafana:
     default:
       vmcluster:
         gnetId: 11176
-        revision: 38
+        revision: 45
         datasource: VictoriaMetrics
 ```
 When using this approach, you can find dashboards for VictoriaMetrics components published [here](https://grafana.com/orgs/victoriametrics).


### PR DESCRIPTION
Update docs to reflect new grafana helm chart values.

Old doc gives this error.
```
Error: UPGRADE FAILED: template: victoria-metrics-distributed/charts/victoria-metrics-k8s-stack/charts/grafana/templates/deployment.yaml:36:28: executing "victoria-metrics-distributed/charts/victoria-metrics-k8s-stack/charts/grafana/templates/deployment.yaml" at <include "grafana.configData" .>: error calling include: template: victoria-metrics-distributed/charts/victoria-metrics-k8s-stack/charts/grafana/templates/_config.tpl:87:23: executing "grafana.configData" at <$value>: wrong type for value; expected map[string]interface {}; got string
```

New version works.