### PR TITLE
fix(victoria-metrics-distributed): close anonymous vmauth access by default

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- **BREAKING**: rename `verticalPodAutoscaling` to `verticalPodAutoscaler` in `vmselect`, `vminsert`, `vmauth` and `vmstorage` to match the template, which previously read `verticalPodAutoscaler` and silently ignored the documented field. Users who set `<component>.verticalPodAutoscaling.*` must rename it to `<component>.verticalPodAutoscaler.*`.
 
 ## 0.41.2
 

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -136,7 +136,7 @@ vmselect:
   # -- Vertical Pod Autoscaling.
   # Requires VPA CRD (`autoscaling.k8s.io/v1`) to be installed in the cluster.
   # Note that VPA should not be used together with HPA on the same resource metrics (CPU/memory).
-  verticalPodAutoscaling:
+  verticalPodAutoscaler:
     # -- Use VPA for vmagent
     enabled: false
     # -- List of custom recommenders to use
@@ -507,7 +507,7 @@ vminsert:
   # -- Vertical Pod Autoscaling.
   # Requires VPA CRD (`autoscaling.k8s.io/v1`) to be installed in the cluster.
   # Note that VPA should not be used together with HPA on the same resource metrics (CPU/memory).
-  verticalPodAutoscaling:
+  verticalPodAutoscaler:
     # -- Use VPA for vmagent
     enabled: false
     # -- List of custom recommenders to use
@@ -826,7 +826,7 @@ vmauth:
   # -- Vertical Pod Autoscaling.
   # Requires VPA CRD (`autoscaling.k8s.io/v1`) to be installed in the cluster.
   # Note that VPA should not be used together with HPA on the same resource metrics (CPU/memory).
-  verticalPodAutoscaling:
+  verticalPodAutoscaler:
     # -- Use VPA for vmagent
     enabled: false
     # -- List of custom recommenders to use
@@ -1285,7 +1285,7 @@ vmstorage:
   # -- Vertical Pod Autoscaling.
   # Requires VPA CRD (`autoscaling.k8s.io/v1`) to be installed in the cluster.
   # Note that VPA should not be used together with HPA on the same resource metrics (CPU/memory).
-  verticalPodAutoscaling:
+  verticalPodAutoscaler:
     # -- Use VPA for vmagent
     enabled: false
     # -- List of custom recommenders to use

--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- **BREAKING**: secure-by-default for vmauth. The chart no longer ships an open `unauthorizedUserAccessSpec` proxy across all tenants. New `allowUnauthenticated` toggle (default `false`) gates the chart-injected anonymous routing for `write.global.vmauth`, `read.global.vmauth`, and `zoneTpl.read.vmauth`. When `false` and no auth is configured (`spec.users` / `spec.unauthorizedUserAccessSpec` / `spec.unauthorizedAccessConfig` all empty), the chart fails at template time with a helpful message. Existing installs that relied on anonymous access must either set `allowUnauthenticated: true` (insecure, original behavior) or supply `spec.users`.
 
 ## 0.36.0
 

--- a/charts/victoria-metrics-distributed/templates/per-az/vmauth-read-proxy.yaml
+++ b/charts/victoria-metrics-distributed/templates/per-az/vmauth-read-proxy.yaml
@@ -58,6 +58,7 @@ metadata:
     {{- fail (printf "No read backend urls defined for vmauth in AZ %s" $zone.name) -}}
   {{- end }}
 
+  {{- if $zone.read.vmauth.allowUnauthenticated }}
   {{- $paths := dict "cluster" (list "/select/.+" "/admin/tenants") "single" (list "/select/.+") }}
   {{- $dropPrefixParts := dict "cluster" 0 "single" 2 }}
   {{- $accessSpec := $spec.unauthorizedUserAccessSpec | default dict }}
@@ -73,6 +74,9 @@ metadata:
   {{- end }}
   {{- $_ := set $accessSpec "url_map" $urlMap }}
   {{- $_ := set $spec "unauthorizedUserAccessSpec" $accessSpec }}
