### PR TITLE
renovate: add 21 days cooldown for github-actions manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -102,6 +102,7 @@
     {
       "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
+      "minimumReleaseAge": "21 days",
       "groupName": "GitHub Actions",
       "automerge": false
     }


### PR DESCRIPTION
Add 21 days cooldown for GitHub actions manager (`matchManagers`)

Docs: https://docs.renovatebot.com/key-concepts/minimum-release-age/