### PR TITLE
operator: add configReloaderImage section

### DIFF
--- a/charts/victoria-metrics-operator/templates/server.yaml
+++ b/charts/victoria-metrics-operator/templates/server.yaml
@@ -71,6 +71,10 @@ spec:
             - name: VM_CONTAINERREGISTRY
               value: {{ quote . }}
             {{- end -}}
+            {{- with .Values.configReloaderImage }}
+            - name: VM_CONFIG_RELOADER_IMAGE
+              value: {{ .repository | default "" }}{{ .registry }}:{{ .tag }}
+            {{- end -}}
             {{- if .Values.operator.disable_prometheus_converter }}
             - name: VM_ENABLEDPROMETHEUSCONVERTER_PODMONITOR
               value: "false"

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -29,6 +29,11 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
+configReloaderImage: {}
+  # registry: ""
+  # repository: ""
+  # tag: "" 
+
 crds:
   # -- manages CRD creation. Disables CRD creation only in combination with `crds.plain: false` due to helm dependency conditions limitation
   enabled: true


### PR DESCRIPTION
This provides a renovate-or-similar friendly way to specify the config-reloader image tag, which can be automatically updated.
Specifically, this allows including the image digest in the image tag, which is different between the operator and the config-reloader tag

Closes #2665 