+  {{- else if and (empty $spec.users) (empty $spec.unauthorizedUserAccessSpec) (empty $spec.unauthorizedAccessConfig) }}
+  {{- fail (printf "zoneTpl.read.vmauth (%s): no auth configured. Either set read.vmauth.allowUnauthenticated=true (insecure: open read proxy across all tenants) or supply spec.users / spec.unauthorizedUserAccessSpec / spec.unauthorizedAccessConfig." $zone.name) }}
+  {{- end }}
   {{- if not $spec.nodeSelector }}
     {{- $_ := set $spec "nodeSelector" (dict "topology.kubernetes.io/zone" "{{ (.zone).name }}") }}
   {{- end }}

--- a/charts/victoria-metrics-distributed/templates/per-az/vmauth-read-proxy.yaml
+++ b/charts/victoria-metrics-distributed/templates/per-az/vmauth-read-proxy.yaml
@@ -74,8 +74,15 @@ metadata:
   {{- end }}
   {{- $_ := set $accessSpec "url_map" $urlMap }}
   {{- $_ := set $spec "unauthorizedUserAccessSpec" $accessSpec }}
-  {{- else if and (empty $spec.users) (empty $spec.unauthorizedUserAccessSpec) (empty $spec.unauthorizedAccessConfig) }}
-  {{- fail (printf "zoneTpl.read.vmauth (%s): no auth configured. Either set read.vmauth.allowUnauthenticated=true (insecure: open read proxy across all tenants) or supply spec.users / spec.unauthorizedUserAccessSpec / spec.unauthorizedAccessConfig." $zone.name) }}
+  {{- else if and
+       (empty $spec.users)
+       (empty $spec.userSelector)
+       (empty $spec.userNamespaceSelector)
+       (not $spec.selectAllByDefault)
+       (empty $spec.configSecret)
+       (empty $spec.unauthorizedUserAccessSpec)
+       (empty $spec.unauthorizedAccessConfig) }}
+  {{- fail (printf "zoneTpl.read.vmauth (%s): no auth configured. Either set read.vmauth.allowUnauthenticated=true (insecure: open read proxy across all tenants) or supply one of: spec.users, spec.userSelector / spec.userNamespaceSelector, spec.selectAllByDefault, spec.configSecret, spec.unauthorizedUserAccessSpec, spec.unauthorizedAccessConfig." $zone.name) }}
   {{- end }}
   {{- if not $spec.nodeSelector }}
     {{- $_ := set $spec "nodeSelector" (dict "topology.kubernetes.io/zone" "{{ (.zone).name }}") }}

--- a/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
+++ b/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
@@ -66,8 +66,15 @@ metadata:
   {{- end }}
   {{- $_ := set $accessSpec "url_map" $urlMap }}
   {{- $_ := set $spec "unauthorizedUserAccessSpec" $accessSpec }}
-  {{- else if and (empty $spec.users) (empty $spec.unauthorizedUserAccessSpec) (empty $spec.unauthorizedAccessConfig) }}
-  {{- fail "read.global.vmauth: no auth configured. Either set read.global.vmauth.allowUnauthenticated=true (insecure: open read proxy across all tenants) or supply spec.users / spec.unauthorizedUserAccessSpec / spec.unauthorizedAccessConfig." }}
+  {{- else if and
+       (empty $spec.users)
+       (empty $spec.userSelector)
+       (empty $spec.userNamespaceSelector)
+       (not $spec.selectAllByDefault)
+       (empty $spec.configSecret)
+       (empty $spec.unauthorizedUserAccessSpec)
+       (empty $spec.unauthorizedAccessConfig) }}
+  {{- fail "read.global.vmauth: no auth configured. Either set read.global.vmauth.allowUnauthenticated=true (insecure: open read proxy across all tenants) or supply one of: spec.users, spec.userSelector / spec.userNamespaceSelector, spec.selectAllByDefault, spec.configSecret, spec.unauthorizedUserAccessSpec, spec.unauthorizedAccessConfig." }}
   {{- end }}
 spec: {{ tpl (toYaml $spec) $ctx | nindent 2 }}
 {{- end }}

