### PR TITLE
victoria-metrics-agent: add VPA support

### DIFF
--- a/charts/victoria-metrics-agent/templates/vpa.yaml
+++ b/charts/victoria-metrics-agent/templates/vpa.yaml
@@ -1,0 +1,28 @@
+{{- $vpa := .Values.verticalPodAutoscaling }}
+{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") $vpa.enabled }}
+{{- $ctx := dict "helm" . }}
+{{- $fullname := include "vm.plain.fullname" $ctx }}
+{{- $ns := include "vm.namespace" $ctx }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  {{- $_ := set $ctx "extraLabels" .Values.extraLabels }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- $_ := unset $ctx "extraLabels" }}
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+spec:
+  {{- with $vpa.recommenders }}
+  recommenders: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: {{ title .Values.mode }}
+    name: {{ $fullname }}
+  {{- with $vpa.updatePolicy }}
+  updatePolicy: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $vpa.resourcePolicy }}
+  resourcePolicy: {{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -419,6 +419,31 @@ horizontalPodAutoscaling:
   # -- Metric for HPA to use to scale vmagent
   metrics: []
 
+# -- Vertical Pod Autoscaling.
+# Requires VPA CRD (`autoscaling.k8s.io/v1`) to be installed in the cluster.
+# Note that VPA should not be used together with HPA on the same resource metrics (CPU/memory).
+verticalPodAutoscaling:
+  # -- Use VPA for vmagent
+  enabled: false
+  # -- List of custom recommenders to use
+  # recommenders:
+  #   - name: 'alternative'
+  # -- Update policy for VPA
+  # updatePolicy:
+  #   updateMode: "Auto"
+  #   minReplicas: 1
+  # -- Resource policy for VPA
+  # resourcePolicy:
+  #   containerPolicies:
+  #     - containerName: '*'
+  #       minAllowed:
+  #         cpu: 100m
+  #         memory: 128Mi
+  #       maxAllowed:
+  #         cpu: 1
+  #         memory: 500Mi
+  #       controlledResources: ["cpu", "memory"]
+
 # -- VMAgent scrape configuration
 config:
   # -- Enable config templating


### PR DESCRIPTION
## Summary
- Add `VerticalPodAutoscaler` template (`vpa.yaml`) to the `victoria-metrics-agent` chart
- Add `verticalPodAutoscaling` values section with support for `recommenders`, `updatePolicy`, and `resourcePolicy`
- Template follows the same conventions as the existing HPA template (labels, dynamic `kind` based on `.Values.mode`, naming)
- Includes a cluster capability check for `autoscaling.k8s.io/v1` CRD before rendering

## Details
The VPA template:
- Is gated behind `verticalPodAutoscaling.enabled: false` (disabled by default)
- Requires the VPA CRD (`autoscaling.k8s.io/v1`) to be installed in the cluster
- Dynamically targets the correct workload kind (`Deployment`, `StatefulSet`, or `DaemonSet`) via `{{ title .Values.mode }}`, consistent with the HPA template
- Uses the same `$ctx`/`vm.plain.fullname`/`vm.namespace`/`vm.labels` helpers as all other templates in this chart
- Follows the pattern established by `victoria-metrics-alert`'s VPA implementation

## Test plan
- [ ] `helm template` with `verticalPodAutoscaling.enabled: true` produces a valid VPA manifest
- [ ] `helm template` with default values produces no VPA resource
- [ ] VPA `targetRef.kind` matches the configured `.Values.mode` (deployment/statefulSet/daemonSet)
- [ ] Labels and naming are consistent with other chart resources

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds VerticalPodAutoscaler (VPA) support to the victoria-metrics-agent Helm chart for automatic CPU/memory sizing. Disabled by default and renders only when the VPA CRD is available.

- **New Features**
  - Added vpa.yaml template following existing HPA conventions (labels, naming).
  - Introduced verticalPodAutoscaling values: recommenders, updatePolicy, resourcePolicy.
  - Targets Deployment/StatefulSet/DaemonSet based on .Values.mode.

- **Migration**
  - Install VPA in the cluster (autoscaling.k8s.io/v1) and enable verticalPodAutoscaling.enabled: true.
  - Avoid using VPA with HPA on the same CPU/memory metrics.

<sup>Written for commit e2f128e947031777eef95800ba57fe0603e20e28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

