### PR TITLE
all: replace custom app label with app.kubernetes.io/component

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.0.15
 

--- a/charts/victoria-logs-agent/Chart.lock
+++ b/charts/victoria-logs-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
-digest: sha256:861aeda558bfe15669538c60a64ccf1cd914040670195108c3038b9ffa37de68
-generated: "2025-12-23T21:54:20.359907+02:00"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:31:31.719048+03:00"

--- a/charts/victoria-logs-agent/Chart.yaml
+++ b/charts/victoria-logs-agent/Chart.yaml
@@ -29,5 +29,5 @@ annotations:
       url: https://docs.victoriametrics.com/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.0.32
 

--- a/charts/victoria-logs-cluster/Chart.lock
+++ b/charts/victoria-logs-cluster/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: https://helm.vector.dev
   version: 0.51.0
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts/
-  version: 0.0.46
-digest: sha256:b3d86c5ac179d68f196a1c3c3614347b490383bfbf19a701c5a86e89fe58269b
-generated: "2026-03-12T08:14:21.92250436Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:41a878081e7ddf202edf9a2c557a26dbd73d9391c74b86c7b37922e55bb9be06
+generated: "2026-04-12T20:02:50.044045+03:00"

--- a/charts/victoria-logs-cluster/Chart.yaml
+++ b/charts/victoria-logs-cluster/Chart.yaml
@@ -34,5 +34,5 @@ dependencies:
     repository: https://helm.vector.dev
     condition: vector.enabled
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts/
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-cluster/tests/__snapshot__/hpa_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/hpa_test.yaml.snap
@@ -4,7 +4,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -27,7 +27,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster

--- a/charts/victoria-logs-cluster/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/ingress_test.yaml.snap
@@ -6,7 +6,7 @@ ingress should match snapshot:
       annotations:
         kubernetes.io/ingress.class: alb
       labels:
-        app: vlinsert
+        app.kubernetes.io/component: vlinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -37,7 +37,7 @@ ingress should match snapshot:
       annotations:
         kubernetes.io/ingress.class: kong
       labels:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -64,7 +64,7 @@ ingress should match snapshot:
       annotations:
         kubernetes.io/ingress.class: nginx
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster

--- a/charts/victoria-logs-cluster/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/service_test.yaml.snap
@@ -4,7 +4,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vlinsert
+        app.kubernetes.io/component: vlinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -19,7 +19,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vlinsert
+        app.kubernetes.io/component: vlinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -28,7 +28,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -43,7 +43,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -52,7 +52,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vlstorage
+        app.kubernetes.io/component: vlstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -68,7 +68,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vlstorage
+        app.kubernetes.io/component: vlstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -77,7 +77,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -92,7 +92,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -102,7 +102,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: vlinsert
+        app.kubernetes.io/component: vlinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -117,7 +117,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: vlinsert
+        app.kubernetes.io/component: vlinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -126,7 +126,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -141,7 +141,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -150,7 +150,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: vlstorage
+        app.kubernetes.io/component: vlstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -166,7 +166,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: vlstorage
+        app.kubernetes.io/component: vlstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -175,7 +175,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -191,7 +191,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vlinsert_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vlinsert_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vlinsert
+        app.kubernetes.io/component: vlinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -16,13 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vlinsert
+          app.kubernetes.io/component: vlinsert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
         metadata:
           labels:
-            app: vlinsert
+            app.kubernetes.io/component: vlinsert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-cluster
@@ -71,7 +71,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
-        app: insert
+        app.kubernetes.io/component: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -84,13 +84,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app: insert
+          app.kubernetes.io/component: insert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
         metadata:
           labels:
-            app: insert
+            app.kubernetes.io/component: insert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-cluster

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vlselect_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vlselect_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -16,13 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vlselect
+          app.kubernetes.io/component: vlselect
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
         metadata:
           labels:
-            app: vlselect
+            app.kubernetes.io/component: vlselect
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-cluster
@@ -71,7 +71,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
-        app: select
+        app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -84,13 +84,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app: select
+          app.kubernetes.io/component: select
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
         metadata:
           labels:
-            app: select
+            app.kubernetes.io/component: select
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-cluster

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vlstorage_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vlstorage_test.yaml.snap
@@ -4,7 +4,7 @@ statefulset should match snapshot:
     kind: StatefulSet
     metadata:
       labels:
-        app: vlstorage
+        app.kubernetes.io/component: vlstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -18,14 +18,14 @@ statefulset should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vlstorage
+          app.kubernetes.io/component: vlstorage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       serviceName: RELEASE-NAME-victoria-logs-cluster-vlstorage
       template:
         metadata:
           labels:
-            app: vlstorage
+            app.kubernetes.io/component: vlstorage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-cluster
@@ -80,7 +80,7 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
     kind: StatefulSet
     metadata:
       labels:
