### PR TITLE
k8s-stack: bump operator chart version to 0.61.0

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,12 +1,14 @@
 ## Next release
 
-- TODO
+- bump victoria-metrics-operator dependency chart to version 0.61.0
 
 ## 0.74.1
 
 **Release date:** 16 Apr 2026
 
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v1.140.0](https://img.shields.io/badge/v1.140.0-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fvictoriametrics%2Fchangelog%2F%23v11400)
+
+**Known issue:** this release contains changes in operator Deployment matchLabels, which requires Deployment recreation. Skip this release to avoid disruption.
 
 - revert prometheus-node-exporter service `jobLabel: node-exporter`
 
@@ -16,6 +18,7 @@
 
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v1.140.0](https://img.shields.io/badge/v1.140.0-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fvictoriametrics%2Fchangelog%2F%23v11400)
 
+**Known issue:** this release contains changes in operator Deployment matchLabels, which requires Deployment recreation. Skip this release to avoid disruption.
 **Update note 1**: In this release custom `app` labels were replaced by well-known `app.kubernetes.io/component`. Additionally chart name prefix was removed.
 
 - add ability to set custom labels for scrape configs. See [#2810](https://github.com/VictoriaMetrics/helm-charts/issues/2810).

--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.3.0
 - name: victoria-metrics-operator
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.60.0
+  version: 0.61.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 7.2.2
@@ -14,5 +14,5 @@ dependencies:
 - name: grafana
   repository: https://grafana-community.github.io/helm-charts
   version: 11.6.1
-digest: sha256:73cb3395891853a7681a1f4d42b6d4bee6c98143006163dd538ae57c675679f2
-generated: "2026-04-16T10:13:57.699541833Z"
+digest: sha256:36e0529773ab1b5ab8c4b298c972c0c0c979cbb49acb0133cb307a6d0a269b3e
+generated: "2026-04-16T16:01:19.6828+03:00"

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.74.1
+version: 0.75.0
 # renovate: image=victoriametrics/victoria-metrics
 appVersion: v1.140.0
 sources:
@@ -38,7 +38,7 @@ dependencies:
     version: "0.3.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts
   - name: victoria-metrics-operator
-    version: "0.60.*"
+    version: "0.61.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts
     condition: victoria-metrics-operator.enabled
   - name: kube-state-metrics


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrades the `victoria-metrics-operator` dependency to 0.61.0 and releases `victoria-metrics-k8s-stack` v0.75.0.

- **Migration**
  - The operator Deployment `matchLabels` changed in the new operator. Upgrading will recreate the Deployment; expect a brief disruption. Consider skipping this release if you must avoid downtime.

<sup>Written for commit 76c3b9e0289ab92dcbfdeb55c6fa79cf95b1fcce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

