### PR TITLE
charts/victoria-metrics-alert: add support for new notifier flags

### DIFF
--- a/charts/victoria-metrics-alert/templates/_helpers.tpl
+++ b/charts/victoria-metrics-alert/templates/_helpers.tpl
@@ -204,6 +204,17 @@ Create base alertmanager url for notifers
   {{- with (include "vmalert.alertmanager.bearerTokenFiles" .) -}}
     {{- $_ := set $args "notifier.bearerTokenFile" . -}}
   {{- end -}}
+  {{- if .Values.server.notifier.webhookVlogs.enabled -}}
+    {{- with .Values.server.notifier.webhookVlogs.vlogsURL -}}
+      {{- $_ := set $args "notifier.vlogs.url" . -}}
+    {{- end -}}
+    {{- with .Values.server.notifier.webhookVlogs.slackURL -}}
+      {{- $_ := set $args "notifier.slack.url" . -}}
+    {{- end -}}
+    {{- with .Values.server.notifier.webhookVlogs.ingressURL -}}
+      {{- $_ := set $args "notifier.vlogs.ingress" . -}}
+    {{- end -}}
+  {{- end -}}
   {{- with $app.remote.read.url }}
     {{- $_ := set $args "remoteRead.url" . -}}
   {{- end -}}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -165,6 +165,11 @@ server:
         token: ""
         # -- Token Auth file with Bearer token. You can use one of token or tokenFile
         tokenFile: ""
+    webhookVlogs:
+      enabled: false
+      vlogsURL: ""
+      slackURL: ""
+      ingressURL: ""
 
   # -- Additional notifiers to use for alerts
   notifiers:


### PR DESCRIPTION
depends on https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10070

This PR adds configuration for the new notifier flags in the `victoria-metrics-alert`
This allows users to easily configure the VictoriaLogs alert integration directly from `values.yaml`

Changes:
`values.yaml`: Added a new configuration section `server.notifier.webhookVLogs` to support the following parameters:
  - `enabled`: Toggle to enable/disable this feature.
  - `vlogsURL`: The internal URL for VictoriaLogs (mapped to `-notifier.vlogs.url`).
  - `slackURL`: The Slack Webhook URL (mapped to `-notifier.slack.url`).
  - `ingress`: The public ingress URL for VictoriaLogs (mapped to `-notifier.vlogs.ingress`).

`templates/_helpers.tpl`: Updated the vmalert.args template to automatically