### PR TITLE
fix: remove unnecessary nodes/proxy RBAC permissions

### DIFF
--- a/charts/victoria-metrics-agent/templates/rbac.yaml
+++ b/charts/victoria-metrics-agent/templates/rbac.yaml
@@ -63,7 +63,6 @@ rules:
 - apiGroups: [""]
   resources:
   - nodes
-  - nodes/proxy
   - nodes/metrics
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: {{ toYaml .Values.allowedMetricsEndpoints | nindent 2 }}

--- a/charts/victoria-metrics-operator/templates/role.yaml
+++ b/charts/victoria-metrics-operator/templates/role.yaml
@@ -88,7 +88,6 @@ rules:
   resources:
   - configmaps/status
   - nodes
-  - nodes/proxy
   - nodes/metrics
   - namespaces
   verbs:

--- a/charts/victoria-metrics-single/templates/rbac.yaml
+++ b/charts/victoria-metrics-single/templates/rbac.yaml
@@ -22,7 +22,6 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
-      - nodes/proxy
       - nodes/metrics
       - services
       - endpoints


### PR DESCRIPTION
The `nodes/proxy` permission is not required for the VMAgent's operation and may be used to raise privileges.

See https://github.com/VictoriaMetrics/operator/issues/1753 for more information