### PR TITLE
chore: update tested k8s releases

### DIFF
--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -39,9 +39,9 @@ jobs:
       matrix:
         k8s_version:
           # renovate: image=kindest/node
-          - "v1.35.1"
-          - "v1.34.3"
-          - "v1.33.7"
+          - "v1.36.0"
+          - "v1.35.4"
+          - "v1.34.7"
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
Update tested k8s versions to match the latest supported