--- a/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
+++ b/charts/victoria-metrics-distributed/templates/vmauth-read.yaml
@@ -49,9 +49,10 @@ metadata:
   {{- if and (empty $urls.cluster) (empty $urls.single) }}
     {{- fail "No global vmauth read backend urls defined" -}}
   {{- end }}
+  {{- $spec := deepCopy $auth.spec | default dict -}}
+  {{- if $auth.allowUnauthenticated }}
   {{- $paths := dict "cluster" (list "/select/.+" "/admin/tenants") "single" (list "/select/.+") }}
   {{- $dropPrefixParts := dict "cluster" 0 "single" 2 }}
-  {{- $spec := deepCopy $auth.spec | default dict -}}
   {{- $accessSpec := $spec.unauthorizedUserAccessSpec | default dict }}
   {{- $urlMap := $accessSpec.url_map | default (list (dict)) }}
   {{- $firstItem := index $urlMap 0 }}
@@ -65,6 +66,9 @@ metadata:
   {{- end }}
   {{- $_ := set $accessSpec "url_map" $urlMap }}
   {{- $_ := set $spec "unauthorizedUserAccessSpec" $accessSpec }}
+  {{- else if and (empty $spec.users) (empty $spec.unauthorizedUserAccessSpec) (empty $spec.unauthorizedAccessConfig) }}
+  {{- fail "read.global.vmauth: no auth configured. Either set read.global.vmauth.allowUnauthenticated=true (insecure: open read proxy across all tenants) or supply spec.users / spec.unauthorizedUserAccessSpec / spec.unauthorizedAccessConfig." }}
+  {{- end }}
 spec: {{ tpl (toYaml $spec) $ctx | nindent 2 }}
 {{- end }}
 

--- a/charts/victoria-metrics-distributed/templates/vmauth-write.yaml
+++ b/charts/victoria-metrics-distributed/templates/vmauth-write.yaml
@@ -45,8 +45,15 @@ metadata:
   {{- $firstUrlMapItem := mergeOverwrite $defaultUrlMapItem (deepCopy (index $urlMap 0)) }}
   {{- $_ := set $accessSpec "url_map" (prepend (slice $urlMap 1) $firstUrlMapItem) }}
   {{- $_ := set $spec "unauthorizedUserAccessSpec" $accessSpec }}
-  {{- else if and (empty $spec.users) (empty $spec.unauthorizedUserAccessSpec) (empty $spec.unauthorizedAccessConfig) }}
-  {{- fail "write.global.vmauth: no auth configured. Either set write.global.vmauth.allowUnauthenticated=true (insecure: open write proxy across all tenants) or supply spec.users / spec.unauthorizedUserAccessSpec / spec.unauthorizedAccessConfig." }}
+  {{- else if and
+       (empty $spec.users)
+       (empty $spec.userSelector)
+       (empty $spec.userNamespaceSelector)
+       (not $spec.selectAllByDefault)
+       (empty $spec.configSecret)
+       (empty $spec.unauthorizedUserAccessSpec)
+       (empty $spec.unauthorizedAccessConfig) }}
+  {{- fail "write.global.vmauth: no auth configured. Either set write.global.vmauth.allowUnauthenticated=true (insecure: open write proxy across all tenants) or supply one of: spec.users, spec.userSelector / spec.userNamespaceSelector, spec.selectAllByDefault, spec.configSecret, spec.unauthorizedUserAccessSpec, spec.unauthorizedAccessConfig." }}
   {{- end }}
 spec: {{ tpl (toYaml $spec) $ctx | nindent 2 }}
 {{- end }}

--- a/charts/victoria-metrics-distributed/templates/vmauth-write.yaml
+++ b/charts/victoria-metrics-distributed/templates/vmauth-write.yaml
@@ -36,13 +36,17 @@ metadata:
   {{- if empty $urls }}
     {{- fail "No global vmauth write backend urls defined" -}}
   {{- end }}
+  {{- $spec := deepCopy $auth.spec | default dict -}}
+  {{- if $auth.allowUnauthenticated }}
   {{- $defaultPaths := list "/api/v1/write" "/prometheus/api/v1/write" "/write" "/api/v1/import" "/api/v1/import/.+" "/opentelemetry/.+" "/insert/.+"}}
   {{- $defaultUrlMapItem := dict "src_paths" $defaultPaths "url_prefix" $urls }}
