### PR TITLE
fix(victoria-logs-single): Disable vector by default again, as pre-0.12.3

### DIFF
--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs single Helm chart deploys VictoriaLogs database in Kubernetes.
 name: victoria-logs-single
-version: 0.12.3
+version: 0.12.4
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -410,7 +410,7 @@ server:
 # @ignored
 vector:
   # -- Enable deployment of vector
-  enabled: true
+  enabled: false
   role: Agent
   dataDir: /vector-data-dir
   resources: {}


### PR DESCRIPTION
Fixes #2871 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `vector` by default in the `victoria-logs-single` Helm chart to restore pre-0.12.3 behavior and bump the chart to 0.12.4. This prevents deploying `vector` unless explicitly enabled.

<sup>Written for commit aeb596f204e0ce27400df82f70ef3908f392f361. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

