### PR TITLE
k8s-stack: support per rule overrides in defaultRules.groups.<group>.rules

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - fix Alertmanager templates path to match VM Operator mount. See [#2883](https://github.com/VictoriaMetrics/helm-charts/pull/2883).
+- support per-rule overrides in `defaultRules.groups.<group>.rules`
 
 ## 0.77.0
 

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/rule.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/rule.yaml
@@ -87,7 +87,8 @@ Filter out ignore rules
   {{- $exactRule := index $exactRules $ruleName | default dict }}
   {{- $defaultRule := deepCopy (index $defaultRules $ruleKey) }}
   {{- $defaultInGroup := deepCopy (index $group $ruleKey | default dict) }}
-  {{- $resultRule := mergeOverwrite (deepCopy $commonRule) $defaultRule $commonInGroupRule $defaultInGroup $exactRule }}
+  {{- $exactRuleInGroup := index $commonInGroupRule $ruleName | default dict }}
+  {{- $resultRule := mergeOverwrite (deepCopy $commonRule) $defaultRule $commonInGroupRule $defaultInGroup $exactRule $exactRuleInGroup }}
   {{- if (and (dig "create" true $resultRule) $ruleCondition) }}
     {{- $ruleSpec := mergeOverwrite (deepCopy $ruleSpec) (dig "spec" (dict) $resultRule) }}
     {{- $filteredRulesSpec = append $filteredRulesSpec $ruleSpec }}


### PR DESCRIPTION
Allow group-scoped per-rule settings override global `defaultRules.rules`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-rule overrides in `defaultRules.groups.<group>.rules`, applied after global defaults and global per-rule settings. Group-scoped overrides take precedence, so you can customize or disable specific alerts per group without affecting others.

<sup>Written for commit 22d13add85fa4b4326e79bee9ac4f699030ccca0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

