### PR TITLE
fix(victoria-metrics-k8s-stack): Fix Alertmanager templates path to match VM Operator mount

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- fix Alertmanager templates path to match VM Operator mount. See [#2883](https://github.com/VictoriaMetrics/helm-charts/pull/2883).
 
 ## 0.77.0
 

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalertmanager/vmalertmanager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalertmanager/vmalertmanager.yaml
@@ -26,7 +26,7 @@ metadata:
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
 stringData:
   {{- $config := (.Values.alertmanager).config | default dict }}
-  {{- $_ := set $config "templates" (list "/etc/vm/configs/**/*.tmpl") }}
+  {{- $_ := set $config "templates" (list "/etc/vm/templates/**/*.tmpl") }}
   alertmanager.yaml: |{{ toYaml $config | nindent 4 }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
This PR fixes the Alertmanager templates path in the victoria-metrics-k8s-stack chart so it matches the path mounted by VM Operator for Alertmanager.

Previously, the chart referenced an incorrect templates directory path `/etc/config/**/*.tmpl`, which prevented Alertmanager from finding notification templates at runtime. The updated path aligns the chart configuration with the VM Operator-managed Alertmanager mount location.

Changes included:

* Corrected the Alertmanager templates folder path.

This ensures Alertmanager can load templates correctly when deployed through the victoria-metrics-k8s-stack chart.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Alertmanager templates path in `victoria-metrics-k8s-stack` to match the VM Operator mount so templates load at runtime. Changes glob from `/etc/vm/configs/**/*.tmpl` to `/etc/vm/templates/**/*.tmpl` and updates the chart CHANGELOG.

<sup>Written for commit 2c5b1444cb758b103b766e778c0d957ae519b2b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

