### PR TITLE
victoria-logs-collector: globally configurable `timeField` and `msgField` parameters

### DIFF
--- a/charts/victoria-logs-collector/CHANGELOG.md
+++ b/charts/victoria-logs-collector/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- Add support for globally configurable `timeField` and `msgField` parameters that apply across all remoteWrite destinations. Configure via `timeField` and `msgField` in values.yaml.
 
 ## 0.1.0
 

--- a/charts/victoria-logs-collector/e2e/simple.yaml
+++ b/charts/victoria-logs-collector/e2e/simple.yaml
@@ -9,6 +9,17 @@ remoteWrite:
       - kubernetes.pod_labels*
   - url: http://victoria-logs-2:9428
 
+msgField:
+  - message
+  - log
+  - msg
+
+timeField:
+  - time
+  - timestamp
+  - ts
+  - '@timestamp'
+
 resources:
   limits:
     cpu: 100m

--- a/charts/victoria-logs-collector/templates/configmap.yaml
+++ b/charts/victoria-logs-collector/templates/configmap.yaml
@@ -24,6 +24,14 @@ data:
       {{ fail "specify at least one remoteWrite with valid url"}}
     {{- end }}
     sinks:
+    {{/* Before 0.1.0, each remoteWrite could specify its own msgField. This was removed in favor of global msgField configuration. */}}
+    {{- $msgField := list }}
+    {{- range $rw := .Values.remoteWrite }}
+      {{ $msgField = concat $msgField ($rw.msgField | default list) }}
+    {{- end }}
+    {{- $msgField = concat $msgField .Values.msgField }}
+    {{- $msgField = uniq $msgField }}
+
     {{- $knownFields := list "url" "basicAuth" "accountID" "projectID" "tls" "extraFields" "ignoreFields" "msgField" }}
     {{- range $i, $rw := .Values.remoteWrite }}
       {{- /* Validate remoteWrite object */}}
@@ -50,8 +58,8 @@ data:
             AccountID: {{ or $rw.accountID 0 | quote }}
             ProjectID: {{ or $rw.projectID 0 | quote }}
             VL-Stream-Fields: kubernetes.pod_name,kubernetes.container_name,kubernetes.pod_namespace
-            VL-Msg-Field: {{ join "," ($rw.msgField | default (list "message")) }}
-            VL-Time-Field: timestamp
+            VL-Msg-Field: {{ join "," ($msgField | default (list "message")) }}
+            VL-Time-Field: {{ join "," ($.Values.timeField | default (list "timestamp")) }}
             {{- with $rw.extraFields }}
             VL-Extra-Fields: {{- $pairs := list -}}
               {{- range $k, $v := $rw.extraFields }}
@@ -98,3 +106,4 @@ data:
         {{- end }}
     {{- end }}
 {{- end }}
+    

--- a/charts/victoria-logs-collector/values.yaml
+++ b/charts/victoria-logs-collector/values.yaml
@@ -32,11 +32,18 @@ remoteWrite: []
   #   tls:
   #     insecureSkipVerify: true
 
-  # - url: http://victoria-logs:9428
-  #   msgField:
-  #     - message._msg
-  #     - msg
-  #     - _msg
+# -- List of fields to be used as `_time` field. The first found field will be used.
+# See https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field for more details.
+timeField:
+  - time
+  - ts
+  - timestamp
+
+# -- List of fields to be used as `_msg` field. The first found field will be used.
+# See https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field for more details.
+msgField:
+  - message
+  - msg
 
 # -- Environment variables (ex.: secret tokens).
 env: []


### PR DESCRIPTION
These changes are required to prepare the migration of the underlying implementation to an application that uses the `/internal/insert` handler, which does not support the `VL-Time-Field`, `VL-Msg-Field` headers. Therefore, the client must handle this logic on its own side.

Since it is challenging and unnecessary to use different `_msg` and `_time` fields for each remoteWrite, the `rw.msgField` parameter is now deprecated - clients should use the global `msgField` instead. Existing configurations will not be affected, as the new logic takes the old parameter into account.