-        app: storage
+        app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -95,14 +95,14 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
       replicas: 2
       selector:
         matchLabels:
-          app: storage
+          app.kubernetes.io/component: storage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       serviceName: vlstorage-node
       template:
         metadata:
           labels:
-            app: storage
+            app.kubernetes.io/component: storage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-cluster

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vmauth_test.yaml.snap
@@ -7,7 +7,7 @@ deployment should match snapshot:
     kind: Secret
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -21,7 +21,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -33,15 +33,15 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vmauth
+          app.kubernetes.io/component: vmauth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
         metadata:
           annotations:
-            checksum/config: f321b46b76cdf488b571082e5c986345d95c4cda2a9cbc6d744f6d822f3f7f3a
+            checksum/config: 0965fdbaa20de3aaef7cf3475ffc3334e383be2a8307e4b5ad8f1a653f479eb2
           labels:
-            app: vmauth
+            app.kubernetes.io/component: vmauth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-cluster
@@ -97,7 +97,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Secret
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -111,7 +111,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-cluster
@@ -124,15 +124,15 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app: auth
+          app.kubernetes.io/component: auth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
         metadata:
           annotations:
-            checksum/config: 3f6c2eab9dd05270bf389345b95195e2e43da2b7589bcef4f505fc117b7b087e
+            checksum/config: 15c02bc9ec3b4d856d0e64b544136a5ee34099b581e15b2b83cb334e7567ff1f
           labels:
-            app: auth
+            app.kubernetes.io/component: auth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-cluster

--- a/charts/victoria-logs-collector/CHANGELOG.md
+++ b/charts/victoria-logs-collector/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.2.15
 

--- a/charts/victoria-logs-collector/Chart.lock
+++ b/charts/victoria-logs-collector/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.45
-digest: sha256:206741a78c40bcfca90f8c7213f837092f3f390f095159320bd7a188267082cf
-generated: "2025-12-20T00:04:07.223594+02:00"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T19:52:50.867894+03:00"

--- a/charts/victoria-logs-collector/Chart.yaml
+++ b/charts/victoria-logs-collector/Chart.yaml
@@ -29,5 +29,5 @@ annotations:
       url: https://docs.victoriametrics.com/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-mcp/CHANGELOG.md
+++ b/charts/victoria-logs-mcp/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.1.0
 

--- a/charts/victoria-logs-mcp/Chart.lock
+++ b/charts/victoria-logs-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
-digest: sha256:861aeda558bfe15669538c60a64ccf1cd914040670195108c3038b9ffa37de68
-generated: "2026-04-10T14:04:38.096572+02:00"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:32:00.773833+03:00"

--- a/charts/victoria-logs-mcp/Chart.yaml
+++ b/charts/victoria-logs-mcp/Chart.yaml
@@ -25,5 +25,5 @@ annotations:
       url: https://victoriametrics.github.io/helm-charts/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.0.13
 

--- a/charts/victoria-logs-multilevel/Chart.lock
+++ b/charts/victoria-logs-multilevel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts/
-  version: 0.0.46
-digest: sha256:9da65a67bbea64eb5dfd4dff8dbbb4a92f95c8f5e24f0a6d91b704666fae6e01
-generated: "2025-12-23T12:57:31.318050376Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:03:37.72056+03:00"

--- a/charts/victoria-logs-multilevel/Chart.yaml
+++ b/charts/victoria-logs-multilevel/Chart.yaml
@@ -30,5 +30,5 @@ annotations:
       url: https://docs.victoriametrics.com/victorialogs/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts/
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-multilevel/tests/__snapshot__/hpa_test.yaml.snap
+++ b/charts/victoria-logs-multilevel/tests/__snapshot__/hpa_test.yaml.snap
@@ -4,7 +4,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -27,7 +27,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel

--- a/charts/victoria-logs-multilevel/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/victoria-logs-multilevel/tests/__snapshot__/ingress_test.yaml.snap
@@ -6,7 +6,7 @@ ingress should match snapshot:
       annotations:
         kubernetes.io/ingress.class: kong
       labels:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -33,7 +33,7 @@ ingress should match snapshot:
       annotations:
         kubernetes.io/ingress.class: nginx
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel

--- a/charts/victoria-logs-multilevel/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/victoria-logs-multilevel/tests/__snapshot__/service_test.yaml.snap
@@ -4,7 +4,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -19,7 +19,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-multilevel
       type: ClusterIP
@@ -28,7 +28,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -43,7 +43,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-multilevel
       type: ClusterIP
@@ -53,7 +53,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -68,7 +68,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-multilevel
       type: ClusterIP
@@ -77,7 +77,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -93,7 +93,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-multilevel
       type: ClusterIP

