### PR TITLE
common: revert usage of app label in vm.selectorLabels

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- reverted usage of `app` label in `vm.selectorLabels`
 
 ## 0.2.0
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: VictoriaMetrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.2.0
+version: 0.3.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_helpers.tpl
+++ b/charts/victoria-metrics-common/templates/_helpers.tpl
@@ -187,6 +187,9 @@ If release name contains chart name it will be used as a full name.
   {{- include "vm.validate.args" . -}}
   {{- $Release := (.helm).Release | default .Release -}}
   {{- $labels := fromYaml (include "vm.selectorLabels" .) -}}
+  {{- with $labels.app -}}
+    {{- $_ := set $labels "app.kubernetes.io/component" . -}}
+  {{- end -}}
   {{- $labels = mergeOverwrite $labels (.extraLabels | default dict) -}}
   {{- $_ := set $labels "app.kubernetes.io/managed-by" $Release.Service -}}
   {{- toYaml $labels -}}
@@ -197,7 +200,7 @@ If release name contains chart name it will be used as a full name.
   {{- include "vm.validate.args" . -}}
   {{- $Values := (.helm).Values | default .Values -}}
   {{- $globalLabels := deepCopy (($Values.global).extraLabels | default dict) -}}
-  {{- $labels := fromYaml (include "vm.selectorLabels" .) -}}
+  {{- $labels := fromYaml (include "vm.commonLabels" .) -}}
   {{- $labels = mergeOverwrite $globalLabels $labels (fromYaml (include "vm.metaLabels" .)) -}}
   {{- with (include "vm.image.tag" .) }}
     {{- $_ := set $labels "app.kubernetes.io/version" (regexReplaceAll "(.*)(@sha.*)" . "${1}") -}}
@@ -231,7 +234,16 @@ If release name contains chart name it will be used as a full name.
   {{- $_ := set $labels "app.kubernetes.io/name" (include "vm.name" .) -}}
   {{- $_ := set $labels "app.kubernetes.io/instance" (include "vm.release" .) -}}
   {{- with (include "vm.app.name" .) -}}
-    {{- $_ := set $labels "app.kubernetes.io/component" . -}}
+    {{- $_ := set $labels "app" . -}}
   {{- end -}}
   {{- toYaml $labels -}}
 {{- end }}
+
+{{- define "vm.commonLabels" -}}
+  {{- $labels := fromYaml (include "vm.selectorLabels" . ) -}}
+  {{- with $labels.app -}}
+    {{- $_ := set $labels "app.kubernetes.io/component" . -}}
+    {{- $_ := unset $labels "app" -}}
+  {{- end -}}
+  {{- toYaml $labels -}}
+{{- end -}}


### PR DESCRIPTION
due to bad UX reverting changes in vm.selectorLabels, but keeping `app.kubernetes.io/component` label in `vm.podLabels`  and no `app` label in `vm.labels`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts `vm.selectorLabels` to use the `app` label again to fix UX issues with selectors. Keeps `app.kubernetes.io/component` on Pods and drops `app` from general labels; bumps `victoria-metrics-common` to `0.3.0`.

- **Refactors**
  - `vm.selectorLabels` now sets `app`.
  - `vm.podLabels` adds `app.kubernetes.io/component` when `app` is present.
  - Introduces `vm.commonLabels` to map `app` to `app.kubernetes.io/component` and unset `app` in `vm.labels`.

<sup>Written for commit 8bd1a17e15fc5a5baf85f1b05eb87a06d3c32382. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

