### PR TITLE
collector: use common vm.fullname, vm.labels templates for name and labels generation

### DIFF
--- a/charts/victoria-logs-collector/CHANGELOG.md
+++ b/charts/victoria-logs-collector/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Next release
 
+**Update note**: All resources that are managed by chart will be recreated due to changes in naming and labels.
+
 - Bump Vector version to [v0.51.0](https://vector.dev/releases/0.51.0/).
+- replace chart's template for fullname generation with common's `vm.fullname`
 
 ## 0.0.5
 

--- a/charts/victoria-logs-collector/Chart.yaml
+++ b/charts/victoria-logs-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-logs-collector
 description: VictoriaLogs Collector - collects logs from Kubernetes containers and stores them to VictoriaLogs
-version: 0.0.5
+version: 0.1.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-collector/templates/NOTES.txt
+++ b/charts/victoria-logs-collector/templates/NOTES.txt
@@ -1,2 +1,2 @@
 To view running VictoriaLogs Collectors:
-  kubectl get po -o wide -l app.kubernetes.io/name={{ include "victoria-logs-collector.fullname" . }} -n {{ .Release.Namespace }}
+  kubectl get po -o wide -l app.kubernetes.io/name={{ include "vm.fullname" . }} -n {{ .Release.Namespace }}

--- a/charts/victoria-logs-collector/templates/_helpers.tpl
+++ b/charts/victoria-logs-collector/templates/_helpers.tpl
@@ -1,13 +1,3 @@
-{{/* Generate fullname */}}
-{{- define "victoria-logs-collector.fullname" }}
-  {{- if .Values.fullnameOverride }}
-    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-  {{- else }}
-    {{- $name := default .Chart.Name .Values.nameOverride }}
-    {{- printf "%s" $name | trunc 63 | trimSuffix "-" }}
-  {{- end }}
-{{- end }}
-
 {{- define "victoria-logs-collector.image" }}
   {{- $registry := .Values.global.image.registry | default "docker.io" }}
   {{- if .Values.native }}

--- a/charts/victoria-logs-collector/templates/configmap.yaml
+++ b/charts/victoria-logs-collector/templates/configmap.yaml
@@ -1,36 +1,32 @@
 {{- if not .Values.native }}
+{{- $ctx := dict "helm" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "victoria-logs-collector.fullname" . }}-config
-  labels:
-    app.kubernetes.io/name: {{ include "victoria-logs-collector.fullname" . }}
+  name: {{ include "vm.fullname" $ctx }}-config
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
 data:
   vector.yaml: |
     data_dir: /vl-collector
-
     sources:
       k8s:
         type: kubernetes_logs
         pod_annotation_fields:
           # Disable "pod_ips" as "pod_ip" already includes required info
           pod_ips: ""
-
     transforms:
       json_parser:
         type: remap
         inputs: [k8s]
         source: |
           .message = parse_json(.message) ?? .message
-
     {{- if empty .Values.remoteWrite }}
       {{ fail "specify at least one remoteWrite with valid url"}}
-    {{ end }}
-
+    {{- end }}
     sinks:
     {{- $knownFields := list "url" "basicAuth" "accountID" "projectID" "tls" "extraFields" "ignoreFields" "msgField" }}
     {{- range $i, $rw := .Values.remoteWrite }}
-      {{/* Validate remoteWrite object */}}
+      {{- /* Validate remoteWrite object */}}
       {{- if empty $rw.url }}
         {{ fail (printf "'url' field must be set for remoteWrite[%d]" $i) }}
       {{- end }}

--- a/charts/victoria-logs-collector/templates/daemonset.yaml
+++ b/charts/victoria-logs-collector/templates/daemonset.yaml
@@ -1,32 +1,27 @@
+{{- $ctx := dict "helm" . }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "victoria-logs-collector.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ include "victoria-logs-collector.fullname" . }}
+  name: {{ include "vm.fullname" $ctx }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ include "victoria-logs-collector.fullname" . }}
+    matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 6 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: {{ include "victoria-logs-collector.fullname" . }}
-        {{- with .Values.podLabels }}
-        {{ toYaml . | nindent 8 }}
-        {{- end }}
-      annotations:
-        {{- with .Values.podAnnotations }}
-        {{ toYaml . | nindent 8 }}
-        {{- end }}
-        {{- if not .Values.native }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- end }}
+      {{- $_ := set $ctx "extraLabels" .Values.podLabels }}
+      labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
+      {{- $_ := unset $ctx "extraLabels" }}
+      {{- $annotations := deepCopy .Values.podAnnotations }}
+      {{- if not .Values.native }}
+      {{- $_ := set $annotations "checksum/config" (include (print .Template.BasePath "/configmap.yaml") . | sha256sum) }}
+      {{- end }}
+      annotations: {{ toYaml $annotations | nindent 8 }}
     spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
-      serviceAccountName: {{ include "victoria-logs-collector.fullname" . }}
+      serviceAccountName: {{ include "vm.fullname" $ctx }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
@@ -94,7 +89,7 @@ spec:
         {{- if not .Values.native }}
         - name: config
           configMap:
-            name: {{ include "victoria-logs-collector.fullname" . }}-config
+            name: {{ include "vm.fullname" $ctx }}-config
         {{- end }}
         - name: vl-collector-data
           hostPath:

--- a/charts/victoria-logs-collector/templates/rbac.yaml
+++ b/charts/victoria-logs-collector/templates/rbac.yaml
@@ -1,7 +1,9 @@
+{{- $ctx := dict "helm" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "victoria-logs-collector.fullname" . }}-node-reader
+  name: {{ include "vm.fullname" $ctx }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["nodes", "namespaces", "pods"]
@@ -10,12 +12,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "victoria-logs-collector.fullname" . }}-node-reader-binding
+  name: {{ include "vm.fullname" $ctx }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "victoria-logs-collector.fullname" . }}
+    name: {{ include "vm.fullname" $ctx }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ include "victoria-logs-collector.fullname" . }}-node-reader
+  name: {{ include "vm.fullname" $ctx }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/victoria-logs-collector/templates/serviceaccount.yaml
+++ b/charts/victoria-logs-collector/templates/serviceaccount.yaml
@@ -1,6 +1,8 @@
+{{- $ctx := dict "helm" . }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "victoria-logs-collector.fullname" . }}
+  name: {{ include "vm.fullname" $ctx }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}

