### PR TITLE
charts: update vm apps to v1.136.0

### DIFF
--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.136.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.136.0)
 
 ## 0.31.0
 

--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 type: application
 name: victoria-metrics-agent
 description: VictoriaMetrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
-version: 0.31.0
-appVersion: v1.135.0
+version: 0.32.0
+appVersion: v1.136.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.136.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.136.0)
 
 ## 0.31.0
 

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 type: application
 name: victoria-metrics-alert
 description: VictoriaMetrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.31.0
-appVersion: v1.135.0
+version: 0.32.0
+appVersion: v1.136.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.136.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.136.0)
 
 ## 0.24.0
 

--- a/charts/victoria-metrics-auth/Chart.yaml
+++ b/charts/victoria-metrics-auth/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Auth - is a simple auth proxy and router for VictoriaMetrics.
 name: victoria-metrics-auth
-version: 0.24.0
-appVersion: v1.135.0
+version: 0.25.0
+appVersion: v1.136.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.136.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.136.0)
 
 ## 0.34.0
 

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.34.0
-appVersion: v1.135.0
+version: 0.35.0
+appVersion: v1.136.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- bump version of VM components to [v1.136.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.136.0)
 - updates k8s-stack to v0.70.0 version
 
 ## 0.29.0

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: victoria-metrics-distributed
 description: A Helm chart for Running VMCluster on Multiple Availability Zones
 type: application
-version: 0.29.0
-appVersion: v1.135.0
+version: 0.30.0
+appVersion: v1.136.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.25.0-0"

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.136.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.136.0)
 
 ## 0.22.0
 

--- a/charts/victoria-metrics-gateway/Chart.yaml
+++ b/charts/victoria-metrics-gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Gateway - Auth & Rate-Limitting proxy for Victoria Metrics
 name: victoria-metrics-gateway
-version: 0.22.0
-appVersion: v1.135.0
+version: 0.23.0
+appVersion: v1.136.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- bump version of VM components to [v1.136.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.136.0)
 - support extra labels for default scrape configurations. See [#2688](https://github.com/VictoriaMetrics/helm-charts/issues/2688).
 
 ## 0.70.0

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.70.0
-appVersion: v1.135.0
+version: 0.71.0
+appVersion: v1.136.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.136.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.136.0)
 
 ## 0.30.0
 

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.30.0
-appVersion: v1.135.0
+version: 0.31.0
+appVersion: v1.136.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.25.0-0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update all VictoriaMetrics Helm charts to appVersion v1.136.0 and refresh changelogs to match the upstream release. Bump chart versions: agent 0.32.0, alert 0.32.0, auth 0.25.0, cluster 0.35.0, distributed 0.30.0, gateway 0.23.0, k8s-stack 0.71.0, single 0.31.0.

<sup>Written for commit 4a182a3c7af71825033e9f84fbac338be3dbdfbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

