### PR TITLE
charts/logs-collector: add namespace to templates

### DIFF
--- a/charts/victoria-logs-collector/templates/configmap.yaml
+++ b/charts/victoria-logs-collector/templates/configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "vm.fullname" $ctx }}-config
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "vm.namespace" . }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
 data:
   vector.yaml: |

--- a/charts/victoria-logs-collector/templates/daemonset.yaml
+++ b/charts/victoria-logs-collector/templates/daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "vm.fullname" $ctx }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "vm.namespace" . }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
 spec:
   selector:

--- a/charts/victoria-logs-collector/templates/serviceaccount.yaml
+++ b/charts/victoria-logs-collector/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vm.fullname" $ctx }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "vm.namespace" . }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}


### PR DESCRIPTION
Fixes #2578

`ServiceAccount`, `DaemonSet`, and `ConfigMap` are all properly namedspaced per the release parameter.