--- a/charts/victoria-logs-multilevel/tests/__snapshot__/vlselect_test.yaml.snap
+++ b/charts/victoria-logs-multilevel/tests/__snapshot__/vlselect_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vlselect
+        app.kubernetes.io/component: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -16,13 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vlselect
+          app.kubernetes.io/component: vlselect
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-multilevel
       template:
         metadata:
           labels:
-            app: vlselect
+            app.kubernetes.io/component: vlselect
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-multilevel
@@ -69,7 +69,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
-        app: select
+        app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -82,13 +82,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app: select
+          app.kubernetes.io/component: select
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-multilevel
       template:
         metadata:
           labels:
-            app: select
+            app.kubernetes.io/component: select
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-multilevel

--- a/charts/victoria-logs-multilevel/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-logs-multilevel/tests/__snapshot__/vmauth_test.yaml.snap
@@ -7,7 +7,7 @@ deployment should match empty snapshot:
     kind: Secret
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -21,7 +21,7 @@ deployment should match empty snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -33,15 +33,15 @@ deployment should match empty snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vmauth
+          app.kubernetes.io/component: vmauth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-multilevel
       template:
         metadata:
           annotations:
-            checksum/config: b303f8012cbca552fb2c81b6a7236c4756c8a9e4ca950bb2bdbb29d3408967c1
+            checksum/config: 2fb16488ef03445c6b3ca1a47e1871ad81c19453b3ff0a1cf42ef02d0bd97d7a
           labels:
-            app: vmauth
+            app.kubernetes.io/component: vmauth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-multilevel
@@ -97,7 +97,7 @@ deployment should match snapshot:
     kind: Secret
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -111,7 +111,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -123,15 +123,15 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vmauth
+          app.kubernetes.io/component: vmauth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-multilevel
       template:
         metadata:
           annotations:
-            checksum/config: b303f8012cbca552fb2c81b6a7236c4756c8a9e4ca950bb2bdbb29d3408967c1
+            checksum/config: 2fb16488ef03445c6b3ca1a47e1871ad81c19453b3ff0a1cf42ef02d0bd97d7a
           labels:
-            app: vmauth
+            app.kubernetes.io/component: vmauth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-multilevel
@@ -187,7 +187,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Secret
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -201,7 +201,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-multilevel
@@ -214,15 +214,15 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app: auth
+          app.kubernetes.io/component: auth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-multilevel
       template:
         metadata:
           annotations:
-            checksum/config: 9b92376c479c17fec13a45f9b7f8c678adbfc51e88ca5e026246ab947c652d11
+            checksum/config: 4d9b35efb1512df5ff19438e8307ca81a0ca465f9ffe4bc212f64cbed12d1025
           labels:
-            app: auth
+            app.kubernetes.io/component: auth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-multilevel

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.11.31
 

--- a/charts/victoria-logs-single/Chart.lock
+++ b/charts/victoria-logs-single/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: https://helm.vector.dev
   version: 0.51.0
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts/
-  version: 0.0.46
-digest: sha256:b3d86c5ac179d68f196a1c3c3614347b490383bfbf19a701c5a86e89fe58269b
-generated: "2026-03-12T08:14:31.001652957Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:41a878081e7ddf202edf9a2c557a26dbd73d9391c74b86c7b37922e55bb9be06
+generated: "2026-04-12T20:00:49.949142+03:00"

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -35,5 +35,5 @@ dependencies:
     repository: https://helm.vector.dev
     condition: vector.enabled
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts/
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-single/tests/__snapshot__/server_test.yaml.snap
+++ b/charts/victoria-logs-single/tests/__snapshot__/server_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-single
@@ -16,7 +16,7 @@ deployment should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
       strategy:
@@ -24,7 +24,7 @@ deployment should match snapshot:
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-single
@@ -84,7 +84,7 @@ deployment with volume should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-single
@@ -96,7 +96,7 @@ deployment with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
       strategy:
@@ -104,7 +104,7 @@ deployment with volume should match snapshot:
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-single
@@ -164,7 +164,7 @@ statefulset should match snapshot:
     kind: StatefulSet
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-single
@@ -177,14 +177,14 @@ statefulset should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
       serviceName: RELEASE-NAME-victoria-logs-single-server
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-single
@@ -253,7 +253,7 @@ statefulset with volume should match snapshot:
     kind: StatefulSet
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-logs-single
@@ -266,14 +266,14 @@ statefulset with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
       serviceName: RELEASE-NAME-victoria-logs-single-server
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-logs-single

--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.36.0
 

--- a/charts/victoria-metrics-agent/Chart.lock
+++ b/charts/victoria-metrics-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
-digest: sha256:861aeda558bfe15669538c60a64ccf1cd914040670195108c3038b9ffa37de68
-generated: "2025-12-23T12:57:35.808111836Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:10:18.51217+03:00"

--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -35,5 +35,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.37.0
 

