### PR TITLE
distributed: add deprecation note

### DIFF
--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -3,6 +3,7 @@ name: victoria-metrics-distributed
 description: A Helm chart for Running VMCluster on Multiple Availability Zones
 type: application
 version: 0.36.0
+deprecated: true
 # renovate: image=victoriametrics/victoria-metrics
 appVersion: v1.142.0
 sources:

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -3,6 +3,7 @@ name: victoria-metrics-distributed
 description: A Helm chart for Running VMCluster on Multiple Availability Zones
 type: application
 version: 0.38.0
+deprecated: true
 # renovate: image=victoriametrics/victoria-metrics
 appVersion: v1.144.0
 sources:

--- a/charts/victoria-metrics-distributed/_index.md.gotmpl
+++ b/charts/victoria-metrics-distributed/_index.md.gotmpl
@@ -15,6 +15,9 @@ tags:
 ---
 {{ template "chart.badges" . }}
 
+> [!CAUTION]
+> **This Helm Chart is deprecated!** [Enable VMDistributed resource](https://docs.victoriametrics.com/helm/victoriametrics-k8s-stack/index.html#vmdistributed-enabled) in VictoriaMetrics K8s stack chart instead. Also check [migration guide](#migration-to-k8s-stack-chart) below.
+
 {{ template "chart.description" . }}
 
 {{ template "chart.prerequisites" . }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Deprecates the `victoria-metrics-distributed` Helm chart and directs users to use VMDistributed in the `victoriametrics-k8s-stack` chart. Sets `deprecated: true` in the chart and adds a CAUTION banner in the docs with a link to the migration guide.

- **Migration**
  - In `victoriametrics-k8s-stack`, set `vmdistributed.enabled: true` (https://docs.victoriametrics.com/helm/victoriametrics-k8s-stack/index.html#vmdistributed-enabled).
  - Follow the “Migration to K8s Stack chart” guide in the chart docs.

<sup>Written for commit 8d401f4a4458416c8c5b10a0f9740f194e6d7370. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2880?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