-  {{- $spec := deepCopy $auth.spec | default dict -}}
   {{- $accessSpec := $spec.unauthorizedUserAccessSpec | default dict }}
   {{- $urlMap := $accessSpec.url_map | default (list (dict))  }}
   {{- $firstUrlMapItem := mergeOverwrite $defaultUrlMapItem (deepCopy (index $urlMap 0)) }}
   {{- $_ := set $accessSpec "url_map" (prepend (slice $urlMap 1) $firstUrlMapItem) }}
   {{- $_ := set $spec "unauthorizedUserAccessSpec" $accessSpec }}
+  {{- else if and (empty $spec.users) (empty $spec.unauthorizedUserAccessSpec) (empty $spec.unauthorizedAccessConfig) }}
+  {{- fail "write.global.vmauth: no auth configured. Either set write.global.vmauth.allowUnauthenticated=true (insecure: open write proxy across all tenants) or supply spec.users / spec.unauthorizedUserAccessSpec / spec.unauthorizedAccessConfig." }}
+  {{- end }}
 spec: {{ tpl (toYaml $spec) $ctx | nindent 2 }}
 {{- end }}

--- a/charts/victoria-metrics-distributed/tests/vmauth_test.yaml
+++ b/charts/victoria-metrics-distributed/tests/vmauth_test.yaml
@@ -11,21 +11,32 @@ tests:
       write:
         global:
           vmauth:
+            allowUnauthenticated: true
             spec:
               image:
                 tag: v1.0.2
       read:
         global:
           vmauth:
+            allowUnauthenticated: true
             spec:
               image:
                 tag: v1.0.3
+              unauthorizedUserAccessSpec:
+                url_map:
+                  - load_balancing_policy: first_available
+                    retry_status_codes: [500, 502, 503]
       zoneTpl:
         read:
           vmauth:
+            allowUnauthenticated: true
             spec:
               image:
                 tag: v1.0.5
+              unauthorizedUserAccessSpec:
+                url_map:
+                  - load_balancing_policy: first_available
+                    retry_status_codes: [500, 502, 503]
         cluster:
           spec:
             image:

--- a/charts/victoria-metrics-distributed/values.yaml
+++ b/charts/victoria-metrics-distributed/values.yaml
@@ -42,6 +42,10 @@ write:
     vmauth:
       # -- Create a vmauth as the global write entrypoint
       enabled: true
+      # -- Allow unauthenticated access through this vmauth. When `false`, the chart will not inject
+      # `unauthorizedUserAccessSpec` and you must supply `spec.users` (or set this to `true`).
+      # Defaults to `false` to avoid an open write proxy across all tenants.
+      allowUnauthenticated: false
       # -- Override the name of the vmauth object
       name: "vmauth-global-write-{{ .fullname }}"
       # -- Spec for VMAuth CRD, see [here](https://docs.victoriametrics.com/operator/api/#vmauthspec)
@@ -52,14 +56,14 @@ read:
     vmauth:
       # -- Create vmauth as the global read entrypoint
       enabled: true
+      # -- Allow unauthenticated access through this vmauth. When `false`, the chart will not inject
+      # `unauthorizedUserAccessSpec` and you must supply `spec.users` (or set this to `true`).
+      # Defaults to `false` to avoid an open read proxy across all tenants.
+      allowUnauthenticated: false
       # -- Override the name of the vmauth object
       name: "vmauth-global-read-{{ .fullname }}"
       # -- Spec for VMAuth CRD, see [here](https://docs.victoriametrics.com/operator/api/#vmauthspec)
-      spec:
-        unauthorizedUserAccessSpec:
-          url_map:
-            - load_balancing_policy: first_available
-              retry_status_codes: [500, 502, 503]
+      spec: {}
 
 # -- Default config for each availability zone components, including vmagent, vmcluster, vmsingle, vmauth etc.
 # Defines a template for each availability zone, which can be overridden for each availability zone at `availabilityZones[*]`
