### PR TITLE
fix(victoria-metrics-cluster): make VPA option name match the template

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- **BREAKING**: rename `verticalPodAutoscaling` to `verticalPodAutoscaler` in `vmselect`, `vminsert`, `vmauth` and `vmstorage` to match the template, which previously read `verticalPodAutoscaler` and silently ignored the documented field. Users who set `<component>.verticalPodAutoscaling.*` must rename it to `<component>.verticalPodAutoscaler.*`.
 
 ## 0.41.2
 

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -136,7 +136,7 @@ vmselect:
   # -- Vertical Pod Autoscaling.
   # Requires VPA CRD (`autoscaling.k8s.io/v1`) to be installed in the cluster.
   # Note that VPA should not be used together with HPA on the same resource metrics (CPU/memory).
-  verticalPodAutoscaling:
+  verticalPodAutoscaler:
     # -- Use VPA for vmagent
     enabled: false
     # -- List of custom recommenders to use
@@ -507,7 +507,7 @@ vminsert:
   # -- Vertical Pod Autoscaling.
   # Requires VPA CRD (`autoscaling.k8s.io/v1`) to be installed in the cluster.
   # Note that VPA should not be used together with HPA on the same resource metrics (CPU/memory).
-  verticalPodAutoscaling:
+  verticalPodAutoscaler:
     # -- Use VPA for vmagent
     enabled: false
     # -- List of custom recommenders to use
@@ -826,7 +826,7 @@ vmauth:
   # -- Vertical Pod Autoscaling.
   # Requires VPA CRD (`autoscaling.k8s.io/v1`) to be installed in the cluster.
   # Note that VPA should not be used together with HPA on the same resource metrics (CPU/memory).
-  verticalPodAutoscaling:
+  verticalPodAutoscaler:
     # -- Use VPA for vmagent
     enabled: false
     # -- List of custom recommenders to use
@@ -1285,7 +1285,7 @@ vmstorage:
   # -- Vertical Pod Autoscaling.
   # Requires VPA CRD (`autoscaling.k8s.io/v1`) to be installed in the cluster.
   # Note that VPA should not be used together with HPA on the same resource metrics (CPU/memory).
-  verticalPodAutoscaling:
+  verticalPodAutoscaler:
     # -- Use VPA for vmagent
     enabled: false
     # -- List of custom recommenders to use


### PR DESCRIPTION
The `victoria-metrics-cluster` chart had a name mismatch between `values.yaml` and the VPA template:

- `values.yaml` documented the option as `verticalPodAutoscaling` (for `vmselect`, `vminsert`, `vmauth`, `vmstorage`).
- `templates/vpa.yaml` actually reads `verticalPodAutoscaler` (no `-ing`).

This means if a user followed the documented option and set `verticalPodAutoscaling.enabled: true`, **nothing happened**. The VPA was never created. Only users who guessed the undocumented name got it to work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the VPA values key mismatch in the `victoria-metrics-cluster` chart so enabling VPA actually creates resources. Renames `verticalPodAutoscaling` to `verticalPodAutoscaler` for `vmselect`, `vminsert`, `vmauth`, and `vmstorage` to match the template.

- **Migration**
  - Rename values: `<component>.verticalPodAutoscaling.*` -> `<component>.verticalPodAutoscaler.*` for the components above.

<sup>Written for commit c7d7a7d513ba152fb88a294fdc95ef3b240b8c8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

