### PR TITLE
fix: render topologySpreadConstraints in VictoriaLogs agent chart

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- fixed rendering of `.Values.topologySpreadConstraints` in the pod spec.
 
 ## 0.1.1
 

--- a/charts/victoria-logs-agent/templates/server.yaml
+++ b/charts/victoria-logs-agent/templates/server.yaml
@@ -34,6 +34,16 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range $constraint := . }}
+        - {{ toYaml $constraint | nindent 10 | trim }}
+          {{- if not $constraint.labelSelector }}
+          labelSelector:
+            matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 14 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-logs-collector/CHANGELOG.md
+++ b/charts/victoria-logs-collector/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- fixed rendering of `.Values.topologySpreadConstraints` in the pod spec.
 
 ## 0.3.2
 

--- a/charts/victoria-logs-collector/templates/server.yaml
+++ b/charts/victoria-logs-collector/templates/server.yaml
@@ -31,6 +31,16 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range $constraint := . }}
+        - {{ toYaml $constraint | nindent 10 | trim }}
+          {{- if not $constraint.labelSelector }}
+          labelSelector:
+            matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 14 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Renders `.Values.topologySpreadConstraints` in the `victoria-logs-agent` and `victoria-logs-collector` pod specs, and the default `labelSelector` behavior used by other charts.

Fixes https://github.com/VictoriaMetrics/helm-charts/issues/2862