### PR TITLE
Add gateway api access to RBAC role

### DIFF
--- a/charts/victoria-metrics-operator/templates/role.yaml
+++ b/charts/victoria-metrics-operator/templates/role.yaml
@@ -162,6 +162,13 @@ rules:
   verbs:
   - "*"
 - apiGroups:
+    - gateway.networking.k8s.io
+  resources:
+    - httproutes
+    - httproutes/finalizers
+  verbs:
+    - '*'
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions


### PR DESCRIPTION
Operator lacks access to gateway.networking.k8s.io api and fails to create HTTPRoute resources for CRD-managed services.