### PR TITLE
 Add vlagent chart serviceMonitor

### DIFF
--- a/charts/victoria-logs-agent/Chart.yaml
+++ b/charts/victoria-logs-agent/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 appVersion: v1.43.1
 name: victoria-logs-agent
 description: VictoriaLogs Agent - accepts logs from various protocols and replicates them across multiple VictoriaLogs instances.
-version: 0.0.3
+version: 0.0.4
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-agent/templates/monitor.yaml
+++ b/charts/victoria-logs-agent/templates/monitor.yaml
@@ -1,0 +1,49 @@
+{{- $serviceMonitor := .Values.serviceMonitor -}}
+{{- if $serviceMonitor.enabled -}}
+{{- $ctx := dict "helm" . }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  {{- with $serviceMonitor.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $_ := set $ctx "extraLabels" $serviceMonitor.extraLabels }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- $_ := unset $ctx "extraLabels" }}
+  name: {{ include "vm.fullname" $ctx }}
+  {{- with $serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ include "vm.namespace" $ctx }}
+  selector:
+    matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- with $serviceMonitor.basicAuth }}
+      basicAuth: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with $serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with $serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with $serviceMonitor.tlsConfig }}
+      tlsConfig: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $serviceMonitor.relabelings }}
+      relabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $serviceMonitor.targetPort }}
+      targetPort: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/victoria-logs-agent/values.yaml
+++ b/charts/victoria-logs-agent/values.yaml
@@ -166,6 +166,29 @@ affinity: {}
 # -- Priority class to be assigned to the pod(s)
 priorityClassName: ""
 
+serviceMonitor:
+  # -- Enable deployment of Service Monitor for server component. This is Prometheus operator object
+  enabled: false
+  # -- Service Monitor labels
+  extraLabels: {}
+  # -- Service Monitor annotations
+  annotations: {}
+  # -- Service Monitor relabelings
+  relabelings: []
+  # -- Basic auth params for Service Monitor
+  basicAuth: {}
+  # -- Service Monitor metricRelabelings
+  metricRelabelings: []
+  # -- Service Monitor targetPort
+  targetPort: http
+  # interval: 15s
+  # scrapeTimeout: 5s
+  # -- Commented. HTTP scheme to use for scraping.
+  # scheme: https
+  # -- Commented. TLS configuration to use when scraping the endpoint
+  # tlsConfig:
+  #   insecureSkipVerify: true
+
 service:
   # -- Enable agent service
   enabled: false


### PR DESCRIPTION
This is for the same scrape compatibility as for other Victoira components to be monitored and then vlagent dashboard can be reused same way as other dashboards.