### PR TITLE
k8s-stack: add default securityContext for alertmanager

### DIFF
--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -669,6 +669,13 @@ alertmanager:
     selectAllByDefault: true
     image:
       tag: v0.32.0
+    securityContext:
+      runAsGroup: 2000
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 2000
+      seccompProfile:
+        type: RuntimeDefault
     externalURL: ""
     routePrefix: /
 


### PR DESCRIPTION
Related: https://github.com/VictoriaMetrics/helm-charts/issues/2846

This is default in [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/blob/ef4b651745ca41fdac2874b5ba2160ac0f8cb5df/charts/kube-prometheus-stack/values.yaml#L1157-L1163)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a default securityContext for Alertmanager to run as non-root and match `kube-prometheus-stack` defaults, improving security and avoiding file permission issues.

- **Bug Fixes**
  - Defaults added: runAsUser 1000, runAsGroup 2000, fsGroup 2000, runAsNonRoot true, seccompProfile RuntimeDefault

<sup>Written for commit 5c231f33fad470cce4a693035c954f0fd4ab7b47. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2850?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

