### PR TITLE
k8s-stack: support Grafana HTTPRoute when resolving grafanaAddr

### DIFF
--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -438,11 +438,18 @@
   {{- if not (or (hasPrefix "http://" $grafanaAddr) (hasPrefix "https://" $grafanaAddr)) -}}
     {{- $grafanaAddr = printf "http://%s" $grafanaAddr -}}
   {{- end -}}
-  {{- if ($Values.grafana).enabled -}}
+  {{- if and ($Values.grafana).enabled (($Values.grafana).ingress).enabled -}}
     {{- $grafanaScheme := ternary "https" "http" (gt (len (($Values.grafana).ingress).tls) 0) -}}
     {{- $grafanaHosts := (($Values.grafana).ingress).hosts | default list }}
     {{- if eq (len $grafanaHosts) 0 }}
       {{- fail ".Values.grafana.ingress.hosts should not be empty if .Values.grafana.enabled is true" }}
+    {{- end }}
+    {{- $grafanaAddr = printf "%s://%s" $grafanaScheme (index $grafanaHosts 0) -}}
+  {{- else if and ($Values.grafana).enabled (($Values.grafana).route).main.enabled -}}
+    {{- $grafanaScheme := "https" -}}
+    {{- $grafanaHosts := (($Values.grafana).route).main.hostnames | default list }}
+    {{- if eq (len $grafanaHosts) 0 }}
+      {{- fail ".Values.grafana.route.main.hostnames should not be empty if .Values.grafana.route.main.enabled is true" }}
     {{- end }}
     {{- $grafanaAddr = printf "%s://%s" $grafanaScheme (index $grafanaHosts 0) -}}
   {{- end -}}

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -442,11 +442,11 @@
     {{- $grafanaScheme := ternary "https" "http" (gt (len (($Values.grafana).ingress).tls) 0) -}}
     {{- $grafanaHosts := (($Values.grafana).ingress).hosts | default list }}
     {{- if eq (len $grafanaHosts) 0 }}
-      {{- fail ".Values.grafana.ingress.hosts should not be empty if .Values.grafana.enabled is true" }}
+      {{- fail ".Values.grafana.ingress.hosts should not be empty if .Values.grafana.ingress.enabled is true" }}
     {{- end }}
     {{- $grafanaAddr = printf "%s://%s" $grafanaScheme (index $grafanaHosts 0) -}}
   {{- else if and ($Values.grafana).enabled (($Values.grafana).route).main.enabled -}}
-    {{- $grafanaScheme := "https" -}}
+    {{- $grafanaScheme := (($Values.grafana).route).main.scheme | default "http" -}}
     {{- $grafanaHosts := (($Values.grafana).route).main.hostnames | default list }}
     {{- if eq (len $grafanaHosts) 0 }}
       {{- fail ".Values.grafana.route.main.hostnames should not be empty if .Values.grafana.route.main.enabled is true" }}


### PR DESCRIPTION
Add support [Grafana HTTPRoute](https://github.com/grafana-community/helm-charts/blob/2fbbc56d4d705819c5b6c89eb3feb783527dec80/charts/grafana/values.yaml#L332) when resolving `grafanaAddr`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Grafana HTTPRoute support for resolving `grafanaAddr`, using the route’s scheme when set, so Gateway API clusters work automatically. Also gate ingress-based resolution on `.Values.grafana.ingress.enabled`.

- **New Features**
  - Resolve `grafanaAddr` from `.Values.grafana.route.main.hostnames` when `.Values.grafana.route.main.enabled` is true, using `.Values.grafana.route.main.scheme` (defaults to `http`).

- **Bug Fixes**
  - Validate hosts for route and ingress only when enabled, and correct the ingress fail message to reference `.Values.grafana.ingress.enabled`.

<sup>Written for commit f1d7e0e84e07ca3242c9a5860248c3d8f63bb633. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2859?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

