### PR TITLE
anomaly: added ingress and httproute support

### DIFF
--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- support ingress and httproute. See [#2705](https://github.com/VictoriaMetrics/helm-charts/issues/2705).
 
 ## 1.12.10
 

--- a/charts/victoria-metrics-anomaly/templates/ingress.yaml
+++ b/charts/victoria-metrics-anomaly/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- $ingress := .Values.ingress }}
+{{- if $ingress.enabled  }}
+{{- $shardingEnabled := gt (int .Values.shardsCount) 1 }}
+{{- if $shardingEnabled }}
+  {{- fail ".Values.ingress.enabled is not allowed when sharding is enabled" }}
+{{- end }}
+{{- $ctx := dict "helm" . }}
+{{- $fullname := include "vm.plain.fullname" $ctx }}
+{{- $ns := include "vm.namespace" $ctx }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  {{- with $ingress.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $_ := set $ctx "extraLabels" $ingress.labels }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- $_ := unset $ctx "extraLabels" }}
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+spec:
+  {{- with $ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with $ingress.tls }}
+  tls: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range $host := $ingress.hosts }}
+    {{- $paths := ternary (list $host.path) $host.path (kindIs "string" $host.path) }}
+    - host: {{ tpl $host.name $ | quote }}
+      http:
+        paths:
+          {{- range $path := $paths }}
+          - path: {{ $path }}
+            {{- with $ingress.pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ $fullname }}
+                port: {{ include "vm.ingress.port" $host | nindent 18 }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/victoria-metrics-anomaly/templates/route.yaml
+++ b/charts/victoria-metrics-anomaly/templates/route.yaml
@@ -1,0 +1,46 @@
+{{- $route := .Values.route }}
+{{- if $route.enabled  }}
+{{- $shardingEnabled := gt (int .Values.shardsCount) 1 }}
+{{- if $shardingEnabled }}
+  {{- fail ".Values.route.enabled is not allowed when sharding is enabled" }}
+{{- end }}
+{{- $ctx := dict "helm" . }}
+{{- $fullname := include "vm.plain.fullname" $ctx }}
+{{- $ns := include "vm.namespace" $ctx }}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+  {{- $_ := set $ctx "extraLabels" $route.labels }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- $_ := unset $ctx "extraLabels" }}
+  {{- with $route.annotations }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.extraRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    - backendRefs:
+        - name: {{ $fullname }}
+          port: {{ $route.port }}
+          group: ''
+          kind: Service
+          weight: 1
+      {{- with $route.filters }}
+      filters: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+
+{{- end }}

--- a/charts/victoria-metrics-anomaly/templates/server.yaml
+++ b/charts/victoria-metrics-anomaly/templates/server.yaml
@@ -56,12 +56,16 @@ spec:
         - name: model
           image: {{ include "vm.image" $ctx }}
           workingDir: {{ .Values.containerWorkingDir }}
-          {{- if (((.Values.config).monitoring).pull).enabled }}
-          {{- with (((.Values.config).monitoring).pull).port }}
+          {{- if or (((.Values.config).monitoring).pull).enabled ((.Values.config).server).port }}
           ports:
+            {{- with (((.Values.config).monitoring).pull).port }}
             - containerPort: {{ . }}
               name: metrics
-          {{- end }}
+            {{- end }}
+            {{- with ((.Values.config).server).port }}
+            - containerPort: {{ . }}
+              name: http
+            {{- end }}
           {{- end }}
           args: {{ include "vmanomaly.args" $ctx | nindent 12 }}
           {{- with .Values.envFrom }}

--- a/charts/victoria-metrics-anomaly/templates/service.yaml
+++ b/charts/victoria-metrics-anomaly/templates/service.yaml
@@ -1,0 +1,69 @@
+{{- $service := .Values.service }}
+{{- if $service.enabled }}
+{{- $shardingEnabled := gt (int .Values.shardsCount) 1 }}
+{{- if $shardingEnabled }}
+  {{- fail ".Values.service.enabled is not allowed when sharding is enabled" }}
+{{- end }}
+{{- $pvc := .Values.persistentVolume }}
+{{- $mode := ternary "statefulSet" "deployment" $pvc.enabled }}
+{{- $ctx := dict "helm" . }}
+{{- $fullname := include "vm.plain.fullname" $ctx }}
+{{- $ns := include "vm.namespace" $ctx }}
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ $ns }}
+  {{- with $service.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $_ := set $ctx "extraLabels" $service.labels }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- $_ := unset $ctx "extraLabels" }}
+  name: {{ $fullname }}
+spec:
+  {{- with $service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
+  {{- $type := $service.type }}
+  {{- if and (not $type) (eq $mode "statefulSet") }}
+    {{- $type = "ClusterIP" }}
+  {{- end }}
+  {{- with $type }}
+  type: {{ . }}
+  {{- end }}
+  {{- if eq $type "ClusterIP" }}
+  {{- with $service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- with $service.externalIPs }}
+  externalIPs: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with $service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $service.healthCheckNodePort }}
+  healthCheckNodePort: {{ . }}
+  {{- end }}
+  {{- with $service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- with $service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with $service.ipFamilies }}
+  ipFamilies: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ $service.servicePort }}
+      protocol: TCP
+      targetPort: {{ $service.targetPort }}
+      {{- with $service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+  selector: {{ include "vm.selectorLabels" $ctx | nindent 4 }}
+{{- end }}

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -267,5 +267,86 @@ license:
     # -- Key in secret with license key
     key: ""
 
+service:
+  enabled: false
+  # -- Service traffic distribution. Details are [here](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution)
+  trafficDistribution: ""
+  # -- Service annotations
+  annotations: {}
+  # -- Service labels
+  labels: {}
+  # -- Service ClusterIP
+  clusterIP: "None"
+  # -- Service external IPs. Details are [here](https://kubernetes.io/docs/concepts/services-networking/service/#external-ips)
+  externalIPs: []
+  # -- Service load balancer IP
+  loadBalancerIP: ""
+  # -- Load balancer source range
+  loadBalancerSourceRanges: []
+  # -- Service port
+  servicePort: 8490
+  # -- Target port
+  targetPort: http
+  # -- Node port
+  # nodePort: 30000
+  # -- Service type
+  type: ClusterIP
+  # -- Service external traffic policy. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
+  externalTrafficPolicy: ""
+  # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
+  healthCheckNodePort: ""
+  # -- Service IP family policy. Check [here](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) for details.
+  ipFamilyPolicy: ""
+  # -- List of service IP families. Check [here](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) for details.
+  ipFamilies: []
+
+ingress:
+  # -- Enable deployment of ingress
+  enabled: false
+  # -- Ingress annotations
+  annotations: {}
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: 'true'
+
+  # -- Ingress extra labels
+  labels: {}
+  # -- Array of host objects
+  hosts:
+    - name: vmanomaly.local
+      path:
+        - /
+      port: http
+
+  # -- Array of TLS objects
+  tls: []
+  #   - secretName: vmanomaly-ingress-tls
+  #     hosts:
+  #       - vmanomaly.local
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # ingressClassName: nginx
+  pathType: Prefix
+
+route:
+  # -- Enable deployment of HTTPRoute
+  enabled: false
+  # -- HTTPRoute annotations
+  annotations: {}
+  # -- HTTPRoute extra labels
+  labels: {}
+  # -- HTTPGateway objects refs
+  parentRefs: []
+  # -- Array of hostnames
+  hostnames: []
+  # -- Extra rules to prepend to route. This is useful when working with annotation based services.
+  extraRules: []
+  # -- Filters for a default rule in HTTPRoute
+  filters: []
+  # -- Matches for a default rule in HTTPRoute
+  matches:
+    - path:
+        type: PathPrefix
+        value: '/'
+
 # -- Add extra specs dynamically to this chart
 extraObjects: []


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/helm-charts/issues/2705

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Service, Ingress, and Gateway API HTTPRoute support to expose vmanomaly over HTTP (fixes #2705). Also exposes the HTTP port in the container for easy external access.

- **New Features**
  - Service for HTTP (default 8490) with configurable type, annotations, traffic distribution, LB/IP fields, and IP families.
  - Ingress with hosts/paths, per-host service port, TLS, ingressClassName, pathType, and extra labels.
  - Gateway API HTTPRoute with parentRefs, hostnames, matches/filters, extraRules, and overridable apiVersion/kind.
  - Values updated to configure all of the above.

- **Migration**
  - Set values.config.server.port to expose a named "http" container port, or set service.targetPort to a number.
  - Enable service.enabled, then choose and configure either ingress or route:
    - ingress: set ingress.enabled and hosts/TLS.
    - route: set route.enabled and route.port to your service port, plus parentRefs/hostnames.
  - Ensure shardsCount == 1; service/ingress/route are blocked when sharding is enabled.

<sup>Written for commit 19d3af635d78869864a0cd9070d64e9f0f46057c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

