### PR TITLE
feature: [victoria-metrics-k8s-stack] Update to alertmanager v0.32.0

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - bump victoria-metrics-operator dependency chart to version 0.62.0
 - updates operator to [v0.69.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.69.0) version
+- Upgraded default Alertmanager tag 0.28.1 -> 0.32.0
 
 ## 0.74.1
 

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -668,7 +668,7 @@ alertmanager:
     port: "9093"
     selectAllByDefault: true
     image:
-      tag: v0.28.1
+      tag: v0.32.0
     externalURL: ""
     routePrefix: /
 


### PR DESCRIPTION
New Alertmanager Version is available :)

already deployed it in my setup using the image tag value.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump default Alertmanager image tag from v0.28.1 to v0.32.0 in `victoria-metrics-k8s-stack` to pull in upstream fixes and improvements. Updated the changelog to reflect the change.

<sup>Written for commit 741cd22cdeefa572fa8d36e61683a425a03435cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

