### PR TITLE
victoria-metrics-operator: Add shareProcessNamespace flag

### DIFF
--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added .Values.shareProcessNamespace
 
 ## 0.58.1
 

--- a/charts/victoria-metrics-operator/templates/server.yaml
+++ b/charts/victoria-metrics-operator/templates/server.yaml
@@ -37,6 +37,9 @@ spec:
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}
+      {{- if .Values.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
       {{- if or (.Values.serviceAccount).name (.Values.serviceAccount).create }}
       serviceAccountName: {{ (.Values.serviceAccount).name | default $fullname }}
       {{- end }}

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -357,6 +357,9 @@ extraContainers:
 # -- Enable hostNetwork on operator deployment
 hostNetwork: false
 
+# -- Enable sharing process Namespace between Containers in a Pod. This only makes sense with extraContainers
+shareProcessNamespace: false
+
 # -- Configures resource validation
 admissionWebhooks:
   # -- Enables validation webhook.


### PR DESCRIPTION
Recently we had to instrument the operator with [opentelemetry-go-instrumentation](https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/main/docs/getting-started.md#instrument-an-application-in-kubernetes) due to a performance issue.

The `extraContainer` configuration was useful but we also add to enable `shareProcessNamespace` on the pod. We did it with a postrender but it would be nice to be able to do it directly in the chart.