### PR TITLE
fix(victoria-metrics-k8s-stack): add uid to default VictoriaMetrics datasource

### DIFF
--- a/charts/victoria-metrics-distributed/templates/grafana-datasource.yaml
+++ b/charts/victoria-metrics-distributed/templates/grafana-datasource.yaml
@@ -23,6 +23,7 @@ data:
       type: prometheus
       url: {{ $url }}
       access: proxy
+      uid: VictoriaMetrics
       isDefault: true
       jsonData: {}
 {{- end }}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -1078,10 +1078,12 @@ defaultDatasources:
       - name: VictoriaMetrics
         type: prometheus
         access: proxy
+        uid: VictoriaMetrics
         isDefault: true
       - name: VictoriaMetrics (DS)
         isDefault: false
         access: proxy
+        uid: VictoriaMetricsDS
         type: victoriametrics-metrics-datasource
   # -- List of alertmanager datasources.
   # VMAlertmanager generated `url` will be added to each datasource in template if alertmanager is enabled
@@ -1089,6 +1091,7 @@ defaultDatasources:
     datasources:
       - name: Alertmanager
         access: proxy
+        uid: Alertmanager
         jsonData:
           implementation: prometheus
   # -- Configure additional grafana datasources (passed through tpl).


### PR DESCRIPTION
Set an explicit `uid: VictoriaMetrics` on the default Prometheus-type datasource in `defaultDatasources.victoriametrics.datasources`. Some dashboards reference the datasource by UID rather than name, and without a stable UID Grafana auto-generates one, breaking those dashboards.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set explicit UIDs on default Grafana datasources for stable identifiers and to prevent UID-based dashboards from breaking.

Adds `uid: VictoriaMetrics` to the default Prometheus datasource in both `victoria-metrics-k8s-stack` and `victoria-metrics-distributed`, plus `uid: VictoriaMetricsDS` for the `victoriametrics-metrics-datasource` and `uid: Alertmanager` for the Alertmanager datasource.

<sup>Written for commit a4c36ffa990e842345f2ab17a2e516616221b148. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