--- a/charts/victoria-logs-collector/tests/__snapshot__/collector_test.yaml.snap
+++ b/charts/victoria-logs-collector/tests/__snapshot__/collector_test.yaml.snap
@@ -2,28 +2,71 @@ daemonSet should match snapshot:
   1: |
     apiVersion: v1
     data:
-      vector.yaml: "data_dir: /vl-collector\n\nsources:\n  k8s:\n    type: kubernetes_logs\n    pod_annotation_fields:\n      # Disable \"pod_ips\" as \"pod_ip\" already includes required info\n      pod_ips: \"\"\n\ntransforms:\n  json_parser:\n    type: remap\n    inputs: [k8s]\n    source: |\n      .message = parse_json(.message) ?? .message\n\nsinks:\n  \n  remote_write_0:\n    type: http\n    inputs: [json_parser]\n    uri: \"http://victoria-logs:9428/insert/jsonline\"\n    encoding:\n      codec: json\n    framing:\n      method: newline_delimited\n    healthcheck:\n      enabled: false\n    request:\n      headers:\n        AccountID: \"0\"\n        ProjectID: \"0\"\n        VL-Stream-Fields: kubernetes.pod_name,kubernetes.container_name,kubernetes.pod_namespace\n        VL-Msg-Field: message\n        VL-Time-Field: timestamp\n    compression: \"zstd\"\n"
+      vector.yaml: |
+        data_dir: /vl-collector
+        sources:
+          k8s:
+            type: kubernetes_logs
+            pod_annotation_fields:
+              # Disable "pod_ips" as "pod_ip" already includes required info
+              pod_ips: ""
+        transforms:
+          json_parser:
+            type: remap
+            inputs: [k8s]
+            source: |
+              .message = parse_json(.message) ?? .message
+        sinks:
+          remote_write_0:
+            type: http
+            inputs: [json_parser]
+            uri: "http://victoria-logs:9428/insert/jsonline"
+            encoding:
+              codec: json
+            framing:
+              method: newline_delimited
+            healthcheck:
+              enabled: false
+            request:
+              headers:
+                AccountID: "0"
+                ProjectID: "0"
+                VL-Stream-Fields: kubernetes.pod_name,kubernetes.container_name,kubernetes.pod_namespace
+                VL-Msg-Field: message
+                VL-Time-Field: timestamp
+            compression: "zstd"
     kind: ConfigMap
     metadata:
       labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-collector
-      name: victoria-logs-collector-config
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: victoria-logs-collector-0.1.1
+      name: RELEASE-NAME-victoria-logs-collector-config
   2: |
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
       labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-collector
-      name: victoria-logs-collector
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: victoria-logs-collector-0.1.1
+      name: RELEASE-NAME-victoria-logs-collector
     spec:
       selector:
         matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-collector
       template:
         metadata:
           annotations:
-            checksum/config: 54545d2014de61010a3f06134ac88616b41cf4b9adab576f57ff34c8a79a0f33
+            checksum/config: 4d48db702a3eee6969dfc603924253136385e307ad8aa6a1281df9a3f9869e87
           labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-collector
         spec:
           containers:
@@ -49,7 +92,7 @@ daemonSet should match snapshot:
                 - mountPath: /vl-collector
                   name: vl-collector-data
           securityContext: {}
-          serviceAccountName: victoria-logs-collector
+          serviceAccountName: RELEASE-NAME-victoria-logs-collector
           volumes:
             - hostPath:
                 path: /var/log
@@ -58,7 +101,7 @@ daemonSet should match snapshot:
                 path: /var/lib
               name: varlib
             - configMap:
-                name: victoria-logs-collector-config
+                name: RELEASE-NAME-victoria-logs-collector-config
               name: config
             - hostPath:
                 path: /var/lib/vl-collector
@@ -67,7 +110,13 @@ daemonSet should match snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
-      name: victoria-logs-collector-node-reader
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-logs-collector
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: victoria-logs-collector-0.1.1
+      name: RELEASE-NAME-victoria-logs-collector
     rules:
       - apiGroups:
           - ""
@@ -83,14 +132,20 @@ daemonSet should match snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
-      name: victoria-logs-collector-node-reader-binding
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-logs-collector
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: victoria-logs-collector-0.1.1
+      name: RELEASE-NAME-victoria-logs-collector
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: victoria-logs-collector-node-reader
+      name: RELEASE-NAME-victoria-logs-collector
     subjects:
       - kind: ServiceAccount
-        name: victoria-logs-collector
+        name: RELEASE-NAME-victoria-logs-collector
         namespace: NAMESPACE
   5: |
     apiVersion: v1
@@ -98,4 +153,10 @@ daemonSet should match snapshot:
     kind: ServiceAccount
     metadata:
       annotations: {}
-      name: victoria-logs-collector
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-logs-collector
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: victoria-logs-collector-0.1.1
+      name: RELEASE-NAME-victoria-logs-collector


### PR DESCRIPTION
replace collector's fullname template, which generates output, that doesn't depend on chart's release name and can lead to collision in case of using more than one chart