### PR TITLE
charts: update vm apps to v1.142.0

### DIFF
--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 
 ## 0.37.0
 

--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 name: victoria-metrics-agent
 description: VictoriaMetrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
-version: 0.37.0
+version: 0.38.0
 # renovate: image=victoriametrics/vmagent
-appVersion: v1.141.0
+appVersion: v1.142.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 
 ## 0.38.0
 

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 name: victoria-metrics-alert
 description: VictoriaMetrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.38.0
+version: 0.39.0
 # renovate: image=victoriametrics/vmalert
-appVersion: v1.141.0
+appVersion: v1.142.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 
 ## 0.30.0
 

--- a/charts/victoria-metrics-auth/Chart.yaml
+++ b/charts/victoria-metrics-auth/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Auth - is a simple auth proxy and router for VictoriaMetrics.
 name: victoria-metrics-auth
-version: 0.30.0
+version: 0.31.0
 # renovate: image=victoriametrics/vmauth
-appVersion: v1.141.0
+appVersion: v1.142.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 
 ## 0.40.0
 

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.40.0
+version: 0.41.0
 # renovate: image=victoriametrics/vmselect
-appVersion: v1.141.0
+appVersion: v1.142.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- bump version of VM components to [v1.141.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.141.0)
+- bump version of VM components to [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 
 ## 0.35.0
 

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: victoria-metrics-distributed
 description: A Helm chart for Running VMCluster on Multiple Availability Zones
 type: application
-version: 0.35.0
+version: 0.36.0
 # renovate: image=victoriametrics/victoria-metrics
-appVersion: v1.141.0
+appVersion: v1.142.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.25.0-0"

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 
 ## 0.28.0
 

--- a/charts/victoria-metrics-gateway/Chart.yaml
+++ b/charts/victoria-metrics-gateway/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Gateway - Auth & Rate-Limitting proxy for Victoria Metrics
 name: victoria-metrics-gateway
-version: 0.28.0
+version: 0.29.0
 # renovate: image=victoriametrics/vmgateway
-appVersion: v1.141.0
+appVersion: v1.142.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 
 ## 0.75.0
 

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.75.0
+version: 0.76.0
 # renovate: image=victoriametrics/victoria-metrics
-appVersion: v1.141.0
+appVersion: v1.142.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.142.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.142.0)
 
 ## 0.36.0
 

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.36.0
+version: 0.37.0
 # renovate: image=victoriametrics/victoria-metrics
-appVersion: v1.141.0
+appVersion: v1.142.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.25.0-0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update all VictoriaMetrics Helm charts to VM v1.142.0 to pull the latest images and bump chart versions accordingly.

- **Dependencies**
  - Sets appVersion v1.142.0 for: `victoria-metrics-agent`, `victoria-metrics-alert`, `victoria-metrics-auth`, `victoria-metrics-cluster`, `victoria-metrics-distributed`, `victoria-metrics-gateway`, `victoria-metrics-k8s-stack`, `victoria-metrics-single`.
  - Chart versions: agent 0.38.0, alert 0.39.0, auth 0.31.0, cluster 0.41.0, distributed 0.36.0, gateway 0.29.0, k8s-stack 0.76.0, single 0.37.0.

<sup>Written for commit ef947ea2dd9dde2a0d0a5e793386f4affd9d724c. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2856?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

