### PR TITLE
feat: render remoteWrite if config.useTpl is enabled

### DIFF
--- a/charts/victoria-metrics-agent/templates/_helpers.tpl
+++ b/charts/victoria-metrics-agent/templates/_helpers.tpl
@@ -40,7 +40,11 @@
   {{- range $i, $rw := $Values.remoteWrite }}
     {{- range $rwKey, $rwValue := $rw }}
       {{- if or (kindIs "slice" $rwValue) (kindIs "map" $rwValue) }}
-        {{- $_ := set $rwcm (printf "%d-%s.yaml" $i $rwKey) (toYaml $rwValue) }}
+        {{- $rwContent := toYaml $rwValue }}
+        {{- if $Values.config.useTpl }}
+          {{- $rwContent = tpl $rwContent $ | trim }}
+        {{- end }}
+        {{- $_ := set $rwcm (printf "%d-%s.yaml" $i $rwKey) $rwContent }}
       {{- end -}}
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
Enabling re-rendering in remoteWrite data if `config.useTpl` is enabled.

Allowing to have helm variables in remoteWrite : 
```
remoteWrite:
  - url: "http://victoriametrics-vmagent.domain.tld.in:8429/api/v1/write"
    showURL: true
    urlRelabelConfig:
      - target_label: vm_account_id
        replacement: "{{ $.Values.config.vm_account_id }}"
      - target_label: vm_project_id
        replacement: "{{ $.Values.config.vm_project_id }}"
```