### PR TITLE
charts/victoria-logs-collector: update native mode

### DIFF
--- a/charts/victoria-logs-collector/CHANGELOG.md
+++ b/charts/victoria-logs-collector/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- explicitly define namespace for namespaced resources. See [#2578](https://github.com/VictoriaMetrics/helm-charts/issues/2578).
+- Explicitly define namespace for namespaced resources. See [#2578](https://github.com/VictoriaMetrics/helm-charts/issues/2578).
+- Bump Vector version to [v0.51.1](https://vector.dev/releases/0.51.1/).
 
 ## 0.1.1
 

--- a/charts/victoria-logs-collector/e2e/simple.yaml
+++ b/charts/victoria-logs-collector/e2e/simple.yaml
@@ -30,4 +30,14 @@ resources:
 
 native: true
 image:
-  tag: heads-k8s-collector-0-gbedc0a7f9
+  tag: heads-k8s-collector-0-g8757ae494
+
+podMonitor:
+  enabled: true
+  extraLabels:
+    foo: bar
+  annotations:
+    ping: pong
+  vm: true
+  interval: 10s
+  scrapeTimeout: 5s

--- a/charts/victoria-logs-collector/templates/_helpers.tpl
+++ b/charts/victoria-logs-collector/templates/_helpers.tpl
@@ -4,7 +4,7 @@
     {{- $tag := required "'image' must be set when 'native' is true" (.Values.image).tag }}
     {{- printf "%s/%s:%s" $registry "victoriametrics/vlagent" $tag }}
   {{- else }}
-    {{- printf "%s/%s:%s" $registry "timberio/vector" "0.51.0-alpine" }}
+    {{- printf "%s/%s:%s" $registry "timberio/vector" "0.51.1-alpine" }}
   {{- end }}
 {{- end }}
 
@@ -15,8 +15,8 @@
 
   {{- $args := list }}
   {{- /* Kubernetes integration args */ -}}
-  {{- $args = append $args "--kubernetes=true" }}
-  {{- $args = append $args "--kubernetes.checkpointsPath=/vl-collector/checkpoints.json" }}
+  {{- $args = append $args "--kubernetesCollector" }}
+  {{- $args = append $args "--kubernetesCollector.checkpointsPath=/vl-collector/checkpoints.json" }}
   {{- $args = append $args "--remoteWrite.tmpDataPath=/vl-collector/remotewrite-data" }}
 
   {{- /* Before 0.1.0, each remoteWrite could specify its own msgField. This was removed in favor of global msgField configuration. */}}
@@ -27,10 +27,10 @@
   {{- $msgField = concat $msgField .Values.msgField }}
   {{- $msgField = uniq $msgField }}
   {{- if not (empty $msgField) }}
-    {{- $args = append $args (printf "--kubernetes.msgField=%s" (join "," $msgField)) }}
+    {{- $args = append $args (printf "--kubernetesCollector.msgField=%s" (join "," $msgField)) }}
   {{- end }}
   {{- if not (empty .Values.timeField) }}
-    {{- $args = append $args (printf "--kubernetes.timeField=%s" (join "," .Values.timeField)) }}
+    {{- $args = append $args (printf "--kubernetesCollector.timeField=%s" (join "," .Values.timeField)) }}
   {{- end }}
 
   {{- range $i, $rw := .Values.remoteWrite }}

--- a/charts/victoria-logs-collector/templates/daemonset.yaml
+++ b/charts/victoria-logs-collector/templates/daemonset.yaml
@@ -49,6 +49,10 @@ spec:
           resources: {{ toYaml .Values.resources | nindent 12 }}
           {{- end }}
           {{- if .Values.native }}
+          ports:
+            - name: http
+              containerPort: 9429
+              protocol: TCP
           args: {{ include "victoria-logs-collector.args" . | nindent 12 }}
           {{- end }}
           env:

--- a/charts/victoria-logs-collector/templates/monitor.yaml
+++ b/charts/victoria-logs-collector/templates/monitor.yaml
@@ -1,0 +1,43 @@
+{{- $app := .Values }}
+{{- if and $app.podMonitor.enabled $app.native }}
+{{- $podMonitor := $app.podMonitor }}
+{{- $ctx := dict "helm" . }}
+{{- if $podMonitor.vm }}
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+{{- else }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+{{- end }}
+metadata:
+  name: {{ include "vm.fullname" $ctx }}
+  {{- with $podMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with $podMonitor.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $_ := set $ctx "extraLabels" $podMonitor.extraLabels }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- $_ := unset $ctx "extraLabels" }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ include "vm.namespace" $ctx }}
+  selector:
+    matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 6 }}
+  podMetricsEndpoints:
+    - port: http
+      {{- with $podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with $podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with $podMonitor.relabelings }}
+      relabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $podMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/victoria-logs-collector/values.yaml
+++ b/charts/victoria-logs-collector/values.yaml
@@ -146,3 +146,13 @@ affinity: {}
 
 # -- Priority class to be assigned to the pod(s)
 priorityClassName: ""
+
+podMonitor:
+  # -- Enable PodMonitor
+  enabled: false
+  # -- PodMonitor labels
+  extraLabels: {}
+  # -- PodMonitor annotations
+  annotations: {}
+  # -- Whether to use [VMPodScrape](https://docs.victoriametrics.com/operator/resources/vmpodscrape/) from VM operator instead of PodMonitor
+  vm: false


### PR DESCRIPTION
* Renamed `-kubernetes` to `-kubernetesCollector` CLI-flags.
* Exposed 9429 port to allow collecting vlagent metrics.