### PR TITLE
docs: use canonical link

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -61,7 +61,7 @@
 
 - add ability to set custom labels for scrape configs. See [#2810](https://github.com/VictoriaMetrics/helm-charts/issues/2810).
 - replaced custom `app` label with `app.kubernetes.io/component`. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
-- delegate [relabeling-debug](https://docs.victoriametrics.com/victoria-metrics/relabeling/#relabel-debugging) configuration to the vmagent defaults, by removing `promscrape.dropOriginalLabels` from extraArgs.
+- delegate [relabeling-debug](https://docs.victoriametrics.com/victoriametrics/relabeling/) configuration to the vmagent defaults, by removing `promscrape.dropOriginalLabels` from extraArgs.
 
 ## 0.73.0
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the CHANGELOG to use the canonical VictoriaMetrics relabeling docs URL, replacing the old `victoria-metrics/relabeling/#relabel-debugging` link. This avoids a broken anchor and points to the maintained docs.

<sup>Written for commit e0aeacc9ee81524e3b01cc4ceab8ef981eaeb617. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