@@ -94,14 +98,14 @@ zoneTpl:
     vmauth:
       # -- Create a vmauth with all the zone with `allow: true` as query backends
       enabled: true
+      # -- Allow unauthenticated access through this per-zone vmauth. When `false`, the chart will not
+      # inject `unauthorizedUserAccessSpec` and you must supply `spec.users` (or set this to `true`).
+      # Defaults to `false` to avoid an open read proxy across all tenants.
+      allowUnauthenticated: false
       # -- Override the name of the vmauth object
       name: "vmauth-read-proxy-{{ (.zone).name }}"
       # -- Spec for VMAuth CRD, see [here](https://docs.victoriametrics.com/operator/api/#vmauthspec)
-      spec:
-        unauthorizedUserAccessSpec:
-          url_map:
-            - load_balancing_policy: first_available
-              retry_status_codes: [500, 502, 503]
+      spec: {}
   # vmagent here only meant to proxy write requests to each az,
   # doesn't support customized other remote write address.
   vmagent:


### PR DESCRIPTION
## Summary

The `victoria-metrics-distributed` chart used to expose its vmauth proxies to **anyone with no password** by default.

When you installed the chart out-of-the-box, these paths were open to anonymous traffic:

- **Write paths** (any tenant): `/api/v1/write`, `/insert/<tenant>/...`, `/opentelemetry/...`, etc.
- **Read paths** (any tenant): `/select/...`, `/admin/tenants`

This means anyone who could reach the vmauth Service could read or write metrics for **any tenant**. That broke the whole point of multi-tenancy.

## What this PR does

Adds a new option called `allowUnauthenticated` to three places:

- `write.global.vmauth.allowUnauthenticated`
- `read.global.vmauth.allowUnauthenticated`
- `zoneTpl.read.vmauth.allowUnauthenticated`

The default value is `false`. This means:

1. **By default**, the chart will **not** open the vmauth to anonymous traffic.
2. If you don't configure any users, the chart will **stop with a clear error message** telling you what to do.
3. If you really want the old behavior (anonymous access), you can set `allowUnauthenticated: true`. The chart will then add the same routing rules as before.
4. If you want proper auth, you set `spec.users` (or `spec.unauthorizedAccessConfig`) and the chart will use that.

## Breaking change

Yes. Existing installs that relied on the silent anonymous proxy will fail to render after upgrade. The fix is one line in your `values.yaml`:

```yaml
# Option A: keep the old (insecure) behavior
write:
  global:
    vmauth:
      allowUnauthenticated: true
read:
  global:
    vmauth:
      allowUnauthenticated: true
zoneTpl:
  read:
    vmauth:
      allowUnauthenticated: true

# Option B (recommended): add real users
read:
  global:
    vmauth:
      spec:
        users:
          - username: reader
            password: <secret>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down `vmauth` in `victoria-metrics-distributed` by default. Adds an `allowUnauthenticated` toggle and expands the template-time guard so charts fail fast when no auth is configured. This is breaking for clusters that relied on anonymous access.

- **New Features**
  - New `allowUnauthenticated` (default `false`) in `write.global.vmauth`, `read.global.vmauth`, and `zoneTpl.read.vmauth`.
  - When `false`, templating now fails unless one of these is set: `spec.users`, `spec.userSelector`/`spec.userNamespaceSelector`, `spec.selectAllByDefault`, `spec.configSecret`, `spec.unauthorizedUserAccessSpec`, or `spec.unauthorizedAccessConfig`.
  - Removed implicit `unauthorizedUserAccessSpec.url_map` defaults from `read.global.vmauth.spec` and `zoneTpl.read.vmauth.spec` to avoid open proxies.

- **Migration**
  - Keep old behavior (insecure): set `allowUnauthenticated: true` in the three vmauth blocks.
  - Recommended: configure auth via `spec.users`, or use selectors/secrets (`spec.userSelector`, `spec.userNamespaceSelector`, `spec.selectAllByDefault`, `spec.configSecret`).

<sup>Written for commit 1e016d1b266ccfaf418edcf927ff2b1c61acd211. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

