### PR TITLE
added logs and traces CRs to k8s-stack

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 **Update note 3**: Helm-rendered dashboard ConfigMaps and VMRules are removed. Dashboards and rules are now fetched and applied at deploy time by the sync-job (`syncJob.enabled: true` by default). Disable `syncJob.enabled` only if managing dashboards and rules externally.
 
+- add traces storage support: `vtsingle` and `vtcluster` deploy operator-managed `VTSingle`/`VTCluster` CRs; ports follow the `10xxx` scheme (single `10428`, insert `10481`, select `10471`, storage `10491`); Grafana Jaeger datasource is auto-provisioned pointing at `<endpoint>/select/jaeger`; dashboard sync entries for single-node and cluster views are included
+- add logs collection and storage support: VLSingle, VLCluster, VLAgent with `k8sCollector` for automatic Kubernetes logs collection, Grafana datasource integration, and internal VMAuth routing when both metrics and logs backends are configured. See [#1910](https://github.com/VictoriaMetrics/helm-charts/issues/1910) and [#1909](https://github.com/VictoriaMetrics/helm-charts/issues/1909)
 - introduce sync-job config with `common` section (`clusterLabel`, `multicluster`) shared across dashboards and rules; Grafana-specific settings (`labelName`, `labelValue`, `datasource`, `operator`) live under `dashboards.common.grafana`
 - add `defaultRules.rules` global per-rule overrides map to patch spec or enable/disable individual rules across all groups
 - add per-group `spec:` support in `defaultRules.groups` for VMRule group-level properties (e.g. `interval`, `params`)

--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
+  version: 0.3.10
 - name: victoria-metrics-operator
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.65.0
+  version: 0.65.1
 - name: kube-state-metrics
   repository: oci://ghcr.io/prometheus-community/charts
   version: 7.5.1
@@ -14,5 +14,5 @@ dependencies:
 - name: grafana
   repository: oci://ghcr.io/grafana-community/helm-charts
   version: 12.3.3
-digest: sha256:3f7bff2042b504ce9d1ada9c653f184ca5b9b9576b3a01b228b13d76b42f08f1
-generated: "2026-06-15T18:50:40.552661+03:00"
+digest: sha256:e85b81fcd0fd16119829683f22d85c00c75d3575ee56be1c0f949565d8695b89
+generated: "2026-06-19T09:21:01.378829+03:00"

--- a/charts/victoria-metrics-k8s-stack/_index.md.gotmpl
+++ b/charts/victoria-metrics-k8s-stack/_index.md.gotmpl
@@ -25,13 +25,15 @@ tags:
 * [Uninstall](https://docs.victoriametrics.com/helm/victoria-metrics-k8s-stack/#how-to-uninstall)
 * [Version Upgrade](https://docs.victoriametrics.com/helm/victoria-metrics-k8s-stack/#upgrade-guide)
 * [Troubleshooting](https://docs.victoriametrics.com/helm/victoria-metrics-k8s-stack/#troubleshooting)
+* [Logs storage and collection](https://docs.victoriametrics.com/helm/victoria-metrics-k8s-stack/#logs-storage-and-collection)
+* [Traces storage](https://docs.victoriametrics.com/helm/victoria-metrics-k8s-stack/#traces-storage)
 * [Values](https://docs.victoriametrics.com/helm/victoria-metrics-k8s-stack/#parameters)
 
 ## Overview
 
-This chart is an All-in-one solution to start monitoring kubernetes cluster.
+This chart is an All-in-one solution to start monitoring and logging in a Kubernetes cluster.
 It installs multiple dependency charts like [grafana](https://github.com/grafana/helm-charts/tree/main/charts/grafana), [node-exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter), [kube-state-metrics](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) and [victoria-metrics-operator](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-operator).
-Also it installs Custom Resources like [VMSingle](https://docs.victoriametrics.com/operator/resources/vmsingle/), [VMCluster](https://docs.victoriametrics.com/operator/resources/vmcluster/), [VMAgent](https://docs.victoriametrics.com/operator/resources/vmagent/), [VMAlert](https://docs.victoriametrics.com/operator/resources/vmalert/).
+Also it installs Custom Resources like [VMSingle](https://docs.victoriametrics.com/operator/resources/vmsingle/), [VMCluster](https://docs.victoriametrics.com/operator/resources/vmcluster/), [VMAgent](https://docs.victoriametrics.com/operator/resources/vmagent/), [VMAlert](https://docs.victoriametrics.com/operator/resources/vmalert/) for metrics, optionally [VLSingle](https://docs.victoriametrics.com/operator/resources/vlsingle/), [VLCluster](https://docs.victoriametrics.com/operator/resources/vlcluster/), [VLAgent](https://docs.victoriametrics.com/operator/resources/vlagent/) for logs, and [VTSingle](https://docs.victoriametrics.com/operator/resources/vtsingle/), [VTCluster](https://docs.victoriametrics.com/operator/resources/vtcluster/) for traces.
 
 By default, the operator [converts all existing prometheus-operator API objects](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion) into corresponding VictoriaMetrics Operator objects.
 
@@ -206,6 +208,157 @@ kubelet:
   # https://docs.victoriametrics.com/operator/api/#vmnodescrapespec
   spec:
     interval: "30s"
+```
+
+### Logs storage and collection
+
+This chart supports deploying [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/) alongside VictoriaMetrics for logs storage and collection.
+
+#### Logs storage
+
+Enable **VLSingle** for a single-node logs storage deployment:
+
+```yaml
+vlsingle:
+  enabled: true
+  spec:
+    retentionPeriod: 30d
+    storage:
+      resources:
+        requests:
+          storage: 50Gi
+```
+
+Enable **VLCluster** for a highly-available clustered deployment (mutually exclusive with VLSingle):
+
+```yaml
+vlcluster:
+  enabled: true
+  spec:
+    retentionPeriod: 30d
+    vlstorage:
+      replicaCount: 2
+    vlselect:
+      replicaCount: 2
+    vlinsert:
+      replicaCount: 2
+```
+
+To connect to an existing VictoriaLogs instance instead of deploying one, use the external URL configuration:
+
+```yaml
+external:
+  vl:
+    read:
+      url: http://your-victorialogs-host:9428
+    write:
+      url: http://your-victorialogs-host:9428
+```
+
+#### Logs collection
+
+Enable **VLAgent** to collect logs from Kubernetes pods and nodes:
+
+```yaml
+vlagent:
+  enabled: true
+  spec:
+    k8sCollector:
+      enabled: true
+```
+
+VLAgent automatically writes logs to the configured VictoriaLogs storage (VLSingle, VLCluster, or external). Additional remote write targets can be configured via `vlagent.additionalRemoteWrites`.
+
+#### Grafana datasource for VictoriaLogs
+
+When VLSingle, VLCluster, or an external VL URL is configured, a `VictoriaLogs (DS)` Grafana datasource is automatically provisioned. It requires the `victoriametrics-logs-datasource` Grafana plugin:
+
+```yaml
+grafana:
+  plugins:
+    - victoriametrics-logs-datasource
+```
+
+Without this plugin, the datasource entry will exist in Grafana but the plugin will not be available to use it.
+
+#### VMAlert with both VictoriaMetrics and VictoriaLogs
+
+When both a VM read endpoint (VLSingle, VMCluster, or external) and a VL read endpoint are configured and `vmalert.enabled` is `true`, the chart automatically deploys an internal VMAuth proxy that routes VMAlert datasource queries:
+
+- `/select/logsql/.*` → VictoriaLogs (for LogsQL alert rules)
+- `/.*` → VictoriaMetrics (for MetricsQL alert rules)
+
+No additional configuration is needed — the routing is handled transparently. This allows VMAlert to evaluate both MetricsQL and LogsQL rules against the correct backend.
+
+### Traces storage
+
+This chart supports deploying [VictoriaTraces](https://docs.victoriametrics.com/victorialogs/) alongside VictoriaMetrics for distributed traces storage.
+
+#### VTSingle (single-node)
+
+Enable **VTSingle** for a single-node traces storage deployment:
+
+```yaml
+vtsingle:
+  enabled: true
+  spec:
+    retentionPeriod: "7"    # days
+    storage:
+      resources:
+        requests:
+          storage: 20Gi
+```
+
+#### VTCluster
+
+Enable **VTCluster** for a highly-available clustered deployment (mutually exclusive with VTSingle):
+
+```yaml
+vtcluster:
+  enabled: true
+  spec:
+    retentionPeriod: 14d
+    vtstorage:
+      replicaCount: 2
+```
+
+#### External traces instance
+
+To connect to an existing VictoriaTraces instance instead of deploying one:
+
+```yaml
+external:
+  vt:
+    read:
+      url: http://your-victoriatraces-host:10428
+    write:
+      url: http://your-victoriatraces-host:10428
+```
+
+#### Grafana datasource for VictoriaTraces
+
+When VTSingle, VTCluster, or an external VT URL is configured, a `VictoriaTraces` Grafana datasource is automatically provisioned. It uses the Jaeger-compatible API exposed at `<endpoint>/select/jaeger`:
+
+| Field | Value |
+|---|---|
+| Name | `VictoriaTraces` |
+| UID | `VictoriaTraces` |
+| Type | `jaeger` |
+| URL | auto-set from the VTSingle / VTCluster service endpoint |
+
+The Jaeger datasource type is built into Grafana — no additional plugin is required.
+
+Additional datasource properties can be customised under `defaultDatasources.victoriatraces.datasources`:
+
+```yaml
+defaultDatasources:
+  victoriatraces:
+    datasources:
+      - name: VictoriaTraces
+        uid: VictoriaTraces
+        type: jaeger
+        jsonData:
+          tlsSkipVerify: true
 ```
 
 ### Using externally managed Grafana

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -7,14 +7,10 @@
     {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
   {{- else if and $Values.vmcluster.enabled $Values.vmcluster.spec.vmselect.enabled -}}
     {{- $_ := set . "appKey" (list "vmcluster" "spec" "vmselect") -}}
-    {{- $baseURL := include "vm.url" . -}}
-    {{- $tenant := $Values.tenant | default 0 -}}
-    {{- $_ := set $endpoint "url" (printf "%s/select/%d/prometheus" $baseURL (int $tenant)) -}}
-  {{- else if $Values.vmdistributed.enabled }}
+    {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
+  {{- else if $Values.vmdistributed.enabled -}}
     {{- $_ := set . "appKey" (list "vmdistributed" "spec" "vmauth" "spec") -}}
-    {{- $baseURL := include "vm.url" . -}}
-    {{- $tenant := $Values.tenant | default 0 -}}
-    {{- $_ := set $endpoint "url" (printf "%s/select/%d/prometheus" $baseURL (int $tenant)) -}}
+    {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
   {{- else if $Values.external.vm.read.url -}}
     {{- $endpoint = $Values.external.vm.read -}}
   {{- end -}}
@@ -29,23 +25,46 @@
   {{- $_ := set . "style" "managed" -}}
   {{- if $Values.vmsingle.enabled -}}
     {{- $_ := set . "appKey" (list "vmsingle" "spec") -}}
-    {{- $baseURL := include "vm.url" . -}}
-    {{- $_ := set $endpoint "url" (printf "%s/api/v1/write" $baseURL) -}}
+    {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
   {{- else if and $Values.vmcluster.enabled $Values.vmcluster.spec.vminsert.enabled -}}
     {{- $_ := set . "appKey" (list "vmcluster" "spec" "vminsert") -}}
-    {{- $baseURL := include "vm.url" . -}}
-    {{- $tenant := $Values.tenant | default 0 -}}
-    {{- $_ := set $endpoint "url" (printf "%s/insert/%d/prometheus/api/v1/write" $baseURL (int $tenant)) -}}
-  {{- else if $Values.vmdistributed.enabled }}
+    {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
+  {{- else if $Values.vmdistributed.enabled -}}
     {{- $_ := set . "appKey" (list "vmdistributed" "spec" "vmauth" "spec") -}}
-    {{- $baseURL := include "vm.url" . -}}
-    {{- $tenant := $Values.tenant | default 0 -}}
-    {{- $_ := set $endpoint "url" (printf "%s/insert/%d/prometheus/api/v1/write" $baseURL (int $tenant)) -}}
+    {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
   {{- else if $Values.external.vm.write.url -}}
     {{- $endpoint = $Values.external.vm.write -}}
   {{- end -}}
   {{- with $endpoint -}}
     {{- toYaml . -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* vm.prometheus.read appends /select/<tenant>/prometheus to vm.read.endpoint for cluster/distributed deployments */ -}}
+{{- define "vm.prometheus.read" -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $endpoint := fromYaml (include "vm.read.endpoint" .) -}}
+  {{- if $endpoint.url -}}
+    {{- if or (and $Values.vmcluster.enabled $Values.vmcluster.spec.vmselect.enabled) $Values.vmdistributed.enabled -}}
+      {{- $tenant := $Values.tenant | default 0 -}}
+      {{- $_ := set $endpoint "url" (printf "%s/select/%d/prometheus" $endpoint.url (int $tenant)) -}}
+    {{- end -}}
+    {{- toYaml $endpoint -}}
+  {{- end -}}
+{{- end }}
+
+{{- /* vm.prometheus.write appends the prometheus remote-write path to vm.write.endpoint */ -}}
+{{- define "vm.prometheus.write" -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $endpoint := fromYaml (include "vm.write.endpoint" .) -}}
+  {{- if $endpoint.url -}}
+    {{- if $Values.vmsingle.enabled -}}
+      {{- $_ := set $endpoint "url" (printf "%s/api/v1/write" $endpoint.url) -}}
+    {{- else if or (and $Values.vmcluster.enabled $Values.vmcluster.spec.vminsert.enabled) $Values.vmdistributed.enabled -}}
+      {{- $tenant := $Values.tenant | default 0 -}}
+      {{- $_ := set $endpoint "url" (printf "%s/insert/%d/prometheus/api/v1/write" $endpoint.url (int $tenant)) -}}
+    {{- end -}}
+    {{- toYaml $endpoint -}}
   {{- end -}}
 {{- end -}}
 
@@ -56,22 +75,35 @@
   {{- $remotes := dict -}}
   {{- $fullname := include "vm.managed.fullname" . -}}
   {{- $_ := set $ctx "style" "managed" -}}
-  {{- $remoteWrite := include "vm.write.endpoint" $ctx | fromYaml -}}
+  {{- $vmRemoteWrite := include "vm.prometheus.write" $ctx | fromYaml -}}
   {{- if and $Values.vmalert.remoteWriteVMAgent $Values.vmagent.enabled -}}
     {{- $_ := set $ctx "appKey" (list "vmagent" "spec") -}}
-    {{- $remoteWrite = dict "url" (printf "%s/api/v1/write" (include "vm.url" $ctx)) -}}
+    {{- $vmRemoteWrite = dict "url" (printf "%s/api/v1/write" (include "vm.url" $ctx)) -}}
     {{- $_ := unset $ctx "appKey" -}}
-    {{- $_ := set $remotes "remoteWrite" $remoteWrite -}}
-  {{- else -}}
-    {{- $_ := set $remotes "remoteWrite" $remoteWrite -}}
   {{- end -}}
-  {{- $readEndpoint := include "vm.read.endpoint" $ctx -}}
-  {{- if $readEndpoint }}
-    {{- $remoteRead := fromYaml $readEndpoint -}}
-    {{- $_ := set $remotes "remoteRead" $remoteRead -}}
-    {{- $_ := set $remotes "datasource" $remoteRead -}}
-  {{- else if or (not $Values.vmalert.spec.datasource) (not $Values.vmalert.spec.remoteRead) -}}
-    {{- fail "VM read source required! Either set `vmalert.enabled: false` or provide `vmalert.spec.remoteRead.url` and `vmalert.spec.datasource.url`" -}}
+  {{- with $vmRemoteWrite -}}
+    {{- $_ := set $remotes "remoteWrite" . -}}
+  {{- end -}}
+  {{- $vmReadEndpoint := fromYaml (include "vm.prometheus.read" $ctx) -}}
+  {{- $vlReadEndpoint := fromYaml (include "vl.read.endpoint" $ctx) -}}
+  {{- with $vmReadEndpoint -}}
+    {{- $_ := set $remotes "remoteRead" . -}}
+  {{- end -}}
+  {{- if and $vmReadEndpoint.url $vlReadEndpoint.url -}}
+    {{- $_ := set $ctx "appKey" (list "internal" "vmauth" "spec") -}}
+    {{- $_ := set $ctx "fullname" (include "vm.fullname" $ctx) -}}
+    {{- $_ := set $remotes "datasource" (dict "url" (include "vm.url" $ctx)) -}}
+    {{- $_ := unset $ctx "appKey" -}}
+    {{- $_ := unset $ctx "fullname" -}}
+  {{- else if $vmReadEndpoint.url -}}
+    {{- $_ := set $remotes "datasource" $vmReadEndpoint -}}
+  {{- else if $vlReadEndpoint.url -}}
+    {{- $_ := set $remotes "datasource" $vlReadEndpoint -}}
+  {{- end -}}
+  {{- if not (($remotes.datasource).url) -}}
+    {{- if or (not $Values.vmalert.spec.datasource) (not $Values.vmalert.spec.remoteRead) -}}
+      {{- fail "datasource required for vmalert! Either set `vmalert.enabled: false` or provide a VM/VL read endpoint or `vmalert.spec.datasource.url` and `vmalert.spec.remoteRead.url`" -}}
+    {{- end -}}
   {{- end -}}
   {{- if $Values.vmalert.additionalNotifierConfigs }}
     {{- $configName := printf "%s-additional-notifier" $fullname -}}
@@ -169,11 +201,17 @@
 {{- end -}}
 
 {{- /* VM Agent remoteWrites */ -}}
-{{- define "vm.agent.remote.write" -}}
+{{- /* VMAgent/VLAgent spec. Accepts optional .agentKey and .writeEndpoint on context;
+     defaults to vmagent with vm.prometheus.write when unset. */ -}}
+{{- define "vm.agent.spec" -}}
   {{- $Values := (.helm).Values | default .Values }}
-  {{- $remoteWrites := $Values.vmagent.additionalRemoteWrites | default list }}
-  {{- $rws := $Values.vmagent.spec.remoteWrite | default list }}
-  {{- with include "vm.write.endpoint" . -}}
+  {{- $agentKey := .agentKey | default "vmagent" -}}
+  {{- $agentValues := index $Values $agentKey -}}
+  {{- $image := dict "tag" (include "vm.image.tag" .) }}
+  {{- $remoteWrites := $agentValues.additionalRemoteWrites | default list }}
+  {{- $rws := $agentValues.spec.remoteWrite | default list }}
+  {{- $writeEndpoint := .writeEndpoint | default (include "vm.prometheus.write" .) -}}
+  {{- with $writeEndpoint -}}
     {{- if $rws -}}
       {{- $rws = prepend (slice $rws 1) (mergeOverwrite (fromYaml .) (deepCopy (first $rws))) -}}
     {{- else -}}
@@ -181,60 +219,63 @@
     {{- end -}}
   {{- end -}}
   {{- $remoteWrites = concat $remoteWrites $rws }}
-  {{- toYaml (dict "remoteWrite" $remoteWrites) -}}
-{{- end -}}
-
-{{- /* VMAgent spec */ -}}
-{{- define "vm.agent.spec" -}}
-  {{- $Values := (.helm).Values | default .Values }}
-  {{- $Chart := (.helm).Chart | default .Chart }}
-  {{- $image := dict "tag" (include "vm.image.tag" .) }}
-  {{- $spec := include "vm.agent.remote.write" . | fromYaml -}}
+  {{- $spec := dict "remoteWrite" $remoteWrites -}}
   {{- with (include "vm.license.global" .) -}}
     {{- $_ := set $spec "license" (fromYaml .) -}}
   {{- end -}}
   {{- $_ := set $spec "image" $image -}}
-  {{- tpl (mergeOverwrite (deepCopy $Values.vmagent.spec) (deepCopy $spec) | toYaml) . -}}
+  {{- tpl (mergeOverwrite (deepCopy $agentValues.spec) (deepCopy $spec) | toYaml) . -}}
 {{- end }}
+
+{{- /* Populates .vm, .vl and .vt on the context with read/write URL components */ -}}
+{{- define "vm.auth.context" -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $_ := set . "style" "managed" -}}
+  {{- $vm := dict -}}
+  {{- $vmRead := fromYaml (include "vm.read.endpoint" .) -}}
+  {{- if $vmRead.url -}}
+    {{- $url := urlParse $vmRead.url -}}
+    {{- if and $Values.vmcluster.enabled $Values.vmcluster.spec.vmselect.enabled -}}
+      {{- $_ := set $url "path" (printf "%s/select" $url.path) -}}
+    {{- end -}}
+    {{- $_ := set $vm "read" $url -}}
+  {{- end -}}
+  {{- $vmWrite := fromYaml (include "vm.write.endpoint" .) -}}
+  {{- if $vmWrite.url -}}
+    {{- $url := urlParse $vmWrite.url -}}
+    {{- if and $Values.vmcluster.enabled $Values.vmcluster.spec.vminsert.enabled -}}
+      {{- $_ := set $url "path" (printf "%s/insert" $url.path) -}}
+    {{- end -}}
+    {{- $_ := set $vm "write" $url -}}
+  {{- end -}}
+  {{- $_ := set . "vm" $vm -}}
+  {{- $vl := dict -}}
+  {{- $vlRead := fromYaml (include "vl.read.endpoint" .) -}}
+  {{- if $vlRead.url -}}
+    {{- $_ := set $vl "read" (urlParse $vlRead.url) -}}
+  {{- end -}}
+  {{- $vlWrite := fromYaml (include "vl.write.endpoint" .) -}}
+  {{- if $vlWrite.url -}}
+    {{- $_ := set $vl "write" (urlParse $vlWrite.url) -}}
+  {{- end -}}
+  {{- $_ := set . "vl" $vl -}}
+  {{- $vt := dict -}}
+  {{- $vtRead := fromYaml (include "vt.read.endpoint" .) -}}
+  {{- if $vtRead.url -}}
+    {{- $_ := set $vt "read" (urlParse $vtRead.url) -}}
+  {{- end -}}
+  {{- $vtWrite := fromYaml (include "vt.write.endpoint" .) -}}
+  {{- if $vtWrite.url -}}
+    {{- $_ := set $vt "write" (urlParse $vtWrite.url) -}}
+  {{- end -}}
+  {{- $_ := set . "vt" $vt -}}
+{{- end -}}
 
 {{- /* VMAuth spec */ -}}
 {{- define "vm.auth.spec" -}}
   {{- $Values := (.helm).Values | default .Values }}
   {{- $image := dict "tag" (include "vm.image.tag" .) }}
-  {{- $_ := set . "style" "managed" -}}
-  {{- $vm := dict -}}
-  {{- if $Values.vmsingle.enabled -}}
-    {{- $_ := set . "appKey" (list "vmsingle" "spec") -}}
-    {{- $url := urlParse (include "vm.url" .) -}}
-    {{- $_ := set $vm "read" $url -}}
-    {{- $_ := set $vm "write" $url -}}
-  {{- else if $Values.vmcluster.enabled -}}
-    {{- if $Values.vmcluster.spec.vminsert.enabled -}}
-      {{- $_ := set . "appKey" (list "vmcluster" "spec" "vminsert") -}}
-      {{- $writeURL := urlParse (include "vm.url" .) -}}
-      {{- $_ := set $writeURL "path" (printf "%s/insert" $writeURL.path) -}}
-      {{- $_ := set $vm "write" $writeURL }}
-    {{- else if $Values.external.vm.write.url -}}
-      {{- $_ := set $vm "write" (urlParse $Values.external.vm.write.url) -}}
-    {{- end -}}
-    {{- if $Values.vmcluster.spec.vmselect.enabled -}}
-      {{- $_ := set . "appKey" (list "vmcluster" "spec" "vmselect") -}}
-      {{- $readURL := urlParse (include "vm.url" .) -}}
-      {{- $_ := set $readURL "path" (printf "%s/select" $readURL.path) -}}
-      {{- $_ := set $vm "read" $readURL }}
-    {{- else if $Values.external.vm.read.url -}}
-      {{- $_ := set $vm "read" (urlParse $Values.external.vm.read.url) -}}
-    {{- end -}}
-    {{- $_ := set . "vm" $vm -}}
-  {{- else if or $Values.external.vm.read.url $Values.external.vm.write.url -}}
-    {{- with $Values.external.vm.read.url -}}
-      {{- $_ := set $vm "read" (urlParse .) -}}
-    {{- end -}}
-    {{- with $Values.external.vm.write.url -}}
-      {{- $_ := set $vm "write" (urlParse .) -}}
-    {{- end -}}
-  {{- end -}}
-  {{- $_ := set . "vm" $vm -}}
+  {{- include "vm.auth.context" . -}}
   {{- $spec := deepCopy $Values.vmauth.spec }}
   {{- if $spec.unauthorizedUserAccessSpec }}
     {{- if $spec.unauthorizedUserAccessSpec.disabled }}
@@ -382,12 +423,32 @@
   {{- $ctx := . }}
   {{- $Values := (.helm).Values | default .Values }}
   {{- $datasources := $Values.defaultDatasources.extra | default list -}}
-  {{- $readURL := include "vm.read.endpoint" $ctx -}}
-  {{- if $readURL -}}
-    {{- $readEndpoint := fromYaml $readURL -}}
+  {{- $vmReadEndpoint := include "vm.prometheus.read" $ctx -}}
+  {{- $vlReadEndpoint := include "vl.read.endpoint" $ctx -}}
+  {{- $vtReadEndpoint := include "vt.read.endpoint" $ctx -}}
+  {{- if $vmReadEndpoint -}}
+    {{- $readEndpoint := fromYaml $vmReadEndpoint -}}
     {{- $defaultDatasources := list -}}
     {{- range $ds := $Values.defaultDatasources.victoriametrics.datasources }}
       {{- $_ := set $ds "url" $readEndpoint.url -}}
+      {{- $defaultDatasources = append $defaultDatasources $ds -}}
+    {{- end }}
+    {{- $datasources = concat $datasources $defaultDatasources -}}
+  {{- end -}}
+  {{- if $vlReadEndpoint -}}
+    {{- $readEndpoint := fromYaml $vlReadEndpoint -}}
+    {{- $defaultDatasources := list -}}
+    {{- range $ds := $Values.defaultDatasources.victorialogs.datasources }}
+      {{- $_ := set $ds "url" $readEndpoint.url -}}
+      {{- $defaultDatasources = append $defaultDatasources $ds -}}
+    {{- end }}
+    {{- $datasources = concat $datasources $defaultDatasources -}}
+  {{- end -}}
+  {{- if $vtReadEndpoint -}}
+    {{- $readEndpoint := fromYaml $vtReadEndpoint -}}
+    {{- $defaultDatasources := list -}}
+    {{- range $ds := $Values.defaultDatasources.victoriatraces.datasources }}
+      {{- $_ := set $ds "url" (printf "%s/select/jaeger" $readEndpoint.url) -}}
       {{- $defaultDatasources = append $defaultDatasources $ds -}}
     {{- end }}
     {{- $datasources = concat $datasources $defaultDatasources -}}
@@ -405,37 +466,6 @@
   {{- end -}}
   {{- toYaml (dict "datasources" $datasources) -}}
 {{- end }}
-
-{{- /* VMRule name */ -}}
-{{- define "vm-k8s-stack.rulegroup.name" -}}
-  {{- printf "%s-%s" (include "vm.fullname" .) (.name | replace "_" "") -}}
-{{- end -}}
-
-{{- /* VMRule labels */ -}}
-{{- define "vm-k8s-stack.rulegroup.labels" -}}
-  {{- $Values := (.helm).Values | default .Values }}
-  {{- $labels := fromYaml (include "vm.labels" .) -}}
-  {{- $_ := set $labels "app.kubernetes.io/component" "vmalert" -}}
-  {{- $labels = mergeOverwrite $labels (deepCopy $Values.defaultRules.labels) -}}
-  {{- toYaml $labels -}}
-{{- end }}
-
-{{- /* VMRule key */ -}}
-{{- define "vm-k8s-stack.rulegroup.key" -}}
-  {{- without (regexSplit "[-_.]" .name -1) "exporter" "rules" | join "-" | camelcase | untitle -}}
-{{- end -}}
-
-{{- /* VMAlertmanager name */ -}}
-{{- define "vm-k8s-stack.alertmanager.name" -}}
-  {{- $Values := (.helm).Values | default .Values }}
-  {{- $_ := set . "appKey" (list "alertmanager" "spec") -}}
-  {{- $Values.alertmanager.name | default (include "vm.managed.fullname" .) -}}
-{{- end -}}
-
-{{- define "vm-k8s-stack.nodeExporter.name" -}}
-  {{- $Values := (.helm).Values | default .Values }}
-  {{- (index $Values "prometheus-node-exporter").service.labels.jobLabel | default "node-exporter" }}
-{{- end -}}
 
 {{- define "vm-k8s-stack.grafana.addr" -}}
   {{- $Values := (.helm).Values | default .Values -}}
@@ -459,4 +489,193 @@
     {{- $grafanaAddr = printf "%s://%s" $grafanaScheme (index $grafanaHosts 0) -}}
   {{- end -}}
   {{- $grafanaAddr -}}
+{{- end -}}
+
+{{- define "vl.read.endpoint" -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $endpoint := dict -}}
+  {{- $_ := set . "style" "managed" -}}
+  {{- if $Values.vlsingle.enabled -}}
+    {{- $_ := set . "appKey" (list "vlsingle" "spec") -}}
+    {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
+  {{- else if and $Values.vlcluster.enabled $Values.vlcluster.spec.vlselect.enabled -}}
+    {{- $_ := set . "appKey" (list "vlcluster" "spec" "vlselect") -}}
+    {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
+  {{- else if $Values.external.vl.read.url -}}
+    {{- $_ := set $endpoint "url" ((($Values.external).vl).read).url -}}
+  {{- end -}}
+  {{- with $endpoint -}}
+    {{- toYaml . -}}
+  {{- end -}}
+{{- end }}
+
+{{- define "vl.write.endpoint" -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $endpoint := dict -}}
+  {{- $_ := set . "style" "managed" -}}
+  {{- if $Values.vlsingle.enabled -}}
+    {{- $_ := set . "appKey" (list "vlsingle" "spec") -}}
+    {{- $baseURL := include "vm.url" . -}}
+    {{- $_ := set $endpoint "url" (printf "%s/insert/native" $baseURL) -}}
+  {{- else if and $Values.vlcluster.enabled $Values.vlcluster.spec.vlinsert.enabled -}}
+    {{- $_ := set . "appKey" (list "vlcluster" "spec" "vlinsert") -}}
+    {{- $baseURL := include "vm.url" . -}}
+    {{- $_ := set $endpoint "url" (printf "%s/insert/native" $baseURL) -}}
+  {{- else if $Values.external.vl.write.url -}}
+    {{- $endpoint = $Values.external.vl.write -}}
+  {{- end -}}
+  {{- with $endpoint -}}
+    {{- toYaml . -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* VLAgent spec */ -}}
+{{- define "vl.agent.spec" -}}
+  {{- $_ := set . "agentKey" "vlagent" -}}
+  {{- $_ := set . "writeEndpoint" (include "vl.write.endpoint" .) -}}
+  {{- include "vm.agent.spec" . -}}
+  {{- $_ := unset . "agentKey" -}}
+  {{- $_ := unset . "writeEndpoint" -}}
+{{- end }}
+
+{{- /* VLSingle spec */ -}}
+{{- define "vl.single.spec" -}}
+  {{- $Values := (.helm).Values | default .Values }}
+  {{- $image := dict "tag" (include "vm.image.tag" .) }}
+  {{- $extraArgs := dict -}}
+  {{- if $Values.vmalert.enabled }}
+    {{- $_ := set . "appKey" (list "vmalert" "spec") }}
+    {{- $_ := set $extraArgs "vmalert.proxyURL" (include "vm.url" .) -}}
+  {{- end -}}
+  {{- $spec := dict "extraArgs" $extraArgs "image" $image -}}
+  {{- with (include "vm.license.global" .) -}}
+    {{- $_ := set $spec "license" (fromYaml .) -}}
+  {{- end -}}
+  {{- tpl (deepCopy $Values.vlsingle.spec | mergeOverwrite $spec | toYaml) . -}}
+{{- end }}
+
+{{- /* VLCluster select spec */ -}}
+{{- define "vl.select.spec" -}}
+  {{- $Values := (.helm).Values | default .Values }}
+  {{- $extraArgs := dict -}}
+  {{- if $Values.vmalert.enabled -}}
+    {{- $_ := set . "appKey" (list "vmalert" "spec") -}}
+    {{- $_ := set $extraArgs "vmalert.proxyURL" (include "vm.url" .) -}}
+  {{- end -}}
+  {{- $spec := dict "extraArgs" $extraArgs -}}
+  {{- toYaml $spec -}}
+{{- end -}}
+
+{{- /* VLCluster spec */ -}}
+{{- define "vl.cluster.spec" -}}
+  {{- $Values := (.helm).Values | default .Values }}
+  {{- $clusterSpec := deepCopy $Values.vlcluster.spec -}}
+  {{- $clusterSpec = mergeOverwrite (dict "clusterVersion" (printf "%s-cluster" (include "vm.image.tag" .))) $clusterSpec -}}
+  {{- with (include "vm.license.global" .) -}}
+    {{- $_ := set $clusterSpec "license" (fromYaml .) -}}
+  {{- end -}}
+  {{- if ($clusterSpec.requestsLoadBalancer).enabled }}
+    {{- $balancerSpec := $clusterSpec.requestsLoadBalancer.spec | default dict }}
+    {{- $authImage := dict "image" (dict "tag" (include "vm.image.tag" .)) }}
+    {{- $_ := set $clusterSpec.requestsLoadBalancer "spec" (mergeOverwrite $authImage $balancerSpec) }}
+  {{- end }}
+  {{- $clusterSpec = mergeOverwrite (dict "vlselect" (include "vl.select.spec" . | fromYaml)) $clusterSpec }}
+  {{- if not $clusterSpec.vlselect.enabled -}}
+    {{- $_ := unset $clusterSpec "vlselect" -}}
+  {{- else -}}
+    {{- $_ := unset $clusterSpec.vlselect "enabled" -}}
+  {{- end -}}
+  {{- if not $clusterSpec.vlinsert.enabled -}}
+    {{- $_ := unset $clusterSpec "vlinsert" -}}
+  {{- else -}}
+    {{- $_ := unset $clusterSpec.vlinsert "enabled" -}}
+  {{- end -}}
+  {{- tpl (toYaml $clusterSpec) . -}}
+{{- end -}}
+
+{{- define "vt.read.endpoint" -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $endpoint := dict -}}
+  {{- $_ := set . "style" "managed" -}}
+  {{- if $Values.vtsingle.enabled -}}
+    {{- $_ := set . "appKey" (list "vtsingle" "spec") -}}
+    {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
+  {{- else if and $Values.vtcluster.enabled $Values.vtcluster.spec.vtselect.enabled -}}
+    {{- $_ := set . "appKey" (list "vtcluster" "spec" "vtselect") -}}
+    {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
+  {{- else if $Values.external.vt.read.url -}}
+    {{- $_ := set $endpoint "url" ((($Values.external).vt).read).url -}}
+  {{- end -}}
+  {{- with $endpoint -}}
+    {{- toYaml . -}}
+  {{- end -}}
+{{- end }}
+
+{{- define "vt.write.endpoint" -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- $endpoint := dict -}}
+  {{- $_ := set . "style" "managed" -}}
+  {{- if $Values.vtsingle.enabled -}}
+    {{- $_ := set . "appKey" (list "vtsingle" "spec") -}}
+    {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
+  {{- else if and $Values.vtcluster.enabled $Values.vtcluster.spec.vtinsert.enabled -}}
+    {{- $_ := set . "appKey" (list "vtcluster" "spec" "vtinsert") -}}
+    {{- $_ := set $endpoint "url" (include "vm.url" .) -}}
+  {{- else if $Values.external.vt.write.url -}}
+    {{- $endpoint = $Values.external.vt.write -}}
+  {{- end -}}
+  {{- with $endpoint -}}
+    {{- toYaml . -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* VTSingle spec */ -}}
+{{- define "vt.single.spec" -}}
+  {{- $Values := (.helm).Values | default .Values }}
+  {{- $image := dict "tag" (include "vm.image.tag" .) }}
+  {{- $spec := dict "image" $image -}}
+  {{- with (include "vm.license.global" .) -}}
+    {{- $_ := set $spec "license" (fromYaml .) -}}
+  {{- end -}}
+  {{- tpl (deepCopy $Values.vtsingle.spec | mergeOverwrite $spec | toYaml) . -}}
+{{- end }}
+
+{{- /* VTCluster select spec */ -}}
+{{- define "vt.select.spec" -}}
+  {{- $spec := dict -}}
+  {{- toYaml $spec -}}
+{{- end -}}
+
+{{- /* VTCluster spec - translates vtinsert/vtselect/vtstorage → insert/select/storage for CRD */ -}}
+{{- define "vt.cluster.spec" -}}
+  {{- $Values := (.helm).Values | default .Values }}
+  {{- $clusterSpec := deepCopy $Values.vtcluster.spec -}}
+  {{- $clusterSpec = mergeOverwrite (dict "clusterVersion" (printf "%s-cluster" (include "vm.image.tag" .))) $clusterSpec -}}
+  {{- with (include "vm.license.global" .) -}}
+    {{- $_ := set $clusterSpec "license" (fromYaml .) -}}
+  {{- end -}}
+  {{- $clusterSpec = mergeOverwrite (dict "vtselect" (include "vt.select.spec" . | fromYaml)) $clusterSpec -}}
+  {{- $vtselect := deepCopy ($clusterSpec.vtselect | default dict) -}}
+  {{- $_ := unset $clusterSpec "vtselect" -}}
+  {{- if $vtselect.enabled -}}
+    {{- $_ := unset $vtselect "enabled" -}}
+    {{- $_ := set $clusterSpec "select" $vtselect -}}
+  {{- end -}}
+  {{- $vtinsert := deepCopy ($clusterSpec.vtinsert | default dict) -}}
+  {{- $_ := unset $clusterSpec "vtinsert" -}}
+  {{- if $vtinsert.enabled -}}
+    {{- $_ := unset $vtinsert "enabled" -}}
+    {{- $_ := set $clusterSpec "insert" $vtinsert -}}
+  {{- end -}}
+  {{- $vtstorage := deepCopy ($clusterSpec.vtstorage | default dict) -}}
+  {{- $_ := unset $clusterSpec "vtstorage" -}}
+  {{- $_ := set $clusterSpec "storage" $vtstorage -}}
+  {{- tpl (toYaml $clusterSpec) . -}}
+{{- end -}}
+
+{{- /* VMAuth spec for routing vmalert: /select/logsql/.* → VL, everything else → VM */ -}}
+{{- define "vm.auth.internal.spec" -}}
+  {{- $Values := (.helm).Values | default .Values -}}
+  {{- include "vm.auth.context" . -}}
+  {{- tpl (deepCopy $Values.internal.vmauth.spec | toYaml) . -}}
 {{- end -}}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vlagent/rbac.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vlagent/rbac.yaml
@@ -1,0 +1,44 @@
+{{- $app := .Values.vlagent }}
+{{- $rbac := $app.rbac }}
+{{- if and $app.enabled (not (empty $rbac.rules)) -}}
+{{- $ctx := dict "helm" . "appKey" "vlagent" }}
+{{- $fullname := include "vm.managed.fullname" $ctx }}
+{{- $ns := include "vm.namespace" $ctx }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ ternary "RoleBinding" "ClusterRoleBinding" $rbac.namespaced }}
+metadata:
+  name: {{ $fullname }}
+  {{- if $rbac.namespaced }}
+  namespace: {{ $ns }}
+  {{- end }}
+  {{- $_ := set $ctx "extraLabels" $rbac.extraLabels }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- $_ := unset $ctx "extraLabels" }}
+  {{- with $rbac.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ ternary "Role" "ClusterRole" $rbac.namespaced }}
+  name: {{ $fullname }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullname }}
+    namespace: {{ $ns }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ ternary "Role" "ClusterRole" $rbac.namespaced }}
+metadata:
+  name: {{ $fullname }}
+  {{- if $rbac.namespaced }}
+  namespace: {{ include "vm.namespace" $ctx }}
+  {{- end }}
+  {{- $_ := set $ctx "extraLabels" $rbac.extraLabels }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- $_ := unset $ctx "extraLabels" }}
+  {{- with $rbac.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+rules: {{ tpl (toYaml $rbac.rules) . | nindent 2 }}
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vlagent/vlagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vlagent/vlagent.yaml
@@ -1,0 +1,20 @@
+{{- $app := .Values.vlagent }}
+{{- if $app.enabled }}
+{{- $ctx := dict "helm" . "appKey" (list "vlagent" "spec") }}
+{{- $fullname := include "vm.cr.fullname" $ctx }}
+{{- $ns := include "vm.namespace" $ctx }}
+---
+apiVersion: operator.victoriametrics.com/v1
+kind: VLAgent
+metadata:
+  {{- with $app.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end  }}
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+  {{- $_ := set $ctx "style" "managed" }}
+  {{- $_ := set $ctx "extraLabels" ($app.labels | default dict) }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- $_ := unset $ctx "extraLabels" }}
+spec: {{ include "vl.agent.spec" $ctx | nindent 2 }}
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vlcluster/vlcluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vlcluster/vlcluster.yaml
@@ -1,0 +1,27 @@
+{{- $app := .Values.vlcluster }}
+{{- if $app.enabled }}
+{{- if .Values.vlsingle.enabled }}
+  {{- fail "Only one of .vlsingle.enabled and .vlcluster.enabled can be true"}}
+{{- end }}
+{{- $ctx := dict "helm" . "appKey" (list "vlcluster" "spec") }}
+{{- $fullname := include "vm.cr.fullname" $ctx }}
+{{- $ns := include "vm.namespace" $ctx }}
+---
+apiVersion: operator.victoriametrics.com/v1
+kind: VLCluster
+metadata:
+  {{- with $app.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end  }}
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+  {{- $_ := set $ctx "style" "managed" }}
+  {{- $_ := set $ctx "extraLabels" ($app.labels | default dict) }}
+  {{- $labels := include "vm.labels" $ctx | fromYaml }}
+  {{- $_ := unset $ctx "extraLabels" }}
+  {{- if $app.spec.clusterVersion }}
+    {{- $_ := set $labels "app.kubernetes.io/version" $app.spec.clusterVersion }}
+  {{- end }}
+  labels: {{ toYaml $labels | nindent 4 }}
+spec: {{ include "vl.cluster.spec" $ctx | nindent 2 }}
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vlsingle/vlsingle.yml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vlsingle/vlsingle.yml
@@ -1,0 +1,22 @@
+{{- $app := .Values.vlsingle }}
+{{- if $app.enabled }}
+{{- if .Values.vlcluster.enabled }}
+  {{- fail "Only one of .vlsingle.enabled and .vlcluster.enabled can be true"}}
+{{- end }}
+{{- $ctx := dict "helm" . "appKey" (list "vlsingle" "spec") }}
+{{- $fullname := include "vm.cr.fullname" $ctx }}
+{{- $ns := include "vm.namespace" $ctx }}
+apiVersion: operator.victoriametrics.com/v1
+kind: VLSingle
+metadata:
+  {{- with $app.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end  }}
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+  {{- $_ := set $ctx "style" "managed" }}
+  {{- $_ := set $ctx "extraLabels" ($app.labels | default dict) }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- $_ := unset $ctx "extraLabels" }}
+spec: {{ include "vl.single.spec" $ctx | nindent 2 }}
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmauth/internal.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmauth/internal.yaml
@@ -1,0 +1,23 @@
+{{- $app := .Values.vmalert }}
+{{- if $app.enabled }}
+{{- $ctx := dict "helm" . "appKey" (list "internal" "vmauth" "spec") }}
+{{- $_ := set $ctx "fullname" (include "vm.fullname" $ctx) }}
+{{- $vmReadEndpoint := include "vm.prometheus.read" $ctx | fromYaml }}
+{{- $vlReadEndpoint := include "vl.read.endpoint" $ctx | fromYaml }}
+{{- if and $vmReadEndpoint.url $vlReadEndpoint.url }}
+{{- $_ := set $ctx "appKey" (list "internal" "vmauth" "spec") -}}
+{{- $_ := set $ctx "style" "managed" -}}
+{{- $fullname := include "vm.cr.fullname" $ctx }}
+{{- $ns := include "vm.namespace" $ctx }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMAuth
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+  {{- $labels := include "vm.labels" $ctx | fromYaml }}
+  {{- $_ := set $labels "app.kubernetes.io/component" "vmauth" }}
+  labels: {{ toYaml $labels | nindent 4 }}
+spec: {{ include "vm.auth.internal.spec" $ctx | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vtcluster/vtcluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vtcluster/vtcluster.yaml
@@ -1,0 +1,27 @@
+{{- $app := .Values.vtcluster }}
+{{- if $app.enabled }}
+{{- if .Values.vtsingle.enabled }}
+  {{- fail "Only one of .vtsingle.enabled and .vtcluster.enabled can be true"}}
+{{- end }}
+{{- $ctx := dict "helm" . "appKey" (list "vtcluster" "spec") }}
+{{- $fullname := include "vm.cr.fullname" $ctx }}
+{{- $ns := include "vm.namespace" $ctx }}
+---
+apiVersion: operator.victoriametrics.com/v1
+kind: VTCluster
+metadata:
+  {{- with $app.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end  }}
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+  {{- $_ := set $ctx "style" "managed" }}
+  {{- $_ := set $ctx "extraLabels" ($app.labels | default dict) }}
+  {{- $labels := include "vm.labels" $ctx | fromYaml }}
+  {{- $_ := unset $ctx "extraLabels" }}
+  {{- if $app.spec.clusterVersion }}
+    {{- $_ := set $labels "app.kubernetes.io/version" $app.spec.clusterVersion }}
+  {{- end }}
+  labels: {{ toYaml $labels | nindent 4 }}
+spec: {{ include "vt.cluster.spec" $ctx | nindent 2 }}
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vtsingle/vtsingle.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vtsingle/vtsingle.yaml
@@ -1,0 +1,22 @@
+{{- $app := .Values.vtsingle }}
+{{- if $app.enabled }}
+{{- if .Values.vtcluster.enabled }}
+  {{- fail "Only one of .vtsingle.enabled and .vtcluster.enabled can be true"}}
+{{- end }}
+{{- $ctx := dict "helm" . "appKey" (list "vtsingle" "spec") }}
+{{- $fullname := include "vm.cr.fullname" $ctx }}
+{{- $ns := include "vm.namespace" $ctx }}
+apiVersion: operator.victoriametrics.com/v1
+kind: VTSingle
+metadata:
+  {{- with $app.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end  }}
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+  {{- $_ := set $ctx "style" "managed" }}
+  {{- $_ := set $ctx "extraLabels" ($app.labels | default dict) }}
+  labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  {{- $_ := unset $ctx "extraLabels" }}
+spec: {{ include "vt.single.spec" $ctx | nindent 2 }}
+{{- end }}

--- a/charts/victoria-metrics-k8s-stack/tests/datasource_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/datasource_test.yaml
@@ -1,0 +1,82 @@
+suite: grafana datasource tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - grafana/datasource.yaml
+tests:
+  - it: VL datasource is absent when no VL backend configured
+    set:
+      alertmanager:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - notMatchRegex:
+          path: data["datasource.yaml"]
+          pattern: 'victoriametrics-logs-datasource'
+
+  - it: VL datasource has correct URL when vlsingle enabled
+    set:
+      alertmanager:
+        enabled: false
+      vlsingle:
+        enabled: true
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - matchRegex:
+          path: data["datasource.yaml"]
+          pattern: 'vlsingle-RELEASE-NAME-victoria-metrics-k8s-stack\.NAMESPACE\.svc\.cluster\.local\.:9428'
+
+  - it: VM datasource has correct URL when vmsingle enabled
+    set:
+      vmsingle:
+        enabled: true
+      alertmanager:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - matchRegex:
+          path: data["datasource.yaml"]
+          pattern: 'vmsingle-RELEASE-NAME-victoria-metrics-k8s-stack\.NAMESPACE\.svc\.cluster\.local\.:8428'
+
+  - it: VM datasource is absent when no VM backend configured
+    set:
+      vmsingle:
+        enabled: false
+      vmalert:
+        enabled: false
+      alertmanager:
+        enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["datasource.yaml"]
+          pattern: 'victoriametrics-metrics-datasource'
+
+  - it: both VM and VL datasources present when both backends enabled
+    set:
+      vmsingle:
+        enabled: true
+      alertmanager:
+        enabled: false
+      vlsingle:
+        enabled: true
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - matchRegex:
+          path: data["datasource.yaml"]
+          pattern: 'vmsingle-RELEASE-NAME-victoria-metrics-k8s-stack'
+      - matchRegex:
+          path: data["datasource.yaml"]
+          pattern: 'vlsingle-RELEASE-NAME-victoria-metrics-k8s-stack'

--- a/charts/victoria-metrics-k8s-stack/tests/internal_vmauth_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/internal_vmauth_test.yaml
@@ -1,0 +1,92 @@
+suite: internal vmauth tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vmauth/internal.yaml
+tests:
+  - it: renders VMAuth CR when vmalert enabled with both VM and VL
+    set:
+      vlsingle:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VMAuth
+
+  - it: does not render when vmalert disabled
+    set:
+      vmalert:
+        enabled: false
+      vlsingle:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when only VM configured (no VL)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when only VL configured (no VM)
+    set:
+      vmsingle:
+        enabled: false
+      vlsingle:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: CR name includes release name with internal suffix
+    set:
+      vlsingle:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-k8s-stack-internal
+
+  - it: component label is vmauth
+    set:
+      vlsingle:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: vmauth
+
+  - it: url_map routes logsql paths to vlsingle
+    set:
+      vlsingle:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.unauthorizedUserAccessSpec.url_map[0].src_paths[0]
+          value: '/select/logsql/.*'
+      - equal:
+          path: spec.unauthorizedUserAccessSpec.url_map[0].url_prefix[0]
+          value: 'http://vlsingle-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:9428/'
+
+  - it: url_map routes all other paths to vmsingle
+    set:
+      vlsingle:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.unauthorizedUserAccessSpec.url_map[1].src_paths[0]
+          value: '/.*'
+      - equal:
+          path: spec.unauthorizedUserAccessSpec.url_map[1].url_prefix[0]
+          value: 'http://vmsingle-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:8428/'
+
+  - it: port is 8427
+    set:
+      vlsingle:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.port
+          value: "8427"

--- a/charts/victoria-metrics-k8s-stack/tests/vlagent_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vlagent_test.yaml
@@ -1,0 +1,79 @@
+suite: vlagent spec tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vlagent/vlagent.yaml
+tests:
+  - it: remoteWrite points to vlsingle write endpoint when vlsingle enabled
+    set:
+      vlagent:
+        enabled: true
+      vlsingle:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.remoteWrite[0].url
+          value: http://vlsingle-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:9428/insert/native
+
+  - it: user-configured spec.remoteWrite entries after the first are all preserved
+    set:
+      vlagent:
+        enabled: true
+        spec:
+          remoteWrite:
+            - url: http://custom1.example.com
+            - url: http://custom2.example.com
+            - url: http://custom3.example.com
+      vlsingle:
+        enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.remoteWrite
+          count: 3
+      - equal:
+          path: spec.remoteWrite[1].url
+          value: http://custom2.example.com
+      - equal:
+          path: spec.remoteWrite[2].url
+          value: http://custom3.example.com
+
+  - it: remoteWrite points to vlinsert when vlcluster enabled
+    set:
+      vlagent:
+        enabled: true
+      vlcluster:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.remoteWrite[0].url
+          value: http://vlinsert-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:9481/insert/native
+
+  - it: external vl write URL is used when no vl CR configured
+    set:
+      vlagent:
+        enabled: true
+      external:
+        vl:
+          write:
+            url: http://vl.external.example.com/insert/native
+    asserts:
+      - equal:
+          path: spec.remoteWrite[0].url
+          value: http://vl.external.example.com/insert/native
+
+  - it: additionalRemoteWrites are prepended to remoteWrite list
+    set:
+      vlagent:
+        enabled: true
+        additionalRemoteWrites:
+          - url: http://additional.example.com
+      vlsingle:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.remoteWrite[0].url
+          value: http://additional.example.com
+      - equal:
+          path: spec.remoteWrite[1].url
+          value: http://vlsingle-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:9428/insert/native

--- a/charts/victoria-metrics-k8s-stack/tests/vlcluster_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vlcluster_test.yaml
@@ -1,0 +1,101 @@
+suite: vlcluster tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vlcluster/vlcluster.yaml
+tests:
+  - it: renders VLCluster CR when enabled
+    set:
+      vlcluster:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VLCluster
+      - isAPIVersion:
+          of: operator.victoriametrics.com/v1
+
+  - it: does not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when both vlsingle and vlcluster are enabled
+    set:
+      vlsingle:
+        enabled: true
+      vlcluster:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of .vlsingle.enabled and .vlcluster.enabled can be true"
+
+  - it: CR name is derived from release name
+    set:
+      vlcluster:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-k8s-stack
+
+  - it: clusterVersion defaults to the pinned VictoriaLogs version in values
+    set:
+      vlcluster:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.clusterVersion
+          value: v1.51.0
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: v1.51.0
+
+  - it: custom clusterVersion in values overrides the pinned default
+    set:
+      vlcluster:
+        enabled: true
+        spec:
+          clusterVersion: v1.99.0
+    asserts:
+      - equal:
+          path: spec.clusterVersion
+          value: v1.99.0
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: v1.99.0
+
+  - it: vlselect is removed from spec when disabled
+    set:
+      vlcluster:
+        enabled: true
+        spec:
+          vlselect:
+            enabled: false
+    asserts:
+      - isNull:
+          path: spec.vlselect
+
+  - it: vlinsert is removed from spec when disabled
+    set:
+      vlcluster:
+        enabled: true
+        spec:
+          vlinsert:
+            enabled: false
+    asserts:
+      - isNull:
+          path: spec.vlinsert
+
+  - it: vmalert proxyURL is injected into vlselect extraArgs
+    set:
+      vlcluster:
+        enabled: true
+      alertmanager:
+        enabled: false
+    asserts:
+      - equal:
+          path: spec.vlselect.extraArgs["vmalert.proxyURL"]
+          value: http://vmalert-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:8080

--- a/charts/victoria-metrics-k8s-stack/tests/vlsingle_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vlsingle_test.yaml
@@ -1,0 +1,73 @@
+suite: vlsingle tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vlsingle/vlsingle.yml
+tests:
+  - it: renders VLSingle CR when enabled
+    set:
+      vlsingle:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VLSingle
+      - isAPIVersion:
+          of: operator.victoriametrics.com/v1
+
+  - it: does not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when both vlsingle and vlcluster are enabled
+    set:
+      vlsingle:
+        enabled: true
+      vlcluster:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of .vlsingle.enabled and .vlcluster.enabled can be true"
+
+  - it: CR name is derived from release name
+    set:
+      vlsingle:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-k8s-stack
+
+  - it: retentionPeriod is passed through to spec
+    set:
+      vlsingle:
+        enabled: true
+        spec:
+          retentionPeriod: 30d
+    asserts:
+      - equal:
+          path: spec.retentionPeriod
+          value: 30d
+
+  - it: port is passed through to spec
+    set:
+      vlsingle:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.port
+          value: "9428"
+
+  - it: vmalert proxyURL is injected into extraArgs
+    set:
+      vlsingle:
+        enabled: true
+      alertmanager:
+        enabled: false
+    asserts:
+      - equal:
+          path: spec.extraArgs["vmalert.proxyURL"]
+          value: http://vmalert-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:8080

--- a/charts/victoria-metrics-k8s-stack/tests/vmagent_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vmagent_test.yaml
@@ -1,0 +1,75 @@
+suite: vmagent spec tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vmagent/vmagent.yaml
+tests:
+  - it: default remoteWrite points to vmsingle write endpoint
+    asserts:
+      - equal:
+          path: spec.remoteWrite[0].url
+          value: http://vmsingle-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:8428/api/v1/write
+
+  - it: additionalRemoteWrites are prepended to remoteWrite list
+    set:
+      vmagent:
+        additionalRemoteWrites:
+          - url: http://additional.example.com
+    asserts:
+      - equal:
+          path: spec.remoteWrite[0].url
+          value: http://additional.example.com
+      - equal:
+          path: spec.remoteWrite[1].url
+          value: http://vmsingle-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:8428/api/v1/write
+
+  - it: user-configured spec.remoteWrite entries after the first are preserved
+    set:
+      vmagent:
+        spec:
+          remoteWrite:
+            - url: http://custom1.example.com
+            - url: http://custom2.example.com
+    asserts:
+      - lengthEqual:
+          path: spec.remoteWrite
+          count: 2
+      - equal:
+          path: spec.remoteWrite[1].url
+          value: http://custom2.example.com
+
+  - it: user spec.remoteWrite overrides auto-discovered URL for first entry
+    set:
+      vmagent:
+        spec:
+          remoteWrite:
+            - url: http://custom.example.com
+    asserts:
+      - equal:
+          path: spec.remoteWrite[0].url
+          value: http://custom.example.com
+
+  - it: external vm write URL is used when vmsingle disabled
+    set:
+      vmsingle:
+        enabled: false
+      external:
+        vm:
+          write:
+            url: http://vm.external.example.com/api/v1/write
+    asserts:
+      - equal:
+          path: spec.remoteWrite[0].url
+          value: http://vm.external.example.com/api/v1/write
+
+  - it: vmcluster write endpoint is used when vmcluster enabled
+    set:
+      vmsingle:
+        enabled: false
+      vmcluster:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.remoteWrite[0].url
+          pattern: '^http://vminsert-.*\.svc\.cluster\.local\.:8480/insert/0/prometheus/api/v1/write$'

--- a/charts/victoria-metrics-k8s-stack/tests/vmalert_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vmalert_test.yaml
@@ -1,0 +1,108 @@
+suite: vmalert datasource routing tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vmalert/vmalert.yaml
+tests:
+  - it: datasource points to vmsingle when only VM configured
+    set:
+      grafana:
+        enabled: false
+      alertmanager:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.datasource.url
+          value: http://vmsingle-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:8428
+
+  - it: datasource points to internal vmauth when both VM and VL configured
+    set:
+      grafana:
+        enabled: false
+      alertmanager:
+        enabled: false
+      vlsingle:
+        enabled: true
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.datasource.url
+          value: http://vmauth-RELEASE-NAME-victoria-metrics-k8s-stack-internal.NAMESPACE.svc.cluster.local.:8427
+
+  - it: datasource points to vlsingle when only VL configured
+    set:
+      grafana:
+        enabled: false
+      alertmanager:
+        enabled: false
+      vmsingle:
+        enabled: false
+      vlsingle:
+        enabled: true
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.datasource.url
+          value: http://vlsingle-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:9428
+
+  - it: datasource uses external VM URL when vmsingle disabled and external URL set
+    set:
+      grafana:
+        enabled: false
+      alertmanager:
+        enabled: false
+      vmsingle:
+        enabled: false
+      external:
+        vm:
+          read:
+            url: http://vm.external.example.com:8428
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.datasource.url
+          value: http://vm.external.example.com:8428
+
+  - it: remoteWrite points to vmsingle by default
+    set:
+      grafana:
+        enabled: false
+      alertmanager:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.remoteWrite.url
+          value: http://vmsingle-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:8428/api/v1/write
+
+  - it: remoteRead points to vmsingle by default
+    set:
+      grafana:
+        enabled: false
+      alertmanager:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.remoteRead.url
+          value: http://vmsingle-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:8428

--- a/charts/victoria-metrics-k8s-stack/tests/vmcluster_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vmcluster_test.yaml
@@ -1,0 +1,150 @@
+suite: vmcluster tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vmcluster/vmcluster.yaml
+tests:
+  - it: renders VMCluster CR when enabled
+    set:
+      vmsingle:
+        enabled: false
+      vmcluster:
+        enabled: true
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VMCluster
+      - isAPIVersion:
+          of: operator.victoriametrics.com/v1beta1
+
+  - it: does not render when disabled
+    set:
+      vmsingle:
+        enabled: false
+      vmalert:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when both vmsingle and vmcluster are enabled
+    set:
+      vmcluster:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of .Values.vmsingle.enabled, .Values.vmdistributed.enabled and .Values.vmcluster.enabled can be true"
+
+  - it: clusterVersion is auto-computed from appVersion
+    set:
+      vmsingle:
+        enabled: false
+      vmcluster:
+        enabled: true
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.clusterVersion
+          value: 0.1.0-cluster
+
+  - it: custom clusterVersion in values overrides auto-computed value
+    set:
+      vmsingle:
+        enabled: false
+      vmcluster:
+        enabled: true
+        spec:
+          clusterVersion: v1.99.0
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.clusterVersion
+          value: v1.99.0
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: v1.99.0
+
+  - it: vmalert proxyURL is injected into vmselect extraArgs
+    set:
+      vmsingle:
+        enabled: false
+      vmcluster:
+        enabled: true
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.vmselect.extraArgs["vmalert.proxyURL"]
+          value: http://vmalert-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:8080
+
+  - it: vmselect is removed from spec when disabled
+    set:
+      vmsingle:
+        enabled: false
+      vmcluster:
+        enabled: true
+        spec:
+          vmselect:
+            enabled: false
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - isNull:
+          path: spec.vmselect
+
+  - it: vminsert is removed from spec when disabled
+    set:
+      vmsingle:
+        enabled: false
+      vmcluster:
+        enabled: true
+        spec:
+          vminsert:
+            enabled: false
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - isNull:
+          path: spec.vminsert

--- a/charts/victoria-metrics-k8s-stack/tests/vmdistributed_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vmdistributed_test.yaml
@@ -1,0 +1,160 @@
+suite: vmdistributed tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vmdistributed/vmdistributed.yaml
+tests:
+  - it: renders VMDistributed CR when enabled
+    set:
+      vmsingle:
+        enabled: false
+      vmdistributed:
+        enabled: true
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VMDistributed
+      - isAPIVersion:
+          of: operator.victoriametrics.com/v1alpha1
+
+  - it: does not render when disabled
+    set:
+      vmsingle:
+        enabled: false
+      vmalert:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when both vmsingle and vmdistributed are enabled
+    set:
+      vmdistributed:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of .Values.vmsingle.enabled, .Values.vmdistributed.enabled and .Values.vmcluster.enabled can be true"
+
+  - it: fails when both vmcluster and vmdistributed are enabled
+    set:
+      vmsingle:
+        enabled: false
+      vmcluster:
+        enabled: true
+      vmdistributed:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of .Values.vmsingle.enabled, .Values.vmdistributed.enabled and .Values.vmcluster.enabled can be true"
+
+  - it: CR name is derived from release name
+    set:
+      vmsingle:
+        enabled: false
+      vmdistributed:
+        enabled: true
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-k8s-stack
+
+  - it: zoneCommon vmcluster clusterVersion is auto-computed from appVersion
+    set:
+      vmsingle:
+        enabled: false
+      vmdistributed:
+        enabled: true
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.zoneCommon.vmcluster.spec.clusterVersion
+          value: 0.1.0-cluster
+
+  - it: zoneCommon vmagent image tag is injected from appVersion
+    set:
+      vmsingle:
+        enabled: false
+      vmdistributed:
+        enabled: true
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.zoneCommon.vmagent.spec.image.tag
+          value: 0.1.0
+
+  - it: vmalert proxyURL is injected into vmselect extraArgs
+    set:
+      vmsingle:
+        enabled: false
+      vmdistributed:
+        enabled: true
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.zoneCommon.vmcluster.spec.vmselect.extraArgs["vmalert.proxyURL"]
+          value: http://vmalert-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:8080
+
+  - it: zones are passed through to spec
+    set:
+      vmsingle:
+        enabled: false
+      vmdistributed:
+        enabled: true
+        spec:
+          zones:
+            - name: us-east-1
+            - name: eu-west-1
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - lengthEqual:
+          path: spec.zones
+          count: 2
+      - equal:
+          path: spec.zones[1].name
+          value: eu-west-1

--- a/charts/victoria-metrics-k8s-stack/tests/vmsingle_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vmsingle_test.yaml
@@ -1,0 +1,110 @@
+suite: vmsingle tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vmsingle/vmsingle.yml
+tests:
+  - it: renders VMSingle CR when enabled
+    set:
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VMSingle
+      - isAPIVersion:
+          of: operator.victoriametrics.com/v1beta1
+
+  - it: does not render when disabled
+    set:
+      vmsingle:
+        enabled: false
+      vmalert:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when both vmsingle and vmcluster are enabled
+    set:
+      vmcluster:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of .Values.vmsingle.enabled, .Values.vmdistributed.enabled and .Values.vmcluster.enabled can be true"
+
+  - it: fails when both vmsingle and vmdistributed are enabled
+    set:
+      vmdistributed:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of .Values.vmsingle.enabled, .Values.vmdistributed.enabled and .Values.vmcluster.enabled can be true"
+
+  - it: CR name is derived from release name
+    set:
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-k8s-stack
+
+  - it: injects vmalert proxyURL into extraArgs when vmalert enabled
+    set:
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - equal:
+          path: spec.extraArgs["vmalert.proxyURL"]
+          value: http://vmalert-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:8080
+
+  - it: does not inject vmalert proxyURL when vmalert disabled
+    set:
+      vmalert:
+        enabled: false
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+    asserts:
+      - isNull:
+          path: spec.extraArgs["vmalert.proxyURL"]
+
+  - it: retentionPeriod is passed through to spec
+    set:
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+      vmsingle:
+        spec:
+          retentionPeriod: 90d
+    asserts:
+      - equal:
+          path: spec.retentionPeriod
+          value: 90d

--- a/charts/victoria-metrics-k8s-stack/tests/vtcluster_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vtcluster_test.yaml
@@ -1,0 +1,117 @@
+suite: vtcluster tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vtcluster/vtcluster.yaml
+tests:
+  - it: renders VTCluster CR when enabled
+    set:
+      vtcluster:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VTCluster
+      - isAPIVersion:
+          of: operator.victoriametrics.com/v1
+
+  - it: does not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when both vtsingle and vtcluster are enabled
+    set:
+      vtsingle:
+        enabled: true
+      vtcluster:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of .vtsingle.enabled and .vtcluster.enabled can be true"
+
+  - it: CR name is derived from release name
+    set:
+      vtcluster:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-k8s-stack
+
+  - it: clusterVersion defaults to the pinned VictoriaTraces version in values
+    set:
+      vtcluster:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.clusterVersion
+          value: v0.9.3
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: v0.9.3
+
+  - it: custom clusterVersion in values overrides the pinned default
+    set:
+      vtcluster:
+        enabled: true
+        spec:
+          clusterVersion: v0.99.0
+    asserts:
+      - equal:
+          path: spec.clusterVersion
+          value: v0.99.0
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: v0.99.0
+
+  - it: vtselect is removed from spec when disabled
+    set:
+      vtcluster:
+        enabled: true
+        spec:
+          vtselect:
+            enabled: false
+    asserts:
+      - isNull:
+          path: spec.select
+
+  - it: vtinsert is removed from spec when disabled
+    set:
+      vtcluster:
+        enabled: true
+        spec:
+          vtinsert:
+            enabled: false
+    asserts:
+      - isNull:
+          path: spec.insert
+
+  - it: vtselect port is passed through to spec
+    set:
+      vtcluster:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.select.port
+          value: "10471"
+
+  - it: vtinsert port is passed through to spec
+    set:
+      vtcluster:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.insert.port
+          value: "10481"
+
+  - it: vtstorage port is passed through to spec
+    set:
+      vtcluster:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.storage.port
+          value: "10491"

--- a/charts/victoria-metrics-k8s-stack/tests/vtsingle_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vtsingle_test.yaml
@@ -1,0 +1,62 @@
+suite: vtsingle tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vtsingle/vtsingle.yaml
+tests:
+  - it: renders VTSingle CR when enabled
+    set:
+      vtsingle:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VTSingle
+      - isAPIVersion:
+          of: operator.victoriametrics.com/v1
+
+  - it: does not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when both vtsingle and vtcluster are enabled
+    set:
+      vtsingle:
+        enabled: true
+      vtcluster:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of .vtsingle.enabled and .vtcluster.enabled can be true"
+
+  - it: CR name is derived from release name
+    set:
+      vtsingle:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-k8s-stack
+
+  - it: retentionPeriod is passed through to spec
+    set:
+      vtsingle:
+        enabled: true
+        spec:
+          retentionPeriod: 30d
+    asserts:
+      - equal:
+          path: spec.retentionPeriod
+          value: 30d
+
+  - it: port is passed through to spec
+    set:
+      vtsingle:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.port
+          value: "10428"

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -71,6 +71,16 @@ defaultDashboards:
     victoriametrics-operator:
       enabled: true
       clusterMetric: vm_app_version
+    victorialogs-cluster:
+      clusterMetric: vm_app_version
+    victorialogs-single-node:
+      clusterMetric: vm_app_version
+    victorialogs-vlagent:
+      clusterMetric: vm_app_version
+    victoriatraces-single-node:
+      clusterMetric: vm_app_version
+    victoriatraces-cluster:
+      clusterMetric: vm_app_version
     node-exporter-full:
       enabled: true
       clusterMetric: node_uname_info
@@ -88,6 +98,21 @@ defaultDashboards:
       enabled: '{{ .Values.kubeScheduler.enabled }}'
   # -- Dashboard sources. Set enabled: false on any entry to disable it. Add new keys to extend.
   sources:
+    victoriatraces-cluster:
+      url: https://raw.githubusercontent.com/VictoriaMetrics/VictoriaTraces/master/dashboards/victoriatraces-cluster.json
+      enabled: '{{ .Values.vtcluster.enabled }}'
+    victoriatraces-single-node:
+      url: https://raw.githubusercontent.com/VictoriaMetrics/VictoriaTraces/master/dashboards/victoriatraces.json
+      enabled: '{{ .Values.vtsingle.enabled }}'
+    victorialogs-cluster:
+      url: https://raw.githubusercontent.com/VictoriaMetrics/VictoriaLogs/master/dashboards/victorialogs-cluster.json
+      enabled: '{{ .Values.vlcluster.enabled }}'
+    victorialogs-single-node:
+      url: https://raw.githubusercontent.com/VictoriaMetrics/VictoriaLogs/master/dashboards/victorialogs.json
+      enabled: '{{ .Values.vlsingle.enabled }}'
+    victorialogs-vlagent:
+      url: https://raw.githubusercontent.com/VictoriaMetrics/VictoriaLogs/master/dashboards/vlagent.json
+      enabled: '{{ .Values.vlagent.enabled }}'
     victoriametrics-single-node:
       url: https://raw.githubusercontent.com/VictoriaMetrics/VictoriaMetrics/master/dashboards/victoriametrics.json
       enabled: '{{ .Values.vmsingle.enabled }}'
@@ -355,6 +380,21 @@ defaultRules:
     vmoperator:
       url: https://raw.githubusercontent.com/VictoriaMetrics/operator/master/config/alerting/vmoperator-rules.yaml
       enabled: '{{ index .Values "victoria-metrics-operator" "enabled" }}'
+    vlhealth:
+      url: https://raw.githubusercontent.com/VictoriaMetrics/VictoriaLogs/master/deployment/docker/rules/alerts-health.yml
+      enabled: '{{ or .Values.vlsingle.enabled .Values.vlcluster.enabled .Values.vlagent.enabled }}'
+    vlagent:
+      url: https://raw.githubusercontent.com/VictoriaMetrics/VictoriaLogs/master/deployment/docker/rules/alerts-vlagent.yml
+      enabled: '{{ .Values.vlagent.enabled }}'
+    victorialogs:
+      url: https://raw.githubusercontent.com/VictoriaMetrics/VictoriaLogs/master/deployment/docker/rules/alerts-vlogs.yml
+      enabled: '{{ or .Values.vlsingle.enabled .Values.vlcluster.enabled }}'
+    victoriatraces:
+      url: https://raw.githubusercontent.com/VictoriaMetrics/VictoriaTraces/master/deployment/docker/rules/alerts-vtraces.yml
+      enabled: '{{ or .Values.vtsingle.enabled .Values.vtcluster.enabled }}'
+    vthealth:
+      url: https://raw.githubusercontent.com/VictoriaMetrics/VictoriaTraces/master/deployment/docker/rules/alerts-health.yml
+      enabled: '{{ or .Values.vtsingle.enabled .Values.vtcluster.enabled }}'
 
 # -- Provide custom recording or alerting rules to be deployed into the cluster.
 extraRules: {}
@@ -392,6 +432,775 @@ external:
       # bearerTokenSecret:
       #   name: dbaas-read-access-token
       #   key: bearerToken
+  # -- External VL read and write URLs
+  vl:
+    read:
+      url: ""
+      # bearerTokenSecret:
+      #   name: dbaas-read-access-token
+      #   key: bearerToken
+    write:
+      url: ""
+      # bearerTokenSecret:
+      #   name: dbaas-read-access-token
+      #   key: bearerToken
+  # -- External VT read and write URLs
+  vt:
+    read:
+      url: ""
+      # bearerTokenSecret:
+      #   name: dbaas-read-access-token
+      #   key: bearerToken
+    write:
+      url: ""
+      # bearerTokenSecret:
+      #   name: dbaas-read-access-token
+      #   key: bearerToken
+
+# Configures VLSingle params
+vlsingle:
+  # -- VLSingle labels
+  labels: {}
+  # -- VLSingle annotations
+  annotations: {}
+  # -- Create VLSingle CR
+  enabled: false
+  # -- Full spec for VLSingle CRD. Allowed values describe [here](https://docs.victoriametrics.com/operator/api/#vlsinglespec)
+  spec:
+    port: "9428"
+    image:
+      # renovate: image=victoriametrics/victoria-logs
+      tag: v1.51.0
+    # -- Data retention period. Possible units character: h(ours), d(ays), w(eeks), y(ears), if no unit character specified - month. The minimum retention period is 24h. See these [docs](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention)
+    retentionPeriod: "1"
+    replicaCount: 1
+    extraArgs: {}
+    storage:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi
+  ingress:
+    # -- Enable deployment of ingress for server component
+    enabled: false
+    # -- Ingress annotations
+    annotations:
+      {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    # -- Ingress extra labels
+    labels: {}
+    # -- Ingress default path
+    path: ""
+    # -- Ingress path type
+    pathType: Prefix
+    # -- Ingress controller class name
+    ingressClassName: ""
+
+    # -- Array of host objects
+    hosts: []
+    #  - vlsingle.domain.com
+    # -- Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+    extraPaths: []
+    # - path: /*
+    #   pathType: Prefix
+    #   backend:
+    #     service:
+    #       name: ssl-redirect
+    #       port:
+    #         name: service
+
+    # -- Array of TLS objects
+    tls: []
+    #  - secretName: vlsingle-ingress-tls
+    #    hosts:
+    #      - vlsingle.domain.com
+  route:
+    # -- Enable deployment of HTTPRoute for server component
+    enabled: false
+    # -- HTTPRoute annotations
+    annotations: {}
+    # -- HTTPRoute extra labels
+    labels: {}
+    # -- HTTPGateway objects refs
+    parentRefs: []
+    # -- Array of hostnames
+    hostnames: []
+    # -- Extra rules to prepend to route. This is useful when working with annotation based services.
+    extraRules: []
+    # -- Route port
+    port: '{{ .Values.vlsingle.spec.port }}'
+    # -- Filters for a default rule in HTTPRoute
+    filters: []
+    # -- Matches for a default rule in HTTPRoute
+    matches:
+      - path:
+          type: PathPrefix
+          value: '{{ dig "spec" "extraArgs" "http.pathPrefix" "/" .Values.vlsingle }}'
+vlcluster:
+  # -- Create VLCluster CR
+  enabled: false
+  # -- VLCluster labels
+  labels: {}
+  # -- VLCluster annotations
+  annotations: {}
+  # -- Full spec for VLCluster CRD. Allowed values described [here](https://docs.victoriametrics.com/operator/api/#vlclusterspec)
+  spec:
+    # -- Data retention period. Possible units character: h(ours), d(ays), w(eeks), y(ears), if no unit character specified - month. The minimum retention period is 24h. See these [docs](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention)
+    retentionPeriod: 14d
+    # renovate: image=victoriametrics/victoria-logs
+    clusterVersion: v1.51.0
+    vlstorage:
+      replicaCount: 2
+      storageDataPath: /vl-data
+      port: "9491"
+      storage:
+        volumeClaimTemplate:
+          spec:
+            resources:
+              requests:
+                storage: 10Gi
+      resources:
+        {}
+        # limits:
+        #   cpu: "1"
+        #   memory: 1500Mi
+    vlselect:
+      # -- Set this value to false to disable VMSelect
+      enabled: true
+      port: "9471"
+      replicaCount: 2
+      extraArgs: {}
+      storage:
+        volumeClaimTemplate:
+          spec:
+            resources:
+              requests:
+                storage: 2Gi
+      resources:
+        {}
+        # limits:
+        #   cpu: "1"
+        #   memory: "1000Mi"
+        # requests:
+        #   cpu: "0.5"
+        #   memory: "500Mi"
+    vlinsert:
+      # -- Set this value to false to disable VMInsert
+      enabled: true
+      port: "9481"
+      replicaCount: 2
+      extraArgs: {}
+      resources:
+        {}
+        # limits:
+        #   cpu: "1"
+        #   memory: 1000Mi
+        # requests:
+        #   cpu: "0.5"
+        #   memory: "500Mi"
+
+  ingress:
+    vlstorage:
+      # -- Enable deployment of ingress for server component
+      enabled: false
+
+      # -- Ingress annotations
+      annotations: {}
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+
+      # -- Ingress extra labels
+      labels: {}
+
+      # -- Ingress controller class name
+      ingressClassName: ""
+
+      # -- Ingress path type
+      pathType: Prefix
+
+      # -- Ingress default path
+      path: ""
+
+      # -- Array of host objects
+      hosts: []
+      #  - vlstorage.domain.com
+
+      # -- Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+      extraPaths: []
+      # - path: /*
+      #   pathType: Prefix
+      #   backend:
+      #     service:
+      #       name: ssl-redirect
+      #       port:
+      #         name: service
+
+      # -- Array of TLS objects
+      tls: []
+      #  - secretName: vlstorage-ingress-tls
+      #    hosts:
+      #      - vlstorage.domain.com
+    vlselect:
+      # -- Enable deployment of ingress for server component
+      enabled: false
+
+      # -- Ingress annotations
+      annotations: {}
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+
+      # -- Ingress extra labels
+      labels: {}
+
+      # -- Ingress controller class name
+      ingressClassName: ""
+
+      # -- Ingress path type
+      pathType: Prefix
+
+      # -- Ingress default path
+      path: '{{ dig "extraArgs" "http.pathPrefix" "/" .Values.vlcluster.spec.vlselect }}'
+
+      # -- Array of host objects
+      hosts: []
+      #  - vlselect.domain.com
+      # -- Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+      extraPaths: []
+      # - path: /*
+      #   pathType: Prefix
+      #   backend:
+      #     service:
+      #       name: ssl-redirect
+      #       port:
+      #         name: service
+
+      # -- Array of TLS objects
+      tls: []
+      #  - secretName: vlselect-ingress-tls
+      #    hosts:
+      #      - vlselect.domain.com
+    vlinsert:
+      # -- Enable deployment of ingress for server component
+      enabled: false
+
+      # -- Ingress annotations
+      annotations:
+        {}
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+
+      # -- Ingress extra labels
+      labels: {}
+
+      # -- Ingress controller class name
+      ingressClassName: ""
+
+      # -- Ingress path type
+      pathType: Prefix
+
+      # -- Ingress default path
+      path: '{{ dig "extraArgs" "http.pathPrefix" "/" .Values.vlcluster.spec.vlinsert }}'
+
+      # -- Array of host objects
+      hosts: []
+      #  - vlinsert.domain.com
+      # -- Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+      extraPaths: []
+      # - path: /*
+      #   pathType: Prefix
+      #   backend:
+      #     service:
+      #       name: ssl-redirect
+      #       port:
+      #         name: service
+
+      # -- Array of TLS objects
+      tls: []
+      #  - secretName: vlinsert-ingress-tls
+      #    hosts:
+      #      - vlinsert.domain.com
+  route:
+    vlstorage:
+      # -- Enable deployment of HTTPRoute for storage component
+      enabled: false
+      # -- HTTPRoute annotations
+      annotations: {}
+      # -- HTTPRoute extra labels
+      labels: {}
+      # -- HTTPGateway objects refs
+      parentRefs: []
+      # -- Array of hostnames
+      hostnames: []
+      # -- Extra rules to prepend to route. This is useful when working with annotation based services.
+      extraRules: []
+      # -- Route port
+      port: '{{ .Values.vlcluster.spec.vlstorage.port }}'
+      # -- Filters for a default rule in HTTPRoute
+      filters: []
+      # -- Matches for a default rule in HTTPRoute
+      matches:
+        - path:
+            type: PathPrefix
+            value: '{{ dig "extraArgs" "http.pathPrefix" "/" .Values.vlcluster.spec.vlstorage }}'
+    vlselect:
+      # -- Enable deployment of HTTPRoute for select component
+      enabled: false
+      # -- HTTPRoute annotations
+      annotations: {}
+      # -- HTTPRoute extra labels
+      labels: {}
+      # -- HTTPGateway objects refs
+      parentRefs: []
+      # -- Array of hostnames
+      hostnames: []
+      # -- Extra rules to prepend to route. This is useful when working with annotation based services.
+      extraRules: []
+      # -- Route port
+      port: '{{ .Values.vlcluster.spec.vlselect.port }}'
+      # -- Filters for a default rule in HTTPRoute
+      filters: []
+      # -- Matches for a default rule in HTTPRoute
+      matches:
+        - path:
+            type: PathPrefix
+            value: '{{ dig "extraArgs" "http.pathPrefix" "/" .Values.vlcluster.spec.vlselect }}'
+    vlinsert:
+      # -- Enable deployment of HTTPRoute for insert component
+      enabled: false
+      # -- HTTPRoute annotations
+      annotations: {}
+      # -- HTTPRoute extra labels
+      labels: {}
+      # -- HTTPGateway objects refs
+      parentRefs: []
+      # -- Array of hostnames
+      hostnames: []
+      # -- Extra rules to prepend to route. This is useful when working with annotation based services.
+      extraRules: []
+      # -- Route port
+      port: '{{ .Values.vlcluster.spec.vlinsert.port }}'
+      # -- Filters for a default rule in HTTPRoute
+      filters: []
+      # -- Matches for a default rule in HTTPRoute
+      matches:
+        - path:
+            type: PathPrefix
+            value: '{{ dig "extraArgs" "http.pathPrefix" "/" .Values.vlcluster.spec.vlinsert }}'
+
+vlagent:
+  # -- Create VLAgent CR
+  enabled: false
+  # -- VLAgent labels
+  labels: {}
+  # -- VLAgent annotations
+  annotations: {}
+  rbac:
+    # -- Role/RoleBinding annotations
+    annotations: {}
+    # -- Defines if ClusterRole or Role with respective bindings should be created
+    namespaced: true
+    # -- Role/RoleBinding labels
+    extraLabels: {}
+    # -- additional rules for a role
+    rules: []
+  # -- Remote write configuration of VLAgent, allowed parameters defined in a [spec](https://docs.victoriametrics.com/operator/api/#vlagentremotewritespec)
+  additionalRemoteWrites:
+    []
+    #- url: http://some-remote-write/api/v1/write
+  # -- (object) Full spec for VLAgent CRD. Allowed values described [here](https://docs.victoriametrics.com/operator/api/#vlagentspec)
+  spec:
+    port: "9429"
+    image:
+      # renovate: image=victoriametrics/victoria-logs
+      tag: v1.51.0
+    k8sCollector:
+      enabled: true
+  # -- (object) VLAgent ingress configuration
+  ingress:
+    enabled: false
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+    # Values can be templated
+    annotations:
+      {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    labels: {}
+    path: ""
+    pathType: Prefix
+
+    hosts:
+      - vlagent.domain.com
+    extraPaths: []
+    # - path: /*
+    #   pathType: Prefix
+    #   backend:
+    #     service:
+    #       name: ssl-redirect
+    #       port:
+    #         name: service
+    tls: []
+    #  - secretName: vlagent-ingress-tls
+    #    hosts:
+    #      - vlagent.domain.com
+
+  # -- (object) VLAgent route configuration
+  route:
+    # -- Enable deployment of HTTPRoute for vlagent component
+    enabled: false
+    # -- HTTPRoute annotations
+    annotations: {}
+    # -- HTTPRoute extra labels
+    labels: {}
+    # -- HTTPGateway objects refs
+    parentRefs: []
+    # -- Array of hostnames
+    hostnames: []
+    # -- Extra rules to prepend to route. This is useful when working with annotation based services.
+    extraRules: []
+    # -- Route port
+    port: '{{ .Values.vlagent.spec.port }}'
+    # -- Filters for a default rule in HTTPRoute
+    filters: []
+    # -- Matches for a default rule in HTTPRoute
+    matches:
+      - path:
+          type: PathPrefix
+          value: '{{ dig "spec" "extraArgs" "http.pathPrefix" "/" .Values.vlagent }}'
+
+# Configures VTSingle params
+vtsingle:
+  # -- VTSingle labels
+  labels: {}
+  # -- VTSingle annotations
+  annotations: {}
+  # -- Create VTSingle CR
+  enabled: false
+  # -- Full spec for VTSingle CRD. Allowed values described [here](https://docs.victoriametrics.com/operator/api/#vtsinglespec)
+  spec:
+    port: "10428"
+    image:
+      # renovate: image=victoriametrics/victoria-traces
+      tag: v0.9.3
+    # -- Data retention period. Possible units character: h(ours), d(ays), w(eeks), y(ears), if no unit character specified - month. The minimum retention period is 24h.
+    retentionPeriod: "1"
+    replicaCount: 1
+    extraArgs: {}
+    storage:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi
+  ingress:
+    # -- Enable deployment of ingress for server component
+    enabled: false
+    # -- Ingress annotations
+    annotations:
+      {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    # -- Ingress extra labels
+    labels: {}
+    # -- Ingress default path
+    path: ""
+    # -- Ingress path type
+    pathType: Prefix
+    # -- Ingress controller class name
+    ingressClassName: ""
+    # -- Array of host objects
+    hosts: []
+    #  - vtsingle.domain.com
+    # -- Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+    extraPaths: []
+    # - path: /*
+    #   pathType: Prefix
+    #   backend:
+    #     service:
+    #       name: ssl-redirect
+    #       port:
+    #         name: service
+    # -- Array of TLS objects
+    tls: []
+    #  - secretName: vtsingle-ingress-tls
+    #    hosts:
+    #      - vtsingle.domain.com
+  route:
+    # -- Enable deployment of HTTPRoute for server component
+    enabled: false
+    # -- HTTPRoute annotations
+    annotations: {}
+    # -- HTTPRoute extra labels
+    labels: {}
+    # -- HTTPGateway objects refs
+    parentRefs: []
+    # -- Array of hostnames
+    hostnames: []
+    # -- Extra rules to prepend to route. This is useful when working with annotation based services.
+    extraRules: []
+    # -- Route port
+    port: '{{ .Values.vtsingle.spec.port }}'
+    # -- Filters for a default rule in HTTPRoute
+    filters: []
+    # -- Matches for a default rule in HTTPRoute
+    matches:
+      - path:
+          type: PathPrefix
+          value: '{{ dig "spec" "extraArgs" "http.pathPrefix" "/" .Values.vtsingle }}'
+
+vtcluster:
+  # -- Create VTCluster CR
+  enabled: false
+  # -- VTCluster labels
+  labels: {}
+  # -- VTCluster annotations
+  annotations: {}
+  # -- Full spec for VTCluster CRD. Allowed values described [here](https://docs.victoriametrics.com/operator/api/#vtclusterspec)
+  spec:
+    # -- Data retention period. Possible units character: h(ours), d(ays), w(eeks), y(ears), if no unit character specified - month. The minimum retention period is 24h.
+    retentionPeriod: 14d
+    # renovate: image=victoriametrics/victoria-traces
+    clusterVersion: v0.9.3
+    vtstorage:
+      replicaCount: 2
+      storageDataPath: /vt-data
+      port: "10491"
+      storage:
+        volumeClaimTemplate:
+          spec:
+            resources:
+              requests:
+                storage: 10Gi
+      resources:
+        {}
+        # limits:
+        #   cpu: "1"
+        #   memory: 1500Mi
+    vtselect:
+      # -- Set this value to false to disable VTSelect
+      enabled: true
+      port: "10471"
+      replicaCount: 2
+      extraArgs: {}
+      storage:
+        volumeClaimTemplate:
+          spec:
+            resources:
+              requests:
+                storage: 2Gi
+      resources:
+        {}
+        # limits:
+        #   cpu: "1"
+        #   memory: "1000Mi"
+        # requests:
+        #   cpu: "0.5"
+        #   memory: "500Mi"
+    vtinsert:
+      # -- Set this value to false to disable VTInsert
+      enabled: true
+      port: "10481"
+      replicaCount: 2
+      extraArgs: {}
+      resources:
+        {}
+        # limits:
+        #   cpu: "1"
+        #   memory: 1000Mi
+        # requests:
+        #   cpu: "0.5"
+        #   memory: "500Mi"
+
+  ingress:
+    vtstorage:
+      # -- Enable deployment of ingress for storage component
+      enabled: false
+
+      # -- Ingress annotations
+      annotations: {}
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+
+      # -- Ingress extra labels
+      labels: {}
+
+      # -- Ingress controller class name
+      ingressClassName: ""
+
+      # -- Ingress path type
+      pathType: Prefix
+
+      # -- Ingress default path
+      path: ""
+
+      # -- Array of host objects
+      hosts: []
+      #  - vtstorage.domain.com
+
+      # -- Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+      extraPaths: []
+      # - path: /*
+      #   pathType: Prefix
+      #   backend:
+      #     service:
+      #       name: ssl-redirect
+      #       port:
+      #         name: service
+
+      # -- Array of TLS objects
+      tls: []
+      #  - secretName: vtstorage-ingress-tls
+      #    hosts:
+      #      - vtstorage.domain.com
+    vtselect:
+      # -- Enable deployment of ingress for select component
+      enabled: false
+
+      # -- Ingress annotations
+      annotations: {}
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+
+      # -- Ingress extra labels
+      labels: {}
+
+      # -- Ingress controller class name
+      ingressClassName: ""
+
+      # -- Ingress path type
+      pathType: Prefix
+
+      # -- Ingress default path
+      path: '{{ dig "extraArgs" "http.pathPrefix" "/" .Values.vtcluster.spec.vtselect }}'
+
+      # -- Array of host objects
+      hosts: []
+      #  - vtselect.domain.com
+      # -- Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+      extraPaths: []
+      # - path: /*
+      #   pathType: Prefix
+      #   backend:
+      #     service:
+      #       name: ssl-redirect
+      #       port:
+      #         name: service
+
+      # -- Array of TLS objects
+      tls: []
+      #  - secretName: vtselect-ingress-tls
+      #    hosts:
+      #      - vtselect.domain.com
+    vtinsert:
+      # -- Enable deployment of ingress for insert component
+      enabled: false
+
+      # -- Ingress annotations
+      annotations:
+        {}
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+
+      # -- Ingress extra labels
+      labels: {}
+
+      # -- Ingress controller class name
+      ingressClassName: ""
+
+      # -- Ingress path type
+      pathType: Prefix
+
+      # -- Ingress default path
+      path: '{{ dig "extraArgs" "http.pathPrefix" "/" .Values.vtcluster.spec.vtinsert }}'
+
+      # -- Array of host objects
+      hosts: []
+      #  - vtinsert.domain.com
+      # -- Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+      extraPaths: []
+      # - path: /*
+      #   pathType: Prefix
+      #   backend:
+      #     service:
+      #       name: ssl-redirect
+      #       port:
+      #         name: service
+
+      # -- Array of TLS objects
+      tls: []
+      #  - secretName: vtinsert-ingress-tls
+      #    hosts:
+      #      - vtinsert.domain.com
+  route:
+    vtstorage:
+      # -- Enable deployment of HTTPRoute for storage component
+      enabled: false
+      # -- HTTPRoute annotations
+      annotations: {}
+      # -- HTTPRoute extra labels
+      labels: {}
+      # -- HTTPGateway objects refs
+      parentRefs: []
+      # -- Array of hostnames
+      hostnames: []
+      # -- Extra rules to prepend to route. This is useful when working with annotation based services.
+      extraRules: []
+      # -- Route port
+      port: '{{ .Values.vtcluster.spec.vtstorage.port }}'
+      # -- Filters for a default rule in HTTPRoute
+      filters: []
+      # -- Matches for a default rule in HTTPRoute
+      matches:
+        - path:
+            type: PathPrefix
+            value: '{{ dig "extraArgs" "http.pathPrefix" "/" .Values.vtcluster.spec.vtstorage }}'
+    vtselect:
+      # -- Enable deployment of HTTPRoute for select component
+      enabled: false
+      # -- HTTPRoute annotations
+      annotations: {}
+      # -- HTTPRoute extra labels
+      labels: {}
+      # -- HTTPGateway objects refs
+      parentRefs: []
+      # -- Array of hostnames
+      hostnames: []
+      # -- Extra rules to prepend to route. This is useful when working with annotation based services.
+      extraRules: []
+      # -- Route port
+      port: '{{ .Values.vtcluster.spec.vtselect.port }}'
+      # -- Filters for a default rule in HTTPRoute
+      filters: []
+      # -- Matches for a default rule in HTTPRoute
+      matches:
+        - path:
+            type: PathPrefix
+            value: '{{ dig "extraArgs" "http.pathPrefix" "/" .Values.vtcluster.spec.vtselect }}'
+    vtinsert:
+      # -- Enable deployment of HTTPRoute for insert component
+      enabled: false
+      # -- HTTPRoute annotations
+      annotations: {}
+      # -- HTTPRoute extra labels
+      labels: {}
+      # -- HTTPGateway objects refs
+      parentRefs: []
+      # -- Array of hostnames
+      hostnames: []
+      # -- Extra rules to prepend to route. This is useful when working with annotation based services.
+      extraRules: []
+      # -- Route port
+      port: '{{ .Values.vtcluster.spec.vtinsert.port }}'
+      # -- Filters for a default rule in HTTPRoute
+      filters: []
+      # -- Matches for a default rule in HTTPRoute
+      matches:
+        - path:
+            type: PathPrefix
+            value: '{{ dig "extraArgs" "http.pathPrefix" "/" .Values.vtcluster.spec.vtinsert }}'
 
 # Configures vmsingle params
 vmsingle:
@@ -1062,6 +1871,10 @@ vmauth:
   # It's possible to use given below predefined variables in spec:
   # * `{{ .vm.read }}` - parsed vmselect, vmsingle or external.vm.read URL
   # * `{{ .vm.write }}` - parsed vminsert, vmsingle or external.vm.write URL
+  # * `{{ .vl.read }}` - parsed vlselect, vlsingle or external.vl.read URL
+  # * `{{ .vl.write }}` - parsed vlinsert, vlsingle or external.vl.write URL
+  # * `{{ .vt.read }}` - parsed vtselect, vtsingle or external.vt.read URL
+  # * `{{ .vt.write }}` - parsed vtinsert, vtsingle or external.vt.write URL
   spec:
     port: "8427"
     unauthorizedUserAccessSpec:
@@ -1187,6 +2000,22 @@ defaultDatasources:
         access: proxy
         uid: VictoriaMetricsDS
         type: victoriametrics-metrics-datasource
+  victorialogs:
+    # -- List of VictoriaLogs datasource configurations.
+    # VL `url` will be added to each of them in templates.
+    datasources:
+      - name: VictoriaLogs (DS)
+        access: proxy
+        uid: VictoriaLogs
+        type: victoriametrics-logs-datasource
+  victoriatraces:
+    # -- List of VictoriaTraces (Jaeger-compatible) datasource configurations.
+    # VT `url` will be added to each of them in templates.
+    datasources:
+      - name: VictoriaTraces
+        access: proxy
+        uid: VictoriaTraces
+        type: jaeger
   # -- List of alertmanager datasources.
   # VMAlertmanager generated `url` will be added to each datasource in template if alertmanager is enabled
   alertmanager:
@@ -1630,6 +2459,28 @@ kubeProxy:
           scheme: https
           tlsConfig:
             caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+internal:
+  vmauth:
+    # -- name is a template for the internal VMAuth CR used for vmalert datasource routing
+    name: '{{ .fullname }}-internal'
+    # -- (object) Spec for internal VMAuth CRD used as a vmalert datasource proxy.
+    # It's possible to use given below predefined variables in spec:
+    # * `{{ .vm.read }}` - parsed vmselect, vmsingle or external.vm.read URL
+    # * `{{ .vl.read }}` - parsed vlselect, vlsingle or external.vl.read URL
+    # * `{{ .vt.read }}` - parsed vtselect, vtsingle or external.vt.read URL
+    spec:
+      port: "8427"
+      unauthorizedUserAccessSpec:
+        url_map:
+          - src_paths:
+              - '/select/logsql/.*'
+            url_prefix:
+              - '{{ urlJoin (omit .vl.read "path") }}/'
+          - src_paths:
+              - '/.*'
+            url_prefix:
+              - '{{ (include "vm.prometheus.read" . | fromYaml).url }}/'
 
 # -- Add extra objects dynamically to this chart
 extraObjects: []

--- a/hack/sync-job/README.md
+++ b/hack/sync-job/README.md
@@ -16,6 +16,7 @@ A Go binary that runs as a Kubernetes Job on every Helm install/upgrade. It fetc
 | `CONFIG` | `/etc/config/config.yaml` | Path to the config file |
 | `NAMESPACE` | `default` | Namespace where resources are created |
 | `RELEASE` | _(empty)_ | Helm release name; scopes managed resources per release via `app.kubernetes.io/instance` |
+| `RESOURCE_PREFIX` | value of `RELEASE` | Prefix for managed resource names (`<prefix>-rule-<group>`, `<prefix>-dashboard-<name>`). Defaults to `RELEASE`; falls back to `vm-k8s-stack` when both are unset. |
 | `PRUNE` | `true` | Set to `false` to disable deletion of orphaned resources |
 
 ## Config file


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/helm-charts/issues/1909
fixes https://github.com/VictoriaMetrics/helm-charts/issues/1910

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds VictoriaLogs to the `victoria-metrics-k8s-stack` chart: deploy `VLSingle`/`VLCluster` and optional `VLAgent` with `k8sCollector`, plus dashboards, alerts, networking, external endpoints, and an auto-provisioned Grafana VL datasource. Adds an internal `VMAuth` to route `vmalert` queries between VM (MetricsQL) and VL (LogsQL) when both are enabled.

- **New Features**
  - Operator CRs: `VLSingle` or `VLCluster` (mutually exclusive) and `VLAgent` with RBAC; spec builders apply global license and image tags; `VLAgent` remoteWrite defaults to VL, supports extras, and enables `k8sCollector` for Kubernetes logs.
  - Grafana: auto-add VictoriaLogs datasource (requires `victoriametrics-logs-datasource`), plus default VL dashboards (cluster, single-node, `VLAgent`) and alert rules (`vlhealth`, `victorialogs`, `vlagent`); supports Grafana Operator CRs and `extraRules`.
  - Networking & external: Ingress and Gateway API `HTTPRoute` for `VLSingle`, `VLCluster` (`vlselect`/`vlinsert`/`vlstorage`) and `VLAgent`; new `external.vl.read`/`external.vl.write`; `vmauth` templates can use `{{ .vm.read }}`/`{{ .vm.write }}` and `{{ .vl.read }}`/`{{ .vl.write }}`.

- **Refactors**
  - `vmalert` datasource/remoteRead now auto-picks VM or VL endpoints, prefers internal `VMAuth` when both are available, and fails fast with clear errors if none are provided.
  - Helpers: added `vl.read.endpoint`/`vl.write.endpoint`; Grafana datasources auto-provision for VM and VL based on availability; cluster tagging and dashboard auto-enable refined for `vlsingle`, `vlcluster`, and `vlagent`.

<sup>Written for commit bdea983367632eba6a39346d9795c75bb24826fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->











