### PR TITLE
updated common dependency in all charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ lint: helm-repo-update
 	)
 
 update: helm-repo-update
-	$(foreach values,$(wildcard charts/*/lint/*.yaml), \
+	$(foreach values,$(wildcard charts/*/Chart.yaml), \
 		$(eval chart := $(word 2, $(subst /, ,$(values)))) \
 		CMD="dep update charts/$(chart)" $(MAKE) $(HELM) || exit 1; \
         )

--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- revert change in Deployment's matchLabels, that was introduced in release 0.0.16
 
 ## 0.0.16
 
@@ -8,7 +8,7 @@
 
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v1.50.0](https://img.shields.io/badge/v1.50.0-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fchangelog%2F%23v1500)
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old StatefulSet with `--cascade=orphan`.
+**Known issue:** this release contains changes in StatefulSet matchLabels, which requires StatefulSet recreation. Skip this release to avoid disruption.
 
 - replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 - bump vlagent version to [v1.50.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.50.0).

--- a/charts/victoria-logs-agent/Chart.lock
+++ b/charts/victoria-logs-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T14:16:39.549523+03:00"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:13:05.105514128Z"

--- a/charts/victoria-logs-agent/Chart.yaml
+++ b/charts/victoria-logs-agent/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 name: victoria-logs-agent
 description: VictoriaLogs Agent - accepts logs from various protocols and replicates them across multiple VictoriaLogs instances.
-version: 0.0.16
+version: 0.1.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
@@ -29,5 +29,5 @@ annotations:
       url: https://docs.victoriametrics.com/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- revert change in Deployment and StatefulSet matchLabels, that was introduced in release 0.0.33
 
 ## 0.0.33
 
@@ -8,7 +8,7 @@
 
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v1.50.0](https://img.shields.io/badge/v1.50.0-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fvictorialogs%2Fchangelog%2F%23v1500)
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old StatefulSets and Deployments with `--cascade=orphan`.
+**Known issue:** this release contains changes in Deployment and StatefulSet matchLabels, which requires Deployment and StatefulSet recreation. Skip this release to avoid disruption.
 
 - replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 - bump VictoriaLogs version to [v1.50.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.50.0).

--- a/charts/victoria-logs-cluster/Chart.lock
+++ b/charts/victoria-logs-cluster/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.51.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:1b581dba18f596ad97ab66a549789a47f20600628678dad20b0abb29bf0868d7
-generated: "2026-04-14T11:14:08.867636416Z"
+  version: 0.3.0
+digest: sha256:597ed42d027f86a4357fa8958bc87ca679e0373765f9c133fc7257052e94d728
+generated: "2026-04-16T10:13:08.554654755Z"

--- a/charts/victoria-logs-cluster/Chart.yaml
+++ b/charts/victoria-logs-cluster/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs cluster Helm chart deploys VictoriaLogs cluster database in Kubernetes.
 name: victoria-logs-cluster
-version: 0.0.33
+version: 0.1.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
@@ -34,5 +34,5 @@ dependencies:
     repository: https://helm.vector.dev
     condition: vector.enabled
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-cluster/tests/__snapshot__/hpa_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/hpa_test.yaml.snap
@@ -4,6 +4,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: vmauth
         app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -27,6 +28,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-logs-cluster/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/service_test.yaml.snap
@@ -19,7 +19,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vlinsert
+        app: vlinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -43,7 +43,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vlselect
+        app: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -68,7 +68,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vlstorage
+        app: vlstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -92,7 +92,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vmauth
+        app: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -117,7 +117,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vlinsert
+        app: vlinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -141,7 +141,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vlselect
+        app: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -166,7 +166,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vlstorage
+        app: vlstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP
@@ -175,6 +175,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -191,7 +192,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: auth
+        app: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-cluster
       type: ClusterIP

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vlinsert_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vlinsert_test.yaml.snap
@@ -16,12 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vlinsert
+          app: vlinsert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
         metadata:
           labels:
+            app: vlinsert
             app.kubernetes.io/component: vlinsert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -71,6 +72,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
+        app: insert
         app.kubernetes.io/component: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -84,12 +86,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: insert
+          app: insert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
         metadata:
           labels:
+            app: insert
             app.kubernetes.io/component: insert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vlselect_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vlselect_test.yaml.snap
@@ -16,12 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vlselect
+          app: vlselect
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
         metadata:
           labels:
+            app: vlselect
             app.kubernetes.io/component: vlselect
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -71,6 +72,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
+        app: select
         app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -84,12 +86,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: select
+          app: select
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
         metadata:
           labels:
+            app: select
             app.kubernetes.io/component: select
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vlstorage_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vlstorage_test.yaml.snap
@@ -18,13 +18,14 @@ statefulset should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vlstorage
+          app: vlstorage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       serviceName: RELEASE-NAME-victoria-logs-cluster-vlstorage
       template:
         metadata:
           labels:
+            app: vlstorage
             app.kubernetes.io/component: vlstorage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -80,6 +81,7 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
     kind: StatefulSet
     metadata:
       labels:
+        app: storage
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -95,13 +97,14 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: storage
+          app: storage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       serviceName: vlstorage-node
       template:
         metadata:
           labels:
+            app: storage
             app.kubernetes.io/component: storage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-logs-cluster/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-logs-cluster/tests/__snapshot__/vmauth_test.yaml.snap
@@ -33,7 +33,7 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vmauth
+          app: vmauth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
@@ -41,6 +41,7 @@ deployment should match snapshot:
           annotations:
             checksum/config: 0965fdbaa20de3aaef7cf3475ffc3334e383be2a8307e4b5ad8f1a653f479eb2
           labels:
+            app: vmauth
             app.kubernetes.io/component: vmauth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -111,6 +112,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -124,7 +126,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: auth
+          app: auth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-cluster
       template:
@@ -132,6 +134,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
           annotations:
             checksum/config: 15c02bc9ec3b4d856d0e64b544136a5ee34099b581e15b2b83cb334e7567ff1f
           labels:
+            app: auth
             app.kubernetes.io/component: auth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-logs-collector/CHANGELOG.md
+++ b/charts/victoria-logs-collector/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- revert change in DaemonSet matchLabels, that was introduced in release 0.2.16
 
 ## 0.2.16
 
@@ -8,7 +8,7 @@
 
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v1.50.0](https://img.shields.io/badge/v1.50.0-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fchangelog%2F%23v1500)
 
-**Update node 1**: due to change in label name pods will be restarted.
+**Known issue:** this release contains changes in DaemonSet matchLabels, which requires DaemonSet recreation. Skip this release to avoid disruption.
 
 - replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 - bump vlagent version to [v1.50.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.50.0).

--- a/charts/victoria-logs-collector/Chart.lock
+++ b/charts/victoria-logs-collector/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T14:16:27.706393+03:00"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:13:11.850169506Z"

--- a/charts/victoria-logs-collector/Chart.yaml
+++ b/charts/victoria-logs-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-logs-collector
 description: VictoriaLogs Collector - collects logs from Kubernetes containers and stores them to VictoriaLogs
-version: 0.2.16
+version: 0.3.0
 # renovate: image=victoriametrics/vlagent
 appVersion: v1.50.0
 sources:
@@ -29,5 +29,5 @@ annotations:
       url: https://docs.victoriametrics.com/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-mcp/CHANGELOG.md
+++ b/charts/victoria-logs-mcp/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old Deployments with `--cascade=orphan`.
+**Update node 1**: due to change in label name pods will be restarted.
 
-- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.1.0
 

--- a/charts/victoria-logs-mcp/Chart.lock
+++ b/charts/victoria-logs-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T14:16:51.148874+03:00"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:13:15.135343925Z"

--- a/charts/victoria-logs-mcp/Chart.yaml
+++ b/charts/victoria-logs-mcp/Chart.yaml
@@ -25,5 +25,5 @@ annotations:
       url: https://victoriametrics.github.io/helm-charts/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- revert change in Deployment matchLabels, that was introduced in release 0.0.14
 
 ## 0.0.14
 
@@ -8,7 +8,7 @@
 
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v1.50.0](https://img.shields.io/badge/v1.50.0-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fvictorialogs%2Fchangelog%2F%23v1500)
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old StatefulSets with `--cascade=orphan`.
+**Known issue:** this release contains changes in Deployment matchLabels, which requires Deployment recreation. Skip this release to avoid disruption.
 
 - replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 - bump VictoriaLogs version to [v1.50.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.50.0).

--- a/charts/victoria-logs-multilevel/Chart.lock
+++ b/charts/victoria-logs-multilevel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T11:14:12.885324252Z"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:13:18.912481552Z"

--- a/charts/victoria-logs-multilevel/Chart.yaml
+++ b/charts/victoria-logs-multilevel/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs multilevel Helm chart deploys global read for multiple storage groups.
 name: victoria-logs-multilevel
-version: 0.0.14
+version: 0.1.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
@@ -30,5 +30,5 @@ annotations:
       url: https://docs.victoriametrics.com/victorialogs/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-multilevel/tests/__snapshot__/hpa_test.yaml.snap
+++ b/charts/victoria-logs-multilevel/tests/__snapshot__/hpa_test.yaml.snap
@@ -4,6 +4,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: vmauth
         app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -27,6 +28,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-logs-multilevel/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/victoria-logs-multilevel/tests/__snapshot__/service_test.yaml.snap
@@ -19,7 +19,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vlselect
+        app: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-multilevel
       type: ClusterIP
@@ -43,7 +43,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vmauth
+        app: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-multilevel
       type: ClusterIP
@@ -68,7 +68,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vlselect
+        app: vlselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-multilevel
       type: ClusterIP
@@ -77,6 +77,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -93,7 +94,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: auth
+        app: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-logs-multilevel
       type: ClusterIP

--- a/charts/victoria-logs-multilevel/tests/__snapshot__/vlselect_test.yaml.snap
+++ b/charts/victoria-logs-multilevel/tests/__snapshot__/vlselect_test.yaml.snap
@@ -16,12 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vlselect
+          app: vlselect
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-multilevel
       template:
         metadata:
           labels:
+            app: vlselect
             app.kubernetes.io/component: vlselect
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -69,6 +70,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
+        app: select
         app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -82,12 +84,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: select
+          app: select
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-multilevel
       template:
         metadata:
           labels:
+            app: select
             app.kubernetes.io/component: select
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-logs-multilevel/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-logs-multilevel/tests/__snapshot__/vmauth_test.yaml.snap
@@ -33,7 +33,7 @@ deployment should match empty snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vmauth
+          app: vmauth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-multilevel
       template:
@@ -41,6 +41,7 @@ deployment should match empty snapshot:
           annotations:
             checksum/config: 2fb16488ef03445c6b3ca1a47e1871ad81c19453b3ff0a1cf42ef02d0bd97d7a
           labels:
+            app: vmauth
             app.kubernetes.io/component: vmauth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -123,7 +124,7 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vmauth
+          app: vmauth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-multilevel
       template:
@@ -131,6 +132,7 @@ deployment should match snapshot:
           annotations:
             checksum/config: 2fb16488ef03445c6b3ca1a47e1871ad81c19453b3ff0a1cf42ef02d0bd97d7a
           labels:
+            app: vmauth
             app.kubernetes.io/component: vmauth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -201,6 +203,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -214,7 +217,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: auth
+          app: auth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-multilevel
       template:
@@ -222,6 +225,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
           annotations:
             checksum/config: 4d9b35efb1512df5ff19438e8307ca81a0ca465f9ffe4bc212f64cbed12d1025
           labels:
+            app: auth
             app.kubernetes.io/component: auth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- revert change in Deployment and StatefulSet matchLabels, that was introduced in release 0.11.32.
 
 ## 0.11.32
 
@@ -8,7 +8,7 @@
 
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v1.50.0](https://img.shields.io/badge/v1.50.0-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fvictorialogs%2Fchangelog%2F%23v1500)
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old StatefulSet or Deployment with `--cascade=orphan`.
+**Known issue:** this release contains changes in StatefulSet and Deployment matchLabels, which requires Deployment and StatefulSet recreation. Skip this release to avoid disruption.
 
 - replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 - bump VictoriaLogs version to [v1.50.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.50.0).

--- a/charts/victoria-logs-single/Chart.lock
+++ b/charts/victoria-logs-single/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.51.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:1b581dba18f596ad97ab66a549789a47f20600628678dad20b0abb29bf0868d7
-generated: "2026-04-14T11:14:16.288234836Z"
+  version: 0.3.0
+digest: sha256:597ed42d027f86a4357fa8958bc87ca679e0373765f9c133fc7257052e94d728
+generated: "2026-04-16T10:13:21.73851347Z"

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs single Helm chart deploys VictoriaLogs database in Kubernetes.
 name: victoria-logs-single
-version: 0.11.32
+version: 0.12.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
@@ -35,5 +35,5 @@ dependencies:
     repository: https://helm.vector.dev
     condition: vector.enabled
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-single/tests/__snapshot__/server_test.yaml.snap
+++ b/charts/victoria-logs-single/tests/__snapshot__/server_test.yaml.snap
@@ -16,7 +16,7 @@ deployment should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
       strategy:
@@ -24,6 +24,7 @@ deployment should match snapshot:
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -96,7 +97,7 @@ deployment with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
       strategy:
@@ -104,6 +105,7 @@ deployment with volume should match snapshot:
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -177,13 +179,14 @@ statefulset should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
       serviceName: RELEASE-NAME-victoria-logs-single-server
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -266,13 +269,14 @@ statefulset with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-logs-single
       serviceName: RELEASE-NAME-victoria-logs-single-server
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old StatefulSet or Deployment with `--cascade=orphan`.
+**Update node 1**: due to change in label name pods will be restarted.
 
-- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.36.0
 

--- a/charts/victoria-metrics-agent/Chart.lock
+++ b/charts/victoria-metrics-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T11:14:19.540094505Z"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:13:25.270885263Z"

--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -35,5 +35,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old StatefulSets and Deployments with `--cascade=orphan`.
+**Update node 1**: due to change in label name pods will be restarted.
 
-- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.37.0
 

--- a/charts/victoria-metrics-alert/Chart.lock
+++ b/charts/victoria-metrics-alert/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T11:14:26.201888633Z"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:13:29.482231209Z"

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -35,5 +35,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old StatefulSet or Deployment with `--cascade=orphan`.
+**Update node 1**: due to change in label name pods will be restarted.
 
-- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 1.12.11
 

--- a/charts/victoria-metrics-anomaly/Chart.lock
+++ b/charts/victoria-metrics-anomaly/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T11:14:31.512303302Z"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:13:33.311740586Z"

--- a/charts/victoria-metrics-anomaly/Chart.yaml
+++ b/charts/victoria-metrics-anomaly/Chart.yaml
@@ -34,5 +34,5 @@ annotations:
       url: https://docs.victoriametrics.com/anomaly-detection/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old Deployments with `--cascade=orphan`.
+**Update node 1**: due to change in label name pods will be restarted.
 
-- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.29.0
 

--- a/charts/victoria-metrics-auth/Chart.lock
+++ b/charts/victoria-metrics-auth/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T11:14:34.062215012Z"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:13:36.166870712Z"

--- a/charts/victoria-metrics-auth/Chart.yaml
+++ b/charts/victoria-metrics-auth/Chart.yaml
@@ -36,5 +36,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old StatefulSets and Deployments with `--cascade=orphan`.
+**Update node 1**: due to change in label name pods will be restarted.
 
-- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.39.0
 

--- a/charts/victoria-metrics-cluster/Chart.lock
+++ b/charts/victoria-metrics-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T11:14:36.75411543Z"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:13:39.389936005Z"

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -37,5 +37,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/hpa_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/hpa_test.yaml.snap
@@ -4,6 +4,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: vmauth
         app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -26,6 +27,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: vminsert
         app.kubernetes.io/component: vminsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -48,6 +50,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: vmselect
         app.kubernetes.io/component: vmselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -70,6 +73,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: vmstorage
         app.kubernetes.io/component: vmstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -96,6 +100,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -118,6 +123,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: insert
         app.kubernetes.io/component: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -140,6 +146,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: select
         app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -162,6 +169,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: storage
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/service_test.yaml.snap
@@ -19,7 +19,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vmauth
+        app: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -43,7 +43,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vminsert
+        app: vminsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -67,7 +67,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vmselect
+        app: vmselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -100,7 +100,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: vminsert
       selector:
-        app.kubernetes.io/component: vmstorage
+        app: vmstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -110,6 +110,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -126,7 +127,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: auth
+        app: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -135,6 +136,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
+        app: insert
         app.kubernetes.io/component: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -151,7 +153,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: insert
+        app: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -160,6 +162,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
+        app: select
         app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -176,7 +179,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: select
+        app: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP
@@ -185,6 +188,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
+        app: storage
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -210,7 +214,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: vminsert
       selector:
-        app.kubernetes.io/component: storage
+        app: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: victoria-metrics-cluster
       type: ClusterIP

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmauth_test.yaml.snap
@@ -16,12 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vmauth
+          app: vmauth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       template:
         metadata:
           labels:
+            app: vmauth
             app.kubernetes.io/component: vmauth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -71,6 +72,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -84,12 +86,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: auth
+          app: auth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       template:
         metadata:
           labels:
+            app: auth
             app.kubernetes.io/component: auth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vminsert_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vminsert_test.yaml.snap
@@ -16,12 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vminsert
+          app: vminsert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       template:
         metadata:
           labels:
+            app: vminsert
             app.kubernetes.io/component: vminsert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -66,6 +67,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
+        app: insert
         app.kubernetes.io/component: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -79,12 +81,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: insert
+          app: insert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       template:
         metadata:
           labels:
+            app: insert
             app.kubernetes.io/component: insert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmselect_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmselect_test.yaml.snap
@@ -16,13 +16,14 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vmselect
+          app: vmselect
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       strategy: {}
       template:
         metadata:
           labels:
+            app: vmselect
             app.kubernetes.io/component: vmselect
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -76,6 +77,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
+        app: select
         app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -89,13 +91,14 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: select
+          app: select
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       strategy: {}
       template:
         metadata:
           labels:
+            app: select
             app.kubernetes.io/component: select
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -163,13 +166,14 @@ statefulset should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vmselect
+          app: vmselect
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       serviceName: RELEASE-NAME-victoria-metrics-cluster-vmselect
       template:
         metadata:
           labels:
+            app: vmselect
             app.kubernetes.io/component: vmselect
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -225,6 +229,7 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
     kind: StatefulSet
     metadata:
       labels:
+        app: select
         app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -239,13 +244,14 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: select
+          app: select
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       serviceName: vmselect-node
       template:
         metadata:
           labels:
+            app: select
             app.kubernetes.io/component: select
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
+++ b/charts/victoria-metrics-cluster/tests/__snapshot__/vmstorage_test.yaml.snap
@@ -18,13 +18,14 @@ statefulset should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vmstorage
+          app: vmstorage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       serviceName: RELEASE-NAME-victoria-metrics-cluster-vmstorage
       template:
         metadata:
           labels:
+            app: vmstorage
             app.kubernetes.io/component: vmstorage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -80,6 +81,7 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
     kind: StatefulSet
     metadata:
       labels:
+        app: storage
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -95,13 +97,14 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: storage
+          app: storage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-cluster
       serviceName: vmstorage-node
       template:
         metadata:
           labels:
+            app: storage
             app.kubernetes.io/component: storage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-metrics-distributed/Chart.lock
+++ b/charts/victoria-metrics-distributed/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
+  version: 0.3.0
 - name: victoria-metrics-k8s-stack
   repository: oci://ghcr.io/victoriametrics/helm-charts
   version: 0.72.6
-digest: sha256:5aa156cbb9054024b5ee0ec6027f7c5bb420731b1e2912c7ce77ab22286f14d5
-generated: "2026-04-14T14:30:47.670584+03:00"
+digest: sha256:6976d0c66b51d4a440276c4037e14bc005813034e9e7fd956385ae7ec6424529
+generated: "2026-04-16T10:13:47.283340759Z"

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -34,7 +34,7 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts
   - name: victoria-metrics-k8s-stack
     version: "0.72.*"

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old Deployment with `--cascade=orphan`.
+**Update node 1**: due to change in label name pods will be restarted.
 
-- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.27.0
 

--- a/charts/victoria-metrics-gateway/Chart.lock
+++ b/charts/victoria-metrics-gateway/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T11:14:42.877600835Z"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:13:51.823846928Z"

--- a/charts/victoria-metrics-gateway/Chart.yaml
+++ b/charts/victoria-metrics-gateway/Chart.yaml
@@ -37,5 +37,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
+  version: 0.3.0
 - name: victoria-metrics-operator
   repository: oci://ghcr.io/victoriametrics/helm-charts
   version: 0.60.0
@@ -13,6 +13,6 @@ dependencies:
   version: 4.53.1
 - name: grafana
   repository: https://grafana-community.github.io/helm-charts
-  version: 11.6.0
-digest: sha256:b5db8b3afcf0d681ab2aa0be029cd652055c097d74f0916c28051fe0c174cb16
-generated: "2026-04-14T14:23:43.123587+03:00"
+  version: 11.6.1
+digest: sha256:73cb3395891853a7681a1f4d42b6d4bee6c98143006163dd538ae57c675679f2
+generated: "2026-04-16T10:13:57.699541833Z"

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -35,7 +35,7 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts
   - name: victoria-metrics-operator
     version: "0.60.*"

--- a/charts/victoria-metrics-mcp/CHANGELOG.md
+++ b/charts/victoria-metrics-mcp/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old Deployment with `--cascade=orphan`.
+**Update node 1**: due to change in label name pods will be restarted.
 
-- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.2.0
 

--- a/charts/victoria-metrics-mcp/Chart.lock
+++ b/charts/victoria-metrics-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T14:17:48.854368+03:00"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:14:06.303208837Z"

--- a/charts/victoria-metrics-mcp/Chart.yaml
+++ b/charts/victoria-metrics-mcp/Chart.yaml
@@ -26,5 +26,5 @@ annotations:
       url: https://victoriametrics.github.io/helm-charts/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- revert change in Deployment's matchLabels, that was introduced in release 0.60.0
 
 ## 0.60.0
 
@@ -8,7 +8,7 @@
 
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v0.68.4](https://img.shields.io/badge/v0.68.4-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Foperator%2Fchangelog%2F%23v0684)
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old Deployment with `--cascade=orphan`.
+**Known issue:** this release contains changes in Deployment matchLabels, which requires Deployment recreation. Skip this release to avoid disruption.
 
 - replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 - revert default helm hooks for validatingwebhookconfiguration due to ArgoCD issues

--- a/charts/victoria-metrics-operator/Chart.lock
+++ b/charts/victoria-metrics-operator/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
+  version: 0.3.0
 - name: crds
   repository: ""
   version: 0.0.*
-digest: sha256:da25b65f53fe412b9920ef940639baffb629239efc61024b0f1ab921edd5a1e6
-generated: "2026-04-14T11:14:54.061585757Z"
+digest: sha256:adec954bf2814f744f5b69fcf67c8b246bf21f416adb0ab37d91c9b42f72d353
+generated: "2026-04-16T10:14:10.795552631Z"

--- a/charts/victoria-metrics-operator/Chart.yaml
+++ b/charts/victoria-metrics-operator/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/VictoriaMetrics/operator
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
   - https://github.com/VictoriaMetrics/operator
-version: 0.60.0
+version: 0.61.0
 # renovate: image=victoriametrics/operator
 appVersion: v0.68.4
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4
@@ -36,7 +36,7 @@ annotations:
       url: https://docs.victoriametrics.com/operator/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts
   - name: crds
     version: "0.0.*"

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old StatefulSet or Deployment with `--cascade=orphan`.
+**Update node 1**: due to change in label name pods will be restarted.
 
-- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 
 ## 0.35.0
 

--- a/charts/victoria-metrics-single/Chart.lock
+++ b/charts/victoria-metrics-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T11:14:57.662290384Z"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:14:17.281581384Z"

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -33,5 +33,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-single/templates/server.yaml
+++ b/charts/victoria-metrics-single/templates/server.yaml
@@ -31,7 +31,7 @@ spec:
   template:
     metadata:
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
-      labels: {{ include "vm.labels" $ctx | nindent 8 }}
+      labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
       {{- with $app.podAnnotations }}
       annotations: {{ toYaml . | nindent 8 }}

--- a/charts/victoria-metrics-single/tests/__snapshot__/server_test.yaml.snap
+++ b/charts/victoria-metrics-single/tests/__snapshot__/server_test.yaml.snap
@@ -16,7 +16,7 @@ deployment should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-single
       strategy:
@@ -24,12 +24,11 @@ deployment should match snapshot:
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-single
-            app.kubernetes.io/version: 0.1.0
-            helm.sh/chart: victoria-metrics-single-0.1.1
         spec:
           automountServiceAccountToken: true
           containers:
@@ -92,19 +91,18 @@ deployment with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-single
       serviceName: RELEASE-NAME-victoria-metrics-single-server
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-single
-            app.kubernetes.io/version: 0.1.0
-            helm.sh/chart: victoria-metrics-single-0.1.1
         spec:
           automountServiceAccountToken: true
           containers:
@@ -176,19 +174,18 @@ statefulSet should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-single
       serviceName: RELEASE-NAME-victoria-metrics-single-server
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-single
-            app.kubernetes.io/version: 0.1.0
-            helm.sh/chart: victoria-metrics-single-0.1.1
         spec:
           automountServiceAccountToken: true
           containers:
@@ -260,19 +257,18 @@ statefulSet with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: victoria-metrics-single
       serviceName: RELEASE-NAME-victoria-metrics-single-server
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: victoria-metrics-single
-            app.kubernetes.io/version: 0.1.0
-            helm.sh/chart: victoria-metrics-single-0.1.1
         spec:
           automountServiceAccountToken: true
           containers:

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old StatefulSet with `--cascade=orphan`.
+**Update node 1**: due to change in label name pods will be restarted.
 
-- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 - fix: rename `route.labels` to `route.extraLabels` in values.yaml to match the route template
 - support volumeAttributesClassName PVC attribute. See [#2782](https://github.com/VictoriaMetrics/helm-charts/issues/2782).
 

--- a/charts/victoria-traces-cluster/Chart.lock
+++ b/charts/victoria-traces-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T11:15:00.738327177Z"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:14:22.242227845Z"

--- a/charts/victoria-traces-cluster/Chart.yaml
+++ b/charts/victoria-traces-cluster/Chart.yaml
@@ -29,5 +29,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriatraces/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-traces-cluster/tests/__snapshot__/hpa_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/hpa_test.yaml.snap
@@ -4,6 +4,7 @@ hpa should match snapshot:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: vmauth
         app.kubernetes.io/component: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -27,6 +28,7 @@ hpa should match snapshot with fullnameOverride and extraLabels:
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-traces-cluster/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/service_test.yaml.snap
@@ -19,7 +19,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vmauth
+        app: vmauth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -43,7 +43,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vtinsert
+        app: vtinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -67,7 +67,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vtselect
+        app: vtselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -92,7 +92,7 @@ service should match snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vtstorage
+        app: vtstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -102,6 +102,7 @@ service should match snapshot with fullnameOverride and extraLabels:
     kind: Service
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -118,7 +119,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: auth
+        app: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -142,7 +143,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vtinsert
+        app: vtinsert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -166,7 +167,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vtselect
+        app: vtselect
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP
@@ -191,7 +192,7 @@ service should match snapshot with fullnameOverride and extraLabels:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: vtstorage
+        app: vtstorage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: vt-cluster
       type: ClusterIP

--- a/charts/victoria-traces-cluster/tests/__snapshot__/vmauth_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/vmauth_test.yaml.snap
@@ -16,12 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vmauth
+          app: vmauth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
+            app: vmauth
             app.kubernetes.io/component: vmauth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -75,6 +76,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
+        app: auth
         app.kubernetes.io/component: auth
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -88,12 +90,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: auth
+          app: auth
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
+            app: auth
             app.kubernetes.io/component: auth
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-traces-cluster/tests/__snapshot__/vtinsert_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/vtinsert_test.yaml.snap
@@ -16,12 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vtinsert
+          app: vtinsert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
+            app: vtinsert
             app.kubernetes.io/component: vtinsert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -70,6 +71,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
+        app: insert
         app.kubernetes.io/component: insert
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -83,12 +85,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: insert
+          app: insert
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
+            app: insert
             app.kubernetes.io/component: insert
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-traces-cluster/tests/__snapshot__/vtselect_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/vtselect_test.yaml.snap
@@ -16,12 +16,13 @@ deployment should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vtselect
+          app: vtselect
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
+            app: vtselect
             app.kubernetes.io/component: vtselect
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -70,6 +71,7 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
     kind: Deployment
     metadata:
       labels:
+        app: select
         app.kubernetes.io/component: select
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -83,12 +85,13 @@ deployment should match snapshot with fullnameOverride, extraLabels and podLabel
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: select
+          app: select
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       template:
         metadata:
           labels:
+            app: select
             app.kubernetes.io/component: select
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-traces-cluster/tests/__snapshot__/vtstorage_test.yaml.snap
+++ b/charts/victoria-traces-cluster/tests/__snapshot__/vtstorage_test.yaml.snap
@@ -18,13 +18,14 @@ statefulset should match snapshot:
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: vtstorage
+          app: vtstorage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       serviceName: RELEASE-NAME-vt-cluster-vtstorage
       template:
         metadata:
           labels:
+            app: vtstorage
             app.kubernetes.io/component: vtstorage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -80,6 +81,7 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
     kind: StatefulSet
     metadata:
       labels:
+        app: storage
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -95,13 +97,14 @@ statefulset should match snapshot with fullnameOverride, extraLabels and podLabe
       replicas: 2
       selector:
         matchLabels:
-          app.kubernetes.io/component: storage
+          app: storage
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-cluster
       serviceName: vtstorage-node
       template:
         metadata:
           labels:
+            app: storage
             app.kubernetes.io/component: storage
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-**Update node 1**: due to change in label name pods will be restarted. Please delete old StatefulSet with `--cascade=orphan`.
+**Update node 1**: due to change in label name pods will be restarted.
 
-- replace custom app label with app.kubernetes.io/component. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 - fix: rename `route.labels` to `route.extraLabels` in values.yaml to match the route template
 - support volumeAttributesClassName PVC attribute. See [#2782](https://github.com/VictoriaMetrics/helm-charts/issues/2782).
 

--- a/charts/victoria-traces-single/Chart.lock
+++ b/charts/victoria-traces-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.2.0
-digest: sha256:c654bbfbe95313b97ba5800401feaee9cf6efc2f5246ae472c52a9692505ad29
-generated: "2026-04-14T11:15:03.92407097Z"
+  version: 0.3.0
+digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
+generated: "2026-04-16T10:14:26.247647222Z"

--- a/charts/victoria-traces-single/Chart.yaml
+++ b/charts/victoria-traces-single/Chart.yaml
@@ -30,5 +30,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriatraces/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.2.*"
+    version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-traces-single/tests/__snapshot__/server_test.yaml.snap
+++ b/charts/victoria-traces-single/tests/__snapshot__/server_test.yaml.snap
@@ -16,7 +16,7 @@ deployment should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-single
       strategy:
@@ -24,6 +24,7 @@ deployment should match snapshot:
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -96,7 +97,7 @@ deployment with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-single
       strategy:
@@ -104,6 +105,7 @@ deployment with volume should match snapshot:
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -177,13 +179,14 @@ statefulset should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-single
       serviceName: RELEASE-NAME-vt-single-server
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -266,13 +269,14 @@ statefulset with volume should match snapshot:
       replicas: 1
       selector:
         matchLabels:
-          app.kubernetes.io/component: server
+          app: server
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: vt-single
       serviceName: RELEASE-NAME-vt-single-server
       template:
         metadata:
           labels:
+            app: server
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrades `victoria-metrics-common` to 0.3.* across all Helm charts and restores `app`-based selectors to avoid disruptive upgrades. Updates chart versions and locks, fixes changelog guidance, and ensures the tooling updates every chart.

- **Dependencies**
  - Upgrade `victoria-metrics-common` to `0.3.*` in all charts; refresh Chart.lock digests and bump chart versions (e.g., `victoria-logs-*` to 0.1.0/0.3.0, `victoria-logs-single` to 0.12.0, `victoria-metrics-operator` to 0.61.0).
  - Bump `grafana` subchart to `11.6.1` in `victoria-metrics-k8s-stack`.

- **Bug Fixes**
  - Restore `app` in matchLabels/selectors for Deployments/StatefulSets/Services/HPAs; keep `app.kubernetes.io/component` as a non-selector label across charts.
  - Update tests and changelogs to reflect restored labels and note the prior release’s disruption; align `victoria-metrics-single` pod labels with `vm.podLabels`.
  - Makefile: iterate over `charts/*/Chart.yaml` in the `update` target so dependency updates cover all charts.

<sup>Written for commit 12e0dd3170a3ffc025b572c9c5724dfbd4877747. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

