### PR TITLE
charts: document enableTCP6 flag

### DIFF
--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -139,7 +139,7 @@ extraArgs:
   envflag.prefix: VM_
   loggerFormat: json
   httpListenAddr: :8429
-  # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+  # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
   # enableTCP6: true
   # promscrape.maxScrapeSize: "167772160"
 

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -139,6 +139,8 @@ extraArgs:
   envflag.prefix: VM_
   loggerFormat: json
   httpListenAddr: :8429
+  # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+  # enableTCP6: true
   # promscrape.maxScrapeSize: "167772160"
 
   # Uncomment and specify the port if you want to support any of the protocols:

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -188,7 +188,7 @@ server:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8880
-    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
     rule:
       - /config/alert-rules.yaml

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -188,6 +188,8 @@ server:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8880
+    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # enableTCP6: true
     rule:
       - /config/alert-rules.yaml
 

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -77,6 +77,8 @@ extraArgs:
   envflag.prefix: VM_
   loggerFormat: json
   httpListenAddr: :8427
+  # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+  # enableTCP6: true
 
 # -- Additional environment variables (ex.: secret tokens, flags). Check [here](https://docs.victoriametrics.com/victoriametrics/#environment-variables) for details
 env: []

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -77,7 +77,7 @@ extraArgs:
   envflag.prefix: VM_
   loggerFormat: json
   httpListenAddr: :8427
-  # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+  # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
   # enableTCP6: true
 
 # -- Additional environment variables (ex.: secret tokens, flags). Check [here](https://docs.victoriametrics.com/victoriametrics/#environment-variables) for details

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -97,6 +97,8 @@ vmselect:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8481
+    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # enableTCP6: true
   # -- StatefulSet/Deployment annotations
   annotations: {}
   # -- StatefulSet/Deployment additional labels
@@ -447,6 +449,8 @@ vminsert:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8480
+    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # enableTCP6: true
   # -- StatefulSet/Deployment annotations
   annotations: {}
   # -- StatefulSet/Deployment additional labels
@@ -770,6 +774,8 @@ vmauth:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8427
+    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # enableTCP6: true
   # -- VMAuth annotations
   annotations: {}
   # -- VMAuth additional labels
@@ -1066,6 +1072,8 @@ vmstorage:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8482
+    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # enableTCP6: true
 
   # -- Additional hostPath mounts
   extraHostPathMounts:

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -97,7 +97,7 @@ vmselect:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8481
-    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
   # -- StatefulSet/Deployment annotations
   annotations: {}
@@ -449,7 +449,7 @@ vminsert:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8480
-    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
   # -- StatefulSet/Deployment annotations
   annotations: {}
@@ -774,7 +774,7 @@ vmauth:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8427
-    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
   # -- VMAuth annotations
   annotations: {}
@@ -1072,7 +1072,7 @@ vmstorage:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8482
-    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
 
   # -- Additional hostPath mounts

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -73,6 +73,8 @@ extraArgs:
   envflag.prefix: VM_
   loggerFormat: json
   httpListenAddr: :8431
+  # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+  # enableTCP6: true
 
 # -- Additional environment variables (ex.: secret tokens, flags). Check [here](https://docs.victoriametrics.com/victoriametrics/#environment-variables) for details.
 env: []

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -73,7 +73,7 @@ extraArgs:
   envflag.prefix: VM_
   loggerFormat: json
   httpListenAddr: :8431
-  # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+  # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
   # enableTCP6: true
 
 # -- Additional environment variables (ex.: secret tokens, flags). Check [here](https://docs.victoriametrics.com/victoriametrics/#environment-variables) for details.

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -97,6 +97,8 @@ server:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8428
+    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # enableTCP6: true
 
   # Additional hostPath mounts
   extraHostPathMounts:

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -97,7 +97,7 @@ server:
     envflag.prefix: VM_
     loggerFormat: json
     httpListenAddr: :8428
-    # -- Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
+    # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
 
   # Additional hostPath mounts


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documented the `enableTCP6` flag across VictoriaMetrics Helm charts to show how to enable IPv6 in IPv6-only clusters. Adds commented examples in values.yaml for agent, alert, auth, cluster (vmselect, vminsert, vmauth, vmstorage), gateway, and single; docs-only with no behavior change.

<sup>Written for commit c9dc8d2d487e4b3edd395465c5630021668a6766. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