--- a/charts/victoria-metrics-alert/Chart.lock
+++ b/charts/victoria-metrics-alert/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
-digest: sha256:861aeda558bfe15669538c60a64ccf1cd914040670195108c3038b9ffa37de68
-generated: "2025-12-23T12:57:39.785896713Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:10:28.173495+03:00"

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -35,5 +35,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 1.12.11
 

--- a/charts/victoria-metrics-anomaly/Chart.lock
+++ b/charts/victoria-metrics-anomaly/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
-digest: sha256:861aeda558bfe15669538c60a64ccf1cd914040670195108c3038b9ffa37de68
-generated: "2025-12-23T12:57:44.007213132Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:10:35.608144+03:00"

--- a/charts/victoria-metrics-anomaly/Chart.yaml
+++ b/charts/victoria-metrics-anomaly/Chart.yaml
@@ -34,5 +34,5 @@ annotations:
       url: https://docs.victoriametrics.com/anomaly-detection/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.29.0
 

--- a/charts/victoria-metrics-auth/Chart.lock
+++ b/charts/victoria-metrics-auth/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
-digest: sha256:861aeda558bfe15669538c60a64ccf1cd914040670195108c3038b9ffa37de68
-generated: "2025-12-23T12:57:46.000926258Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:31:08.041416+03:00"

--- a/charts/victoria-metrics-auth/Chart.yaml
+++ b/charts/victoria-metrics-auth/Chart.yaml
@@ -36,5 +36,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.39.0
 

--- a/charts/victoria-metrics-cluster/Chart.lock
+++ b/charts/victoria-metrics-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
-digest: sha256:861aeda558bfe15669538c60a64ccf1cd914040670195108c3038b9ffa37de68
-generated: "2025-12-23T12:57:48.268884634Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:11:09.836726+03:00"

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -37,5 +37,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/hpa_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/hpa_test.yaml.snap
@@ -4,7 +4,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -26,7 +26,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: vminsert
+        app.kubernetes.io/component: vminsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -48,7 +48,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: vmselect
+        app.kubernetes.io/component: vmselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -70,7 +70,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: vmstorage
+        app.kubernetes.io/component: vmstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -96,7 +96,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -118,7 +118,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: insert
+        app.kubernetes.io/component: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -140,7 +140,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: select
+        app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -162,7 +162,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: storage
+        app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/ingress_test.yaml.snap
@@ -6,7 +6,7 @@ ingress should match snapshot:
       annotations:
         kubernetes.io/ingress.class: nginx
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -33,7 +33,7 @@ ingress should match snapshot:
       annotations:
         kubernetes.io/ingress.class: alb
       labels:
-        app: vminsert
+        app.kubernetes.io/component: vminsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -64,7 +64,7 @@ ingress should match snapshot:
       annotations:
         kubernetes.io/ingress.class: kong
       labels:
-        app: vmselect
+        app.kubernetes.io/component: vmselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/service_test.yaml.snap
@@ -4,7 +4,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -19,7 +19,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -28,7 +28,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vminsert
+        app.kubernetes.io/component: vminsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -43,7 +43,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vminsert
+        app.kubernetes.io/component: vminsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -52,7 +52,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vmselect
+        app.kubernetes.io/component: vmselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -67,7 +67,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vmselect
+        app.kubernetes.io/component: vmselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -76,7 +76,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vmstorage
+        app.kubernetes.io/component: vmstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -100,7 +100,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: vminsert
       selector:
-        app: vmstorage
+        app.kubernetes.io/component: vmstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -110,7 +110,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -126,7 +126,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -135,7 +135,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: insert
+        app.kubernetes.io/component: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -151,7 +151,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: insert
+        app.kubernetes.io/component: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -160,7 +160,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: select
+        app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -176,7 +176,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: select
+        app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -185,7 +185,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: storage
+        app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -210,7 +210,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: vminsert
       selector:
-        app: storage
+        app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmauth_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -16,13 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vmauth
+          app.kubernetes.io/component: vmauth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       template:
         metadata:
           labels:
-            app: vmauth
+            app.kubernetes.io/component: vmauth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-cluster
@@ -71,7 +71,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -84,13 +84,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app: auth
+          app.kubernetes.io/component: auth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       template:
         metadata:
           labels:
-            app: auth
+            app.kubernetes.io/component: auth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-cluster

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vminsert_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vminsert_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vminsert
+        app.kubernetes.io/component: vminsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -16,13 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vminsert
+          app.kubernetes.io/component: vminsert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       template:
         metadata:
           labels:
-            app: vminsert
+            app.kubernetes.io/component: vminsert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-cluster
@@ -66,7 +66,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
-        app: insert
+        app.kubernetes.io/component: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -79,13 +79,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app: insert
+          app.kubernetes.io/component: insert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       template:
         metadata:
           labels:
