### PR TITLE
victoria-logs-{agent,collector}: allow users to set a custom URL path

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- allow overriding the default `remoteWrite.url` path by specifying a non-empty value other than `/` for the `remoteWrite.url` field
 
 ## 0.0.1
 

--- a/charts/victoria-logs-agent/Chart.yaml
+++ b/charts/victoria-logs-agent/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 appVersion: v1.43.0
 name: victoria-logs-agent
 description: VictoriaLogs Agent - accepts logs from various protocols and replicates them across multiple VictoriaLogs instances.
-version: 0.0.1
+version: 0.0.2
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-agent/templates/_helpers.tpl
+++ b/charts/victoria-logs-agent/templates/_helpers.tpl
@@ -26,7 +26,9 @@
       {{- end }}
       {{- $value := $rwValue }}
       {{- if eq $rwKey "url" }}
-        {{- $value = printf "%s/insert/native" (trimSuffix "/" $rwValue) }}
+        {{- $url := urlParse $rwValue }}
+        {{- $_ = set $url "path" (ternary "/insert/native" $url.path (empty (trimPrefix "/" $url.path))) }}
+        {{- $value = urlJoin $url }}
       {{- else if eq $rwKey "headers" }}
         {{- $headers := list }}
         {{- range $hk, $hv := $rwValue }}

--- a/charts/victoria-logs-agent/values.yaml
+++ b/charts/victoria-logs-agent/values.yaml
@@ -8,6 +8,8 @@
 maxDiskUsagePerURL: 1GiB
 
 # -- List of log destinations. Logs will be replicated to all listed destinations.
+#
+# If the url path is not specified, the logs will be sent to the /insert/native endpoint.
 remoteWrite: []
   # - url: http://victoria-logs:9428
 

--- a/charts/victoria-logs-collector/CHANGELOG.md
+++ b/charts/victoria-logs-collector/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- allow overriding the default `remoteWrite.url` path by specifying a non-empty value other than `/` for the `remoteWrite.url` field
 
 ## 0.2.2
 

--- a/charts/victoria-logs-collector/Chart.yaml
+++ b/charts/victoria-logs-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-logs-collector
 description: VictoriaLogs Collector - collects logs from Kubernetes containers and stores them to VictoriaLogs
-version: 0.2.2
+version: 0.2.3
 appVersion: v1.43.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-logs-collector/templates/_helpers.tpl
+++ b/charts/victoria-logs-collector/templates/_helpers.tpl
@@ -118,7 +118,9 @@
       {{- end }}
       {{- $value := $rwValue }}
       {{- if eq $rwKey "url" }}
-        {{- $value = printf "%s/insert/native" (trimSuffix "/" $rwValue) }}
+        {{- $url := urlParse $rwValue }}
+        {{- $_ = set $url "path" (ternary "/insert/native" $url.path (empty (trimPrefix "/" $url.path))) }}
+        {{- $value = urlJoin $url }}
       {{- else if eq $rwKey "headers" }}
         {{- $headers := list }}
         {{- range $hk, $hv := $rwValue }}

--- a/charts/victoria-logs-collector/values.yaml
+++ b/charts/victoria-logs-collector/values.yaml
@@ -18,7 +18,7 @@ image:
 
 # -- List of log destinations. Logs will be replicated to all listed destinations.
 #
-# If using a proxy (e.g., vmauth, nginx) in front of VictoriaLogs, make sure /insert/jsonline and /insert/native endpoints are properly routed.
+# If the url path is not specified, the logs will be sent to the /insert/native endpoint.
 remoteWrite: []
   # - url: http://victoria-logs:9428
 


### PR DESCRIPTION
This can be useful in cases where VictoriaLogs is deployed behind a proxy, such as vmauth or nginx.