### PR TITLE
victoria-logs-collector: rename container for easier metrics tracking

### DIFF
--- a/charts/victoria-logs-collector/templates/server.yaml
+++ b/charts/victoria-logs-collector/templates/server.yaml
@@ -38,7 +38,7 @@ spec:
       imagePullSecrets: {{ toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: collector
+        - name: vlagent
           image: {{ include "vm.image" $ctx }}
           imagePullPolicy: IfNotPresent
           {{- if .Values.securityContext.enabled }}

--- a/charts/victoria-logs-collector/tests/__snapshot__/collector_test.yaml.snap
+++ b/charts/victoria-logs-collector/tests/__snapshot__/collector_test.yaml.snap
@@ -75,12 +75,13 @@ daemonSet should match snapshot:
                 - --kubernetesCollector.includePodLabels
                 - --kubernetesCollector.msgField=message,msg
                 - --kubernetesCollector.timeField=time,ts,timestamp
+                - --loggerFormat=json
                 - --remoteWrite.headers="AccountID:0^^ProjectID:0"
                 - --remoteWrite.url=http://victoria-logs:9428/insert/native
                 - --tmpDataPath=/vl-collector
               image: victoriametrics/vlagent:0.1.0
               imagePullPolicy: IfNotPresent
-              name: collector
+              name: vlagent
               ports:
                 - containerPort: 9429
                   name: http


### PR DESCRIPTION
Current container name is too common. When looking at the metrics, it's not clear which "collector" is being referred to.