-            app: insert
+            app.kubernetes.io/component: insert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-cluster

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmselect_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmselect_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vmselect
+        app.kubernetes.io/component: vmselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -16,14 +16,14 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vmselect
+          app.kubernetes.io/component: vmselect
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       strategy: {}
       template:
         metadata:
           labels:
-            app: vmselect
+            app.kubernetes.io/component: vmselect
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-cluster
@@ -76,7 +76,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
-        app: select
+        app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -89,14 +89,14 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app: select
+          app.kubernetes.io/component: select
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       strategy: {}
       template:
         metadata:
           labels:
-            app: select
+            app.kubernetes.io/component: select
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-cluster
@@ -150,7 +150,7 @@ statefulset should match snapshot:
     kind: StatefulSet
     metadata:
       labels:
-        app: vmselect
+        app.kubernetes.io/component: vmselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -163,14 +163,14 @@ statefulset should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vmselect
+          app.kubernetes.io/component: vmselect
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       serviceName: RELEASE-NAME-victoria-metrics-cluster-vmselect
       template:
         metadata:
           labels:
-            app: vmselect
+            app.kubernetes.io/component: vmselect
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-cluster
@@ -225,7 +225,7 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
     kind: StatefulSet
     metadata:
       labels:
-        app: select
+        app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -239,14 +239,14 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
       replicas: 2
       selector:
         matchLabels:
-          app: select
+          app.kubernetes.io/component: select
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       serviceName: vmselect-node
       template:
         metadata:
           labels:
-            app: select
+            app.kubernetes.io/component: select
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-cluster

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
@@ -4,7 +4,7 @@ statefulset should match snapshot:
     kind: StatefulSet
     metadata:
       labels:
-        app: vmstorage
+        app.kubernetes.io/component: vmstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -18,14 +18,14 @@ statefulset should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vmstorage
+          app.kubernetes.io/component: vmstorage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       serviceName: RELEASE-NAME-victoria-metrics-cluster-vmstorage
       template:
         metadata:
           labels:
-            app: vmstorage
+            app.kubernetes.io/component: vmstorage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-cluster
@@ -80,7 +80,7 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
     kind: StatefulSet
     metadata:
       labels:
-        app: storage
+        app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-cluster
@@ -95,14 +95,14 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
       replicas: 2
       selector:
         matchLabels:
-          app: storage
+          app.kubernetes.io/component: storage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       serviceName: vmstorage-node
       template:
         metadata:
           labels:
-            app: storage
+            app.kubernetes.io/component: storage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-cluster

--- a/charts/victoria-metrics-distributed/Chart.lock
+++ b/charts/victoria-metrics-distributed/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
 - name: victoria-metrics-k8s-stack
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.72.4
-digest: sha256:5db665813ebb144495190d9b6cf1b53ab1cda85624baf09937f287532ef4205c
-generated: "2026-03-05T10:36:38.308211+02:00"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.72.6
+digest: sha256:1ecd097cc80b327f5a1c72a2a54dc5b09400ae8398bc16f90c4b6024b3c937d4
+generated: "2026-04-12T20:14:17.754932+03:00"

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -34,9 +34,9 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts
   - name: victoria-metrics-k8s-stack
     version: "0.72.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    repository: oci://ghcr.io/victoriametrics/helm-charts
     condition: victoria-metrics-k8s-stack.enabled

--- a/charts/victoria-metrics-distributed/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-metrics-distributed/tests/__snapshot__/vmauth_test.yaml.snap
@@ -4,7 +4,7 @@ vmauth should match snapshot:
     kind: VMAuth
     metadata:
       labels:
-        app: vmauth-read-proxy-zone-eu-1
+        app.kubernetes.io/component: vmauth-read-proxy-zone-eu-1
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed
@@ -42,7 +42,7 @@ vmauth should match snapshot:
     kind: VMAuth
     metadata:
       labels:
-        app: vmauth-read-proxy-zone-us-1
+        app.kubernetes.io/component: vmauth-read-proxy-zone-us-1
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed
@@ -80,7 +80,7 @@ vmauth should match snapshot:
     kind: VMAuth
     metadata:
       labels:
-        app: vmauth-global-read-RELEASE-NAME-vm-distributed
+        app.kubernetes.io/component: vmauth-global-read-RELEASE-NAME-vm-distributed
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed
@@ -111,7 +111,7 @@ vmauth should match snapshot:
     kind: VMAuth
     metadata:
       labels:
-        app: vmauth-global-write-RELEASE-NAME-vm-distributed
+        app.kubernetes.io/component: vmauth-global-write-RELEASE-NAME-vm-distributed
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vm-distributed

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.27.0
 

--- a/charts/victoria-metrics-gateway/Chart.lock
+++ b/charts/victoria-metrics-gateway/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
-digest: sha256:861aeda558bfe15669538c60a64ccf1cd914040670195108c3038b9ffa37de68
-generated: "2025-12-23T12:57:53.37747447Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:31:48.509103+03:00"

