### PR TITLE
Feature: Added support for custom vector transformer source

### DIFF
--- a/charts/victoria-logs-collector/templates/configmap.yaml
+++ b/charts/victoria-logs-collector/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
         type: remap
         inputs: [k8s]
         source: |
-          .message = parse_json(.message) ?? .message
+          {{ .Values.vectorTransformsJsonparserSource | nindent 10 }}
     {{- if empty .Values.remoteWrite }}
       {{ fail "specify at least one remoteWrite with valid url"}}
     {{- end }}

--- a/charts/victoria-logs-collector/values.yaml
+++ b/charts/victoria-logs-collector/values.yaml
@@ -45,6 +45,10 @@ msgField:
   - message
   - msg
 
+# -- Custom VRL source code for the json_parser transform in Vector.
+# Only used if `native` is false.
+vectorTransformsJsonparserSource: ".message = parse_json(.message) ?? .message"
+
 # -- Enable VLAgent logs collection
 native: false
 


### PR DESCRIPTION
- Added  a new key `vectorTransformsJsonparserSource` which defaults to `".message = parse_json(.message) ?? .message"`
- Usecase: We want to set the whole message as raw_msg field. Currently Its impossible with this. 
Eg: 

> source: |
>           .raw_msg = .message 
>           . = merge!(., parse_json(.message) ?? .message)
> 
This enables full text search over all the fields in message