### PR TITLE
fix(victoria-metrics-k8s-stack): Rename collector.filesystem flags

### DIFF
--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -1192,8 +1192,8 @@ prometheus-node-exporter:
     labels:
       jobLabel: node-exporter
   extraArgs:
-    - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
-    - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|erofs|sysfs|tracefs)$
+    - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+    - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|erofs|sysfs|tracefs)$
   # -- Node Exporter VM scrape config
   vmScrape:
     # whether we should create a service scrape resource for node-exporter


### PR DESCRIPTION
Rename filesystem collector flags of prometheus-node-exporter on victoria-metrics-k8s-stack helm chart
Please check: https://github.com/prometheus/node_exporter/pull/2012

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `prometheus-node-exporter` filesystem flags to the new names to stay compatible with recent Node Exporter versions and remove deprecation warnings. Replaced `--collector.filesystem.ignored-mount-points` with `--collector.filesystem.mount-points-exclude` and `--collector.filesystem.ignored-fs-types` with `--collector.filesystem.fs-types-exclude` (same regex values).

<sup>Written for commit 920803d72243a6320bda3b1c7bade18d4482d3b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

