### PR TITLE
operator: release 0.59.2

### DIFF
--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- updates operator to [v0.68.2](https://github.com/VictoriaMetrics/operator/releases/tag/v0.68.2) version
 
 ## 0.59.1
 

--- a/charts/victoria-metrics-operator/Chart.yaml
+++ b/charts/victoria-metrics-operator/Chart.yaml
@@ -6,8 +6,8 @@ home: https://github.com/VictoriaMetrics/operator
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
   - https://github.com/VictoriaMetrics/operator
-version: 0.59.1
-appVersion: v0.68.1
+version: 0.59.2
+appVersion: v0.68.2
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
 kubeVersion: ">=1.25.0-0"
 keywords:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Release victoria-metrics-operator Helm chart 0.59.2 with appVersion v0.68.2. Updates the changelog and pulls in the latest operator fixes and improvements.

<sup>Written for commit d949ebbd72f58c86c8f2d1816d77b9f93220df5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

