### PR TITLE
fix(config-reloader): set default image to match the operator version

### DIFF
--- a/charts/victoria-metrics-operator/templates/server.yaml
+++ b/charts/victoria-metrics-operator/templates/server.yaml
@@ -1,6 +1,10 @@
 {{- $ctx := dict "helm" . "noEnterprise" true }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
+{{- $env := dict -}}
+{{- range .Values.env | default list -}}
+  {{- $_ := set $env .name .value -}}
+{{- end -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -63,6 +67,10 @@ spec:
               value: {{ .Chart.Name }}
             - name: VM_USECUSTOMCONFIGRELOADER
               value: "{{ .Values.operator.useCustomConfigReloader }}"
+            {{- if and (.Values.operator.useCustomConfigReloader) (not (hasKey $env "VM_CUSTOMCONFIGRELOADERIMAGE")) }}
+            - name: VM_CUSTOMCONFIGRELOADERIMAGE
+              value: victoriametrics/operator:config-reloader-{{- include "vm.image.tag" . -}}
+            {{ end }}
             {{- with (((.Values).global).image).registry }}
             - name: VM_CONTAINERREGISTRY
               value: {{ quote . }}


### PR DESCRIPTION
Currently the reloader version is the one here: https://github.com/VictoriaMetrics/operator/blob/2ee997984d1b6d8ec7c3f07eceb2aea40fc993b1/internal/config/config.go#L115 and it doesn't match the operator version.
This is to set it to match the operator version.

By the way before v0.62.0 setting 
```
    - name: VM_USECUSTOMCONFIGRELOADER
      value: "false"
```
was enough to get the same version for the reloader, but I didn't dig into that much. So maybe there is a better way, in the operator code. 