--- a/charts/victoria-metrics-gateway/Chart.yaml
+++ b/charts/victoria-metrics-gateway/Chart.yaml
@@ -37,5 +37,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
 - name: victoria-metrics-operator
-  repository: https://victoriametrics.github.io/helm-charts
+  repository: oci://ghcr.io/victoriametrics/helm-charts
   version: 0.59.5
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
@@ -14,5 +14,5 @@ dependencies:
 - name: grafana
   repository: https://grafana-community.github.io/helm-charts
   version: 11.6.0
-digest: sha256:3426dc24650810d84278ff4d7488529eb62b7dd106eacbedb56c1aced1e6fee6
-generated: "2026-04-12T16:39:03.056148+03:00"
+digest: sha256:7411722ec8ff1baa1be6ca6d3c07a720977aea3d320cbcd3293482752b6b6557
+generated: "2026-04-12T20:31:17.704225+03:00"

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -35,11 +35,11 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts
   - name: victoria-metrics-operator
     version: "0.59.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    repository: oci://ghcr.io/victoriametrics/helm-charts
     condition: victoria-metrics-operator.enabled
   - name: kube-state-metrics
     version: "7.2.*"

--- a/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/grafana/datasource.yaml
@@ -48,7 +48,7 @@ metadata:
   labels:
     {{ $.Values.grafana.sidecar.datasources.label }}: {{ $.Values.grafana.sidecar.datasources.labelValue | quote }}
     {{- $app := ((printf "%s-grafana" (include "vm.name" $ctx)) | trunc 63 | trimSuffix "-") }}
-    app: {{ $app }}
+    app.kubernetes.io/component: {{ $app }}
     {{- include "vm.labels" $ctx | nindent 4 }}
 data:
   datasource.yaml: |-

--- a/charts/victoria-metrics-mcp/CHANGELOG.md
+++ b/charts/victoria-metrics-mcp/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.2.0
 

--- a/charts/victoria-metrics-mcp/Chart.lock
+++ b/charts/victoria-metrics-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
-digest: sha256:861aeda558bfe15669538c60a64ccf1cd914040670195108c3038b9ffa37de68
-generated: "2026-03-18T10:23:22.563257+02:00"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:31:00.70607+03:00"

--- a/charts/victoria-metrics-mcp/Chart.yaml
+++ b/charts/victoria-metrics-mcp/Chart.yaml
@@ -26,5 +26,5 @@ annotations:
       url: https://victoriametrics.github.io/helm-charts/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.59.5
 

--- a/charts/victoria-metrics-operator/Chart.lock
+++ b/charts/victoria-metrics-operator/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
 - name: crds
   repository: ""
   version: 0.0.*
-digest: sha256:43d3d210a9d1a2234e6c56518f8c477125a5ad5e8ed08d46209528f19acd9c89
-generated: "2025-12-23T12:58:01.428960334Z"
+digest: sha256:48f192d4e9b917c3092a6b4e42e851d6ca00d9aad5448ce9fbe0246b16c5dd0a
+generated: "2026-04-12T20:30:23.311494+03:00"

--- a/charts/victoria-metrics-operator/Chart.yaml
+++ b/charts/victoria-metrics-operator/Chart.yaml
@@ -36,8 +36,8 @@ annotations:
       url: https://docs.victoriametrics.com/operator/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts
   - name: crds
     version: "0.0.*"
     condition: crds.plain

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -125,7 +125,7 @@ crds:
     #   whenUnsatisfiable: DoNotSchedule
     #   labelSelector:
     #     matchLabels:
-    #       app: alertmanager
+    #       app.kubernetes.io/component: alertmanager
 
     # -- Labels to add to the upgrade job
     labels: {}

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.35.0
 

--- a/charts/victoria-metrics-single/Chart.lock
+++ b/charts/victoria-metrics-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.0.46
-digest: sha256:861aeda558bfe15669538c60a64ccf1cd914040670195108c3038b9ffa37de68
-generated: "2025-12-23T12:58:03.466006127Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:14:51.895105+03:00"

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -33,5 +33,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-single/tests/__snapshot__/server_test.yaml.snap
+++ b/charts/victoria-metrics-single/tests/__snapshot__/server_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-single
@@ -16,7 +16,7 @@ deployment should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-single
       strategy:
@@ -24,7 +24,7 @@ deployment should match snapshot:
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-single
@@ -79,7 +79,7 @@ deployment with volume should match snapshot:
     kind: StatefulSet
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-single
@@ -92,14 +92,14 @@ deployment with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-single
       serviceName: RELEASE-NAME-victoria-metrics-single-server
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-single
@@ -163,7 +163,7 @@ statefulSet should match snapshot:
     kind: StatefulSet
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-single
@@ -176,14 +176,14 @@ statefulSet should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-single
       serviceName: RELEASE-NAME-victoria-metrics-single-server
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-single
@@ -247,7 +247,7 @@ statefulSet with volume should match snapshot:
     kind: StatefulSet
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: victoria-metrics-single
@@ -260,14 +260,14 @@ statefulSet with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-single
       serviceName: RELEASE-NAME-victoria-metrics-single-server
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-single

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next release
 
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 - fix: rename `route.labels` to `route.extraLabels` in values.yaml to match the route template
 - support volumeAttributesClassName PVC attribute. See [#2782](https://github.com/VictoriaMetrics/helm-charts/issues/2782).
 

--- a/charts/victoria-traces-cluster/Chart.lock
+++ b/charts/victoria-traces-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts/
-  version: 0.0.46
-digest: sha256:9da65a67bbea64eb5dfd4dff8dbbb4a92f95c8f5e24f0a6d91b704666fae6e01
-generated: "2025-12-23T12:58:05.468782503Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T20:02:29.190641+03:00"

--- a/charts/victoria-traces-cluster/Chart.yaml
+++ b/charts/victoria-traces-cluster/Chart.yaml
@@ -29,5 +29,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriatraces/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts/
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-traces-cluster/tests/__snapshot__/hpa_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/hpa_test.yaml.snap
@@ -4,7 +4,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -27,7 +27,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster

--- a/charts/victoria-traces-cluster/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/ingress_test.yaml.snap
@@ -6,7 +6,7 @@ ingress should match snapshot:
       annotations:
         kubernetes.io/ingress.class: nginx
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -33,7 +33,7 @@ ingress should match snapshot:
       annotations:
         kubernetes.io/ingress.class: alb
       labels:
-        app: vtinsert
+        app.kubernetes.io/component: vtinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -64,7 +64,7 @@ ingress should match snapshot:
       annotations:
         kubernetes.io/ingress.class: kong
       labels:
-        app: vtselect
+        app.kubernetes.io/component: vtselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster

--- a/charts/victoria-traces-cluster/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/service_test.yaml.snap
@@ -4,7 +4,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -19,7 +19,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -28,7 +28,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vtinsert
+        app.kubernetes.io/component: vtinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -43,7 +43,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vtinsert
+        app.kubernetes.io/component: vtinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -52,7 +52,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vtselect
+        app.kubernetes.io/component: vtselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -67,7 +67,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vtselect
+        app.kubernetes.io/component: vtselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -76,7 +76,7 @@ service should match snapshot:
     kind: Service
     metadata:
       labels:
-        app: vtstorage
+        app.kubernetes.io/component: vtstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -92,7 +92,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app: vtstorage
+        app.kubernetes.io/component: vtstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -102,7 +102,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -118,7 +118,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -127,7 +127,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: vtinsert
+        app.kubernetes.io/component: vtinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -142,7 +142,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: vtinsert
+        app.kubernetes.io/component: vtinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -151,7 +151,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: vtselect
+        app.kubernetes.io/component: vtselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -166,7 +166,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: vtselect
+        app.kubernetes.io/component: vtselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -175,7 +175,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
-        app: vtstorage
+        app.kubernetes.io/component: vtstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -191,7 +191,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app: vtstorage
+        app.kubernetes.io/component: vtstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP

--- a/charts/victoria-traces-cluster/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/vmauth_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vmauth
+        app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -16,13 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vmauth
+          app.kubernetes.io/component: vmauth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
-            app: vmauth
+            app.kubernetes.io/component: vmauth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-cluster
@@ -75,7 +75,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
-        app: auth
+        app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -88,13 +88,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app: auth
+          app.kubernetes.io/component: auth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
-            app: auth
+            app.kubernetes.io/component: auth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-cluster

--- a/charts/victoria-traces-cluster/tests/__snapshot__/vtinsert_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/vtinsert_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vtinsert
+        app.kubernetes.io/component: vtinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -16,13 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vtinsert
+          app.kubernetes.io/component: vtinsert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
-            app: vtinsert
+            app.kubernetes.io/component: vtinsert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-cluster
@@ -70,7 +70,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
-        app: insert
+        app.kubernetes.io/component: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -83,13 +83,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app: insert
+          app.kubernetes.io/component: insert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
-            app: insert
+            app.kubernetes.io/component: insert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-cluster

--- a/charts/victoria-traces-cluster/tests/__snapshot__/vtselect_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/vtselect_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: vtselect
+        app.kubernetes.io/component: vtselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -16,13 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vtselect
+          app.kubernetes.io/component: vtselect
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
-            app: vtselect
+            app.kubernetes.io/component: vtselect
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-cluster
@@ -70,7 +70,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
-        app: select
+        app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -83,13 +83,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app: select
+          app.kubernetes.io/component: select
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
-            app: select
+            app.kubernetes.io/component: select
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-cluster

--- a/charts/victoria-traces-cluster/tests/__snapshot__/vtstorage_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/vtstorage_test.yaml.snap
@@ -4,7 +4,7 @@ statefulset should match snapshot:
     kind: StatefulSet
     metadata:
       labels:
-        app: vtstorage
+        app.kubernetes.io/component: vtstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -18,14 +18,14 @@ statefulset should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app: vtstorage
+          app.kubernetes.io/component: vtstorage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       serviceName: RELEASE-NAME-vt-cluster-vtstorage
       template:
         metadata:
           labels:
-            app: vtstorage
+            app.kubernetes.io/component: vtstorage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-cluster
@@ -80,7 +80,7 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
     kind: StatefulSet
     metadata:
       labels:
-        app: storage
+        app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-cluster
@@ -95,14 +95,14 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
       replicas: 2
       selector:
         matchLabels:
-          app: storage
+          app.kubernetes.io/component: storage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       serviceName: vtstorage-node
       template:
         metadata:
           labels:
-            app: storage
+            app.kubernetes.io/component: storage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-cluster

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next release
 
+**Update node 1**: due to change in label name pods will be restarted.
+
+- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 - fix: rename `route.labels` to `route.extraLabels` in values.yaml to match the route template
 - support volumeAttributesClassName PVC attribute. See [#2782](https://github.com/VictoriaMetrics/helm-charts/issues/2782).
 

--- a/charts/victoria-traces-single/Chart.lock
+++ b/charts/victoria-traces-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
-  repository: https://victoriametrics.github.io/helm-charts/
-  version: 0.0.46
-digest: sha256:9da65a67bbea64eb5dfd4dff8dbbb4a92f95c8f5e24f0a6d91b704666fae6e01
-generated: "2025-12-23T12:58:07.404699795Z"
+  repository: oci://ghcr.io/victoriametrics/helm-charts
+  version: 0.1.0
+digest: sha256:c8f6be9368513cf4c6bf4b99bb3c04966c86d6b08f5730cd9c5beee8a3f07cf1
+generated: "2026-04-12T19:59:21.617735+03:00"

--- a/charts/victoria-traces-single/Chart.yaml
+++ b/charts/victoria-traces-single/Chart.yaml
@@ -30,5 +30,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriatraces/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.0.*"
-    repository: https://victoriametrics.github.io/helm-charts/
+    version: "0.1.*"
+    repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-traces-single/tests/__snapshot__/server_test.yaml.snap
+++ b/charts/victoria-traces-single/tests/__snapshot__/server_test.yaml.snap
@@ -4,7 +4,7 @@ deployment should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-single
@@ -16,7 +16,7 @@ deployment should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-single
       strategy:
@@ -24,7 +24,7 @@ deployment should match snapshot:
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-single
@@ -84,7 +84,7 @@ deployment with volume should match snapshot:
     kind: Deployment
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-single
@@ -96,7 +96,7 @@ deployment with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-single
       strategy:
@@ -104,7 +104,7 @@ deployment with volume should match snapshot:
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-single
@@ -164,7 +164,7 @@ statefulset should match snapshot:
     kind: StatefulSet
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-single
@@ -177,14 +177,14 @@ statefulset should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-single
       serviceName: RELEASE-NAME-vt-single-server
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-single
@@ -253,7 +253,7 @@ statefulset with volume should match snapshot:
     kind: StatefulSet
     metadata:
       labels:
-        app: server
+        app.kubernetes.io/component: server
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vt-single
@@ -266,14 +266,14 @@ statefulset with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app: server
+          app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-single
       serviceName: RELEASE-NAME-vt-single-server
       template:
         metadata:
           labels:
-            app: server
+            app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: vt-single


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/helm-charts/issues/2785

this change as it leads to pods restart

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the custom `app` label with `app.kubernetes.io/component` across all charts and selectors (including tests and the Grafana datasource) to follow Kubernetes conventions and avoid surprise rollouts. Also moved chart dependencies to OCI and bumped `victoria-metrics-common` to `0.1.*`.

- **Migration**
  - Expect a rolling restart on upgrade due to pod template label changes.
  - Update any custom selectors (Service/Ingress/HPA/NetworkPolicy/ServiceMonitor/PodMonitor/`VM*` CRs) to use `app.kubernetes.io/component`.
  - Helm 3.8+ is required for OCI dependencies.

- **Dependencies**
  - Switched chart repositories to `oci://ghcr.io/victoriametrics/helm-charts`.
  - Bumped `victoria-metrics-common` to `0.1.*`; `victoria-metrics-k8s-stack` to `0.72.6` (where used).

<sup>Written for commit f8fce351701d863ba752717acefc6a66519b26cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

