### PR TITLE
fix(hack): only deploy vector-k8s-monitoring if vector is enabled

### DIFF
--- a/charts/victoria-logs-single/files/dashboards/generated/vector-k8s-monitoring.yaml
+++ b/charts/victoria-logs-single/files/dashboards/generated/vector-k8s-monitoring.yaml
@@ -1178,7 +1178,7 @@ panels:
     "y": 2
   id: 324
   type: row
-condition: true
+condition: {{ ($Values.vector).enabled }}
 description: Vector.dev Kubernetes cluster monitoring dashboard
 fiscalYearStartMonth: 0
 graphTooltip: 1

--- a/charts/victoria-metrics-k8s-stack/files/dashboards/generated/kubernetes-kubelet.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/dashboards/generated/kubernetes-kubelet.yaml
@@ -98,7 +98,7 @@ panels:
   - datasource:
       type: {{ $defaultDatasource }}
       uid: ${datasource}
-    expr: {{ printf "sum(kubelet_running_containers{%s=~\"$cluster\",job=\"kubelet\",metrics_path=\"/metrics\",instance=~\"$instance\"}) by(%s)" $clusterLabel $clusterLabel }}
+    expr: {{ printf "sum(kubelet_running_containers{%s=~\"$cluster\",job=\"kubelet\",metrics_path=\"/metrics\",container_state=\"running\",instance=~\"$instance\"}) by(%s)" $clusterLabel $clusterLabel }}
     instant: true
   datasource:
     type: datasource

--- a/charts/victoria-metrics-k8s-stack/files/dashboards/generated/node-exporter-full.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/dashboards/generated/node-exporter-full.yaml
@@ -830,7 +830,6 @@ panels:
         pointSize: 5
         scaleDistribution:
           type: linear
-        showPoints: never
         spanNulls: false
         stacking:
           group: A
@@ -971,7 +970,6 @@ panels:
         pointSize: 5
         scaleDistribution:
           type: linear
-        showPoints: never
         spanNulls: false
         stacking:
           group: A
@@ -1089,7 +1087,6 @@ panels:
         pointSize: 5
         scaleDistribution:
           type: linear
-        showPoints: never
         spanNulls: false
         stacking:
           group: A
@@ -1166,7 +1163,6 @@ panels:
         pointSize: 5
         scaleDistribution:
           type: linear
-        showPoints: never
         spanNulls: false
         stacking:
           group: A
@@ -1298,7 +1294,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -1510,7 +1505,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -1681,7 +1675,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -1768,7 +1761,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -1853,7 +1845,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -1940,7 +1931,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -2037,7 +2027,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -2112,7 +2101,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -2188,7 +2176,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -2300,7 +2287,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -2403,7 +2389,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -2510,7 +2495,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -2592,7 +2576,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -2690,7 +2673,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -2773,7 +2755,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -2886,7 +2867,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -2970,7 +2950,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -3060,7 +3039,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -3158,7 +3136,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -3240,7 +3217,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -3332,7 +3308,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -3430,7 +3405,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -3512,7 +3486,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -3603,7 +3576,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -3690,7 +3662,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -3784,7 +3755,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -3881,7 +3851,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -3991,7 +3960,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -4066,7 +4034,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -4167,7 +4134,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -4250,7 +4216,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -4333,7 +4298,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -4432,7 +4396,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -4532,7 +4495,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -4610,7 +4572,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -4727,7 +4688,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -4821,7 +4781,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -4912,7 +4871,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -5012,7 +4970,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -5120,7 +5077,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -5216,7 +5172,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -5324,7 +5279,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -5437,7 +5391,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -5512,7 +5465,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -5594,7 +5546,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -5725,7 +5676,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -5811,7 +5761,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -5896,7 +5845,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -5982,7 +5930,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -6100,7 +6047,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -6215,7 +6161,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -6291,7 +6236,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -6367,7 +6311,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -6457,7 +6400,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -6554,7 +6496,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -6649,7 +6590,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -6737,7 +6677,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -6825,7 +6764,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -6927,7 +6865,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7024,7 +6961,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7106,7 +7042,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7188,7 +7123,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7288,7 +7222,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7379,7 +7312,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7462,7 +7394,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7538,7 +7469,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7632,7 +7562,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7720,7 +7649,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7808,7 +7736,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7896,7 +7823,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -7977,7 +7903,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -8052,7 +7977,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -8127,7 +8051,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -8209,7 +8132,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -8290,7 +8212,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -8371,7 +8292,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -8446,7 +8366,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -8528,7 +8447,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -8626,7 +8544,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -8847,7 +8764,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -8932,7 +8848,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9009,7 +8924,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9094,7 +9008,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9185,7 +9098,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9270,7 +9182,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9355,7 +9266,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9440,7 +9350,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9522,7 +9431,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9608,7 +9516,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9711,7 +9618,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9801,7 +9707,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9892,7 +9797,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -9981,7 +9885,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -10116,7 +10019,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -10222,7 +10124,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -10299,7 +10200,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -10390,7 +10290,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -10481,7 +10380,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -10581,7 +10479,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -10664,7 +10561,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -10772,7 +10668,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -10883,7 +10778,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -10966,7 +10860,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -11052,7 +10945,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -11129,7 +11021,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -11210,7 +11101,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A
@@ -11323,7 +11213,6 @@ panels:
           pointSize: 5
           scaleDistribution:
             type: linear
-          showPoints: never
           spanNulls: false
           stacking:
             group: A

--- a/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-cluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-cluster.yaml
@@ -7055,39 +7055,46 @@ panels:
   type: row
 - title: vminsert ($instance)
   panels:
-  - title: Requests rate ($instance)
+  - title: Rows rate ($instance)
     targets:
     - datasource:
         type: {{ $defaultDatasource }}
         uid: $ds
-      expr: {{ printf "sum(rate(vm_http_requests_total{job=~\"$job_insert\",instance=~\"$instance\",%s=~\"$cluster\"}[$__rate_interval])) by(path,%s) > 0" $clusterLabel $clusterLabel }}
+      expr: {{ printf "sum(rate(vm_rows_inserted_total{job=~\"$job\",instance=~\"$instance\",%s=~\"$cluster\"}[$__rate_interval])) by(type,%s) > 0" $clusterLabel $clusterLabel }}
       editorMode: code
       format: time_series
+      interval: ""
       intervalFactor: 1
-      legendFormat: __auto
+      legendFormat: 'sample: {{`{{`}}type{{`}}`}}'
       range: true
       refId: A
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: $ds
+      expr: {{ printf "sum(rate(vm_metadata_rows_inserted_total{job=~\"$job\",instance=~\"$instance\",%s=~\"$cluster\"}[$__rate_interval])) by(type,%s) > 0" $clusterLabel $clusterLabel }}
+      editorMode: code
+      format: time_series
+      interval: ""
+      intervalFactor: 1
+      legendFormat: 'metadata: {{`{{`}}type{{`}}`}}'
+      range: true
+      refId: B
     datasource:
       type: {{ $defaultDatasource }}
       uid: $ds
-    description: |-
-      * `*` - unsupported query path
-      * `/write` - insert into VM
-      * `/metrics` - query VM system metrics
-      * `/query` - query instant values
-      * `/query_range` - query over a range of time
-      * `/series` - match a certain label set
-      * `/label/{}/values` - query a list of label values (variables mostly)
+    description: "Shows the rate of data rows ingested from write requests. There are two kinds of rows:\n1. Raw sample: each sample consists of a value and a timestamp, see https://docs.victoriametrics.com/victoriametrics/keyconcepts/#raw-samples. \n2. Metric metadata: refers to descriptive information about metrics. It can be disabled by setting `-enableMetadata=false`, see https://docs.victoriametrics.com/victoriametrics/vmagent/#metric-metadata."
     fieldConfig:
       defaults:
         color:
           mode: palette-classic
         custom:
+          axisBorderShow: false
           axisCenteredZero: false
           axisColorMode: text
           axisLabel: ""
           axisPlacement: auto
           barAlignment: 0
+          barWidthFactor: 0.6
           drawStyle: line
           fillOpacity: 0
           gradientMode: none
@@ -7095,18 +7102,21 @@ panels:
             legend: false
             tooltip: false
             viz: false
+          insertNulls: false
           lineInterpolation: linear
           lineWidth: 1
           pointSize: 5
           scaleDistribution:
             type: linear
           showPoints: never
+          showValues: false
           spanNulls: false
           stacking:
             group: A
             mode: none
           thresholdsStyle:
             mode: "off"
+        decimals: 2
         links: []
         mappings: []
         min: 0
@@ -7114,6 +7124,7 @@ panels:
           mode: absolute
           steps:
           - color: green
+            value: 0
           - color: red
             value: 80
         unit: short
@@ -7122,8 +7133,8 @@ panels:
       h: 8
       w: 12
       x: 0
-      "y": 8385
-    id: 97
+      "y": 43
+    id: 227
     options:
       legend:
         calcs:
@@ -7136,9 +7147,10 @@ panels:
         sortBy: Last *
         sortDesc: true
       tooltip:
+        hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 9.1.0
+    pluginVersion: 12.4.3
     type: timeseries
   - title: Concurrent inserts ($instance)
     targets:
@@ -7179,11 +7191,13 @@ panels:
         color:
           mode: palette-classic
         custom:
+          axisBorderShow: false
           axisCenteredZero: false
           axisColorMode: text
           axisLabel: ""
           axisPlacement: auto
           barAlignment: 0
+          barWidthFactor: 0.6
           drawStyle: line
           fillOpacity: 10
           gradientMode: none
@@ -7191,12 +7205,14 @@ panels:
             legend: false
             tooltip: false
             viz: false
+          insertNulls: false
           lineInterpolation: linear
           lineWidth: 1
           pointSize: 5
           scaleDistribution:
             type: linear
           showPoints: never
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -7211,6 +7227,7 @@ panels:
           mode: absolute
           steps:
           - color: green
+            value: 0
           - color: red
             value: 80
         unit: short
@@ -7229,7 +7246,7 @@ panels:
       h: 8
       w: 12
       x: 12
-      "y": 8385
+      "y": 43
     id: 99
     options:
       legend:
@@ -7243,9 +7260,101 @@ panels:
         sortBy: Last *
         sortDesc: true
       tooltip:
+        hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 9.1.0
+    pluginVersion: 12.4.3
+    type: timeseries
+  - title: Requests rate ($instance)
+    targets:
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: $ds
+      expr: {{ printf "sum(rate(vm_http_requests_total{job=~\"$job_insert\",instance=~\"$instance\",%s=~\"$cluster\"}[$__rate_interval])) by(path,%s) > 0" $clusterLabel $clusterLabel }}
+      editorMode: code
+      format: time_series
+      intervalFactor: 1
+      legendFormat: __auto
+      range: true
+      refId: A
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: $ds
+    description: |-
+      * `*` - unsupported query path
+      * `/write` - insert into VM
+      * `/metrics` - query VM system metrics
+      * `/query` - query instant values
+      * `/query_range` - query over a range of time
+      * `/series` - match a certain label set
+      * `/label/{}/values` - query a list of label values (variables mostly)
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          barWidthFactor: 0.6
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          showValues: false
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+          - color: green
+            value: 0
+          - color: red
+            value: 80
+        unit: short
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 0
+      "y": 51
+    id: 97
+    options:
+      legend:
+        calcs:
+        - mean
+        - lastNotNull
+        - max
+        displayMode: table
+        placement: bottom
+        showLegend: true
+        sortBy: Last *
+        sortDesc: true
+      tooltip:
+        hideZeros: false
+        mode: multi
+        sort: desc
+    pluginVersion: 12.4.3
     type: timeseries
   - title: CPU usage % ($instance)
     targets:
@@ -7268,7 +7377,6 @@ panels:
       editorMode: code
       exemplar: true
       format: time_series
-      hide: false
       interval: ""
       intervalFactor: 1
       legendFormat: min
@@ -7281,7 +7389,6 @@ panels:
       editorMode: code
       exemplar: true
       format: time_series
-      hide: false
       interval: ""
       intervalFactor: 1
       legendFormat: median
@@ -7295,11 +7402,13 @@ panels:
         color:
           mode: palette-classic
         custom:
+          axisBorderShow: false
           axisCenteredZero: false
           axisColorMode: text
           axisLabel: ""
           axisPlacement: auto
           barAlignment: 0
+          barWidthFactor: 0.6
           drawStyle: line
           fillOpacity: 0
           gradientMode: none
@@ -7307,12 +7416,14 @@ panels:
             legend: false
             tooltip: false
             viz: false
+          insertNulls: false
           lineInterpolation: linear
           lineWidth: 1
           pointSize: 5
           scaleDistribution:
             type: linear
           showPoints: never
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -7329,6 +7440,7 @@ panels:
           mode: absolute
           steps:
           - color: green
+            value: 0
           - color: red
             value: 0.9
         unit: percentunit
@@ -7336,8 +7448,8 @@ panels:
     gridPos:
       h: 8
       w: 12
-      x: 0
-      "y": 8393
+      x: 12
+      "y": 51
     id: 185
     options:
       legend:
@@ -7351,9 +7463,10 @@ panels:
         sortBy: Last *
         sortDesc: true
       tooltip:
+        hideZeros: false
         mode: multi
         sort: none
-    pluginVersion: 9.1.0
+    pluginVersion: 12.4.3
     type: timeseries
   - title: Memory (anon) usage % ($instance)
     targets:
@@ -7376,7 +7489,6 @@ panels:
       editorMode: code
       exemplar: true
       format: time_series
-      hide: false
       interval: ""
       intervalFactor: 1
       legendFormat: min
@@ -7389,7 +7501,6 @@ panels:
       editorMode: code
       exemplar: true
       format: time_series
-      hide: false
       interval: ""
       intervalFactor: 1
       legendFormat: median
@@ -7408,11 +7519,13 @@ panels:
         color:
           mode: palette-classic
         custom:
+          axisBorderShow: false
           axisCenteredZero: false
           axisColorMode: text
           axisLabel: ""
           axisPlacement: auto
           barAlignment: 0
+          barWidthFactor: 0.6
           drawStyle: line
           fillOpacity: 0
           gradientMode: none
@@ -7420,12 +7533,14 @@ panels:
             legend: false
             tooltip: false
             viz: false
+          insertNulls: false
           lineInterpolation: linear
           lineWidth: 1
           pointSize: 5
           scaleDistribution:
             type: linear
           showPoints: never
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -7442,6 +7557,7 @@ panels:
           mode: absolute
           steps:
           - color: green
+            value: 0
           - color: red
             value: 0.9
         unit: percentunit
@@ -7449,8 +7565,8 @@ panels:
     gridPos:
       h: 8
       w: 12
-      x: 12
-      "y": 8393
+      x: 0
+      "y": 59
     id: 187
     options:
       legend:
@@ -7464,9 +7580,93 @@ panels:
         sortBy: Last *
         sortDesc: true
       tooltip:
+        hideZeros: false
         mode: multi
         sort: none
-    pluginVersion: 9.1.0
+    pluginVersion: 12.4.3
+    type: timeseries
+  - title: Storage reachability ($instance)
+    targets:
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: $ds
+      expr: {{ printf "vm_rpc_vmstorage_is_reachable{job=~\"$job\",instance=~\"$instance\",%s=~\"$cluster\"} != 1" $clusterLabel }}
+      editorMode: code
+      format: time_series
+      interval: ""
+      intervalFactor: 1
+      legendFormat: '{{`{{`}}instance{{`}}`}} => {{`{{`}}addr{{`}}`}}'
+      range: true
+      refId: A
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: $ds
+    description: Shows when vmstorage node is unreachable for vminsert.
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          barWidthFactor: 0.6
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          showValues: false
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        decimals: 0
+        links: []
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+          - color: green
+            value: 0
+          - color: red
+            value: 80
+        unit: short
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 12
+      "y": 59
+    id: 114
+    options:
+      legend:
+        calcs:
+        - mean
+        - lastNotNull
+        displayMode: table
+        placement: bottom
+        showLegend: true
+      tooltip:
+        hideZeros: false
+        mode: multi
+        sort: desc
+    pluginVersion: 12.4.3
     type: timeseries
   - title: Storage connection saturation ($instance)
     targets:
@@ -7491,11 +7691,13 @@ panels:
         color:
           mode: palette-classic
         custom:
+          axisBorderShow: false
           axisCenteredZero: false
           axisColorMode: text
           axisLabel: ""
           axisPlacement: auto
           barAlignment: 0
+          barWidthFactor: 0.6
           drawStyle: line
           fillOpacity: 0
           gradientMode: none
@@ -7503,12 +7705,14 @@ panels:
             legend: false
             tooltip: false
             viz: false
+          insertNulls: false
           lineInterpolation: linear
           lineWidth: 1
           pointSize: 5
           scaleDistribution:
             type: linear
           showPoints: never
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -7523,6 +7727,7 @@ panels:
           mode: absolute
           steps:
           - color: transparent
+            value: 0
           - color: red
             value: 0.9
         unit: s
@@ -7531,7 +7736,7 @@ panels:
       h: 8
       w: 12
       x: 0
-      "y": 8401
+      "y": 67
     id: 139
     options:
       legend:
@@ -7544,179 +7749,10 @@ panels:
         sortBy: Last *
         sortDesc: true
       tooltip:
+        hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 9.1.0
-    type: timeseries
-  - title: Storage reachability ($instance)
-    targets:
-    - datasource:
-        type: {{ $defaultDatasource }}
-        uid: $ds
-      expr: {{ printf "vm_rpc_vmstorage_is_reachable{job=~\"$job\",instance=~\"$instance\",%s=~\"$cluster\"} != 1" $clusterLabel }}
-      editorMode: code
-      format: time_series
-      interval: ""
-      intervalFactor: 1
-      legendFormat: '{{`{{`}}instance{{`}}`}} => {{`{{`}}addr{{`}}`}}'
-      range: true
-      refId: A
-    datasource:
-      type: {{ $defaultDatasource }}
-      uid: $ds
-    description: Shows when vmstorage node is unreachable for vminsert.
-    fieldConfig:
-      defaults:
-        color:
-          mode: palette-classic
-        custom:
-          axisCenteredZero: false
-          axisColorMode: text
-          axisLabel: ""
-          axisPlacement: auto
-          barAlignment: 0
-          drawStyle: line
-          fillOpacity: 0
-          gradientMode: none
-          hideFrom:
-            legend: false
-            tooltip: false
-            viz: false
-          lineInterpolation: linear
-          lineWidth: 1
-          pointSize: 5
-          scaleDistribution:
-            type: linear
-          showPoints: never
-          spanNulls: false
-          stacking:
-            group: A
-            mode: none
-          thresholdsStyle:
-            mode: "off"
-        decimals: 0
-        links: []
-        mappings: []
-        min: 0
-        thresholds:
-          mode: absolute
-          steps:
-          - color: green
-          - color: red
-            value: 80
-        unit: short
-      overrides: []
-    gridPos:
-      h: 8
-      w: 12
-      x: 12
-      "y": 8401
-    id: 114
-    options:
-      legend:
-        calcs:
-        - mean
-        - lastNotNull
-        displayMode: table
-        placement: bottom
-        showLegend: true
-      tooltip:
-        mode: multi
-        sort: desc
-    pluginVersion: 9.1.0
-    type: timeseries
-  - title: 'Network usage: clients ($instance)'
-    targets:
-    - datasource:
-        type: {{ $defaultDatasource }}
-        uid: $ds
-      expr: {{ printf "(sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job_insert\",instance=~\"$instance\",%s=~\"$cluster\"}[$__rate_interval])) by(%s) * 8) > 0" $clusterLabel $clusterLabel }}
-      editorMode: code
-      format: time_series
-      intervalFactor: 1
-      legendFormat: read from client
-      range: true
-      refId: A
-    - datasource:
-        type: {{ $defaultDatasource }}
-        uid: $ds
-      expr: {{ printf "(sum(rate(vm_tcplistener_written_bytes_total{job=~\"$job_insert\",instance=~\"$instance\",%s=~\"$cluster\"}[$__rate_interval])) by(%s) * 8) > 0" $clusterLabel $clusterLabel }}
-      editorMode: code
-      format: time_series
-      hide: false
-      intervalFactor: 1
-      legendFormat: write to client
-      range: true
-      refId: B
-    datasource:
-      type: {{ $defaultDatasource }}
-      uid: $ds
-    description: Shows network usage between vminserts and clients, such as vmagent, Prometheus, or any other client pushing metrics to vminsert.
-    fieldConfig:
-      defaults:
-        color:
-          mode: palette-classic
-        custom:
-          axisCenteredZero: false
-          axisColorMode: text
-          axisLabel: ""
-          axisPlacement: auto
-          barAlignment: 0
-          drawStyle: line
-          fillOpacity: 0
-          gradientMode: none
-          hideFrom:
-            legend: false
-            tooltip: false
-            viz: false
-          lineInterpolation: linear
-          lineWidth: 1
-          pointSize: 5
-          scaleDistribution:
-            type: linear
-          showPoints: never
-          spanNulls: false
-          stacking:
-            group: A
-            mode: none
-          thresholdsStyle:
-            mode: "off"
-        links: []
-        mappings: []
-        thresholds:
-          mode: absolute
-          steps:
-          - color: green
-          - color: red
-            value: 80
-        unit: bps
-      overrides:
-      - matcher:
-          id: byRegexp
-          options: /read.*/
-        properties:
-        - id: custom.transform
-          value: negative-Y
-    gridPos:
-      h: 8
-      w: 12
-      x: 0
-      "y": 8409
-    id: 208
-    options:
-      legend:
-        calcs:
-        - mean
-        - lastNotNull
-        displayMode: table
-        placement: bottom
-        showLegend: true
-        sortBy: Last *
-        sortDesc: true
-      tooltip:
-        mode: multi
-        sort: desc
-    pluginVersion: 9.1.0
+    pluginVersion: 12.4.3
     type: timeseries
   - title: 'Network usage: vmstorage ($instance)'
     targets:
@@ -7736,7 +7772,6 @@ panels:
       expr: {{ printf "(sum(rate(vm_tcpdialer_written_bytes_total{job=~\"$job_insert\",instance=~\"$instance\",%s=~\"$cluster\"}[$__rate_interval])) by(%s) * 8) > 0" $clusterLabel $clusterLabel }}
       editorMode: code
       format: time_series
-      hide: false
       intervalFactor: 1
       legendFormat: write to vmstorage
       range: true
@@ -7750,11 +7785,13 @@ panels:
         color:
           mode: palette-classic
         custom:
+          axisBorderShow: false
           axisCenteredZero: false
           axisColorMode: text
           axisLabel: ""
           axisPlacement: auto
           barAlignment: 0
+          barWidthFactor: 0.6
           drawStyle: line
           fillOpacity: 0
           gradientMode: none
@@ -7762,12 +7799,14 @@ panels:
             legend: false
             tooltip: false
             viz: false
+          insertNulls: false
           lineInterpolation: linear
           lineWidth: 1
           pointSize: 5
           scaleDistribution:
             type: linear
           showPoints: never
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -7780,6 +7819,7 @@ panels:
           mode: absolute
           steps:
           - color: green
+            value: 0
           - color: red
             value: 80
         unit: bps
@@ -7794,7 +7834,7 @@ panels:
       h: 8
       w: 12
       x: 12
-      "y": 8409
+      "y": 67
     id: 209
     options:
       legend:
@@ -7807,9 +7847,108 @@ panels:
         sortBy: Last *
         sortDesc: true
       tooltip:
+        hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 9.1.0
+    pluginVersion: 12.4.3
+    type: timeseries
+  - title: 'Network usage: clients ($instance)'
+    targets:
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: $ds
+      expr: {{ printf "(sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job_insert\",instance=~\"$instance\",%s=~\"$cluster\"}[$__rate_interval])) by(%s) * 8) > 0" $clusterLabel $clusterLabel }}
+      editorMode: code
+      format: time_series
+      intervalFactor: 1
+      legendFormat: read from client
+      range: true
+      refId: A
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: $ds
+      expr: {{ printf "(sum(rate(vm_tcplistener_written_bytes_total{job=~\"$job_insert\",instance=~\"$instance\",%s=~\"$cluster\"}[$__rate_interval])) by(%s) * 8) > 0" $clusterLabel $clusterLabel }}
+      editorMode: code
+      format: time_series
+      intervalFactor: 1
+      legendFormat: write to client
+      range: true
+      refId: B
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: $ds
+    description: Shows network usage between vminserts and clients, such as vmagent, Prometheus, or any other client pushing metrics to vminsert.
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          barWidthFactor: 0.6
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          showValues: false
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+          - color: green
+            value: 0
+          - color: red
+            value: 80
+        unit: bps
+      overrides:
+      - matcher:
+          id: byRegexp
+          options: /read.*/
+        properties:
+        - id: custom.transform
+          value: negative-Y
+    gridPos:
+      h: 8
+      w: 12
+      x: 0
+      "y": 75
+    id: 208
+    options:
+      legend:
+        calcs:
+        - mean
+        - lastNotNull
+        displayMode: table
+        placement: bottom
+        showLegend: true
+        sortBy: Last *
+        sortDesc: true
+      tooltip:
+        hideZeros: false
+        mode: multi
+        sort: desc
+    pluginVersion: 12.4.3
     type: timeseries
   - title: Rows per insert ($instance)
     targets:
@@ -7827,17 +7966,18 @@ panels:
     datasource:
       type: {{ $defaultDatasource }}
       uid: $ds
-    description: ""
     fieldConfig:
       defaults:
         color:
           mode: palette-classic
         custom:
+          axisBorderShow: false
           axisCenteredZero: false
           axisColorMode: text
           axisLabel: ""
           axisPlacement: auto
           barAlignment: 0
+          barWidthFactor: 0.6
           drawStyle: line
           fillOpacity: 0
           gradientMode: none
@@ -7845,12 +7985,14 @@ panels:
             legend: false
             tooltip: false
             viz: false
+          insertNulls: false
           lineInterpolation: linear
           lineWidth: 1
           pointSize: 5
           scaleDistribution:
             type: linear
           showPoints: never
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -7865,6 +8007,7 @@ panels:
           mode: absolute
           steps:
           - color: green
+            value: 0
           - color: red
             value: 80
         unit: short
@@ -7873,7 +8016,7 @@ panels:
       h: 8
       w: 12
       x: 12
-      "y": 8417
+      "y": 75
     id: 88
     options:
       legend:
@@ -7887,9 +8030,10 @@ panels:
         sortBy: Last *
         sortDesc: true
       tooltip:
+        hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 9.1.0
+    pluginVersion: 12.4.3
     type: timeseries
   collapsed: true
   gridPos:

--- a/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-vmagent.yaml
@@ -3082,7 +3082,7 @@ panels:
         sort: none
     pluginVersion: 12.2.0
     type: timeseries
-  - title: Datapoints rate ($instance)
+  - title: Rows rate ($instance)
     targets:
     - datasource:
         type: {{ $defaultDatasource }}
@@ -3091,13 +3091,22 @@ panels:
       editorMode: code
       exemplar: true
       interval: ""
-      legendFormat: '{{`{{`}} type {{`}}`}} ({{`{{`}}job{{`}}`}})'
+      legendFormat: 'sample: {{`{{`}} type {{`}}`}} ({{`{{`}}job{{`}}`}})'
       range: true
       refId: A
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: $ds
+      expr: {{ printf "sum(rate(vm_protoparser_metadata_read_total{job=~\"$job\",instance=~\"$instance\",%s=~\"$cluster\"}[$__rate_interval])) by(job,type,%s) > 0" $clusterLabel $clusterLabel }}
+      editorMode: code
+      instant: false
+      legendFormat: 'metadata: {{`{{`}} type {{`}}`}} ({{`{{`}}job{{`}}`}})'
+      range: true
+      refId: B
     datasource:
       type: {{ $defaultDatasource }}
       uid: $ds
-    description: Shows the rate of parsed datapoints from write or scrape requests.
+    description: "Shows the rate of data rows parsed from write requests and scraping. \nThere are two kinds of rows:\n1. Raw sample: each sample consists of a value and a timestamp, see https://docs.victoriametrics.com/victoriametrics/keyconcepts/#raw-samples \n2. Metric metadata: refers to descriptive information about metrics. It can be disabled by setting `-enableMetadata=false`, see https://docs.victoriametrics.com/victoriametrics/vmagent/#metric-metadata."
     fieldConfig:
       defaults:
         color:
@@ -3124,6 +3133,7 @@ panels:
           scaleDistribution:
             type: linear
           showPoints: never
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -3137,6 +3147,7 @@ panels:
           mode: absolute
           steps:
           - color: green
+            value: 0
           - color: red
             value: 80
         unit: short
@@ -3160,7 +3171,7 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 11.5.0
+    pluginVersion: 12.4.3
     type: timeseries
   - title: Invalid datapoints rate ($instance)
     targets:
@@ -4350,7 +4361,7 @@ panels:
         sort: desc
     pluginVersion: 9.2.6
     type: timeseries
-  - title: Rows rate  ($instance)
+  - title: Rows rate ($instance)
     targets:
     - datasource:
         type: {{ $defaultDatasource }}
@@ -4359,13 +4370,22 @@ panels:
       editorMode: code
       exemplar: true
       interval: ""
-      legendFormat: '{{`{{`}} type {{`}}`}} ({{`{{`}}job{{`}}`}})'
+      legendFormat: 'sample: {{`{{`}} type {{`}}`}} ({{`{{`}}job{{`}}`}})'
       range: true
       refId: A
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: $ds
+      expr: {{ printf "sum(rate(vmagent_metadata_inserted_total{job=~\"$job\",instance=~\"$instance\",%s=~\"$cluster\"}[$__rate_interval])) by(job,type,%s) > 0" $clusterLabel $clusterLabel }}
+      editorMode: code
+      instant: false
+      legendFormat: metadata:{{`{{`}} type {{`}}`}} ({{`{{`}}job{{`}}`}})
+      range: true
+      refId: B
     datasource:
       type: {{ $defaultDatasource }}
       uid: $ds
-    description: Shows the rate of rows ingested in vmagent via push protocols.
+    description: "Shows the rate of data rows ingested from write requests. There are two kinds of rows:\n1. Raw sample: each sample consists of a value and a timestamp, see https://docs.victoriametrics.com/victoriametrics/keyconcepts/#raw-samples. \n2. Metric metadata: refers to descriptive information about metrics. It can be disabled by setting `-enableMetadata=false`, see https://docs.victoriametrics.com/victoriametrics/vmagent/#metric-metadata."
     fieldConfig:
       defaults:
         color:
@@ -4377,6 +4397,7 @@ panels:
           axisLabel: ""
           axisPlacement: auto
           barAlignment: 0
+          barWidthFactor: 0.6
           drawStyle: line
           fillOpacity: 0
           gradientMode: none
@@ -4391,6 +4412,7 @@ panels:
           scaleDistribution:
             type: linear
           showPoints: never
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -4404,6 +4426,7 @@ panels:
           mode: absolute
           steps:
           - color: green
+            value: 0
           - color: red
             value: 80
         unit: short
@@ -4412,7 +4435,7 @@ panels:
       h: 8
       w: 12
       x: 12
-      "y": 3931
+      "y": 41
     id: 131
     options:
       legend:
@@ -4424,9 +4447,10 @@ panels:
         placement: bottom
         showLegend: true
       tooltip:
+        hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 9.2.6
+    pluginVersion: 12.4.3
     type: timeseries
   - title: Concurrent inserts ($instance)
     targets:
@@ -5768,6 +5792,392 @@ panels:
     "y": 42
   id: 58
   type: row
+- title: Kafka (Enterprise)
+  panels:
+  - title: Traffic (bytes)
+    targets:
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: ${ds}
+      expr: {{ printf "sum(rate(vmagent_remotewrite_kafka_sent_bytes_total{job=~\"$job\",%s=~\"$cluster\"}[$__rate_interval])) by(job,%s)" $clusterLabel $clusterLabel }}
+      editorMode: code
+      legendFormat: Produced to Kafka
+      range: true
+      refId: A
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: ${ds}
+      expr: {{ printf "0 - sum(rate(vmagent_kafka_consumer_read_bytes_total{job=~\"$job\",%s=~\"$cluster\"}[$__rate_interval])) by(job,%s)" $clusterLabel $clusterLabel }}
+      editorMode: code
+      legendFormat: Consumed from Kafka
+      range: true
+      refId: B
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: $ds
+    description: |-
+      Positive series show bytes written by vmagent producers into Kafka. Negative series show bytes read by vmagent consumers from Kafka. Read this together with Messages in / out: a stable byte rate with rising message rate usually means smaller Kafka payloads and higher per-message overhead. Producer Kafka metrics aggregate at job level because they do not expose the full remoteWrite URL label.
+
+      Docs: <a href="https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#estimating-message-size-and-rate" target="_blank">estimating message size and rate</a>. Kafka read docs: <a href="https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#reading-metrics" target="_blank">reading metrics</a>.
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: true
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          barWidthFactor: 0.6
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          showValues: false
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+          - color: green
+            value: null
+        unit: Bps
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 0
+      "y": 44
+    id: 164
+    links:
+    - title: 'Docs: estimating size/rate'
+      url: https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#estimating-message-size-and-rate
+    - title: 'Docs: reading metrics'
+      url: https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#reading-metrics
+    options:
+      legend:
+        calcs:
+        - mean
+        - lastNotNull
+        - max
+        displayMode: table
+        placement: bottom
+        showLegend: true
+      tooltip:
+        hideZeros: false
+        mode: multi
+        sort: none
+    pluginVersion: 12.2.0
+    type: timeseries
+  - title: Messages in / out
+    targets:
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: ${ds}
+      expr: {{ printf "sum(rate(vmagent_remotewrite_kafka_messages_sent_total{job=~\"$job\",%s=~\"$cluster\"}[$__rate_interval])) by(job,%s)" $clusterLabel $clusterLabel }}
+      editorMode: code
+      legendFormat: Produced to Kafka
+      range: true
+      refId: A
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: ${ds}
+      expr: {{ printf "0 - sum(rate(vmagent_kafka_messages_read_total{job=~\"$job\",%s=~\"$cluster\"}[$__rate_interval])) by(job,%s)" $clusterLabel $clusterLabel }}
+      editorMode: code
+      legendFormat: Consumed from Kafka
+      range: true
+      refId: B
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: $ds
+    description: |-
+      Positive series show Kafka messages produced by vmagent. Negative series show Kafka messages consumed by vmagent. Read this together with Traffic (bytes), because a stable byte rate with rising message rate usually means smaller Kafka messages and higher per-message overhead. Producer Kafka metrics aggregate at job level because they do not expose the full remoteWrite URL label.
+
+      Docs: <a href="https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#estimating-message-size-and-rate" target="_blank">estimating message size and rate</a>. Kafka read docs: <a href="https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#reading-metrics" target="_blank">reading metrics</a>.
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: true
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          barWidthFactor: 0.6
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          showValues: false
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+          - color: green
+            value: null
+        unit: ops
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 12
+      "y": 44
+    id: 165
+    links:
+    - title: 'Docs: estimating size/rate'
+      url: https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#estimating-message-size-and-rate
+    - title: 'Docs: reading metrics'
+      url: https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#reading-metrics
+    options:
+      legend:
+        calcs:
+        - mean
+        - lastNotNull
+        - max
+        displayMode: table
+        placement: bottom
+        showLegend: true
+      tooltip:
+        hideZeros: false
+        mode: multi
+        sort: none
+    pluginVersion: 12.2.0
+    type: timeseries
+  - title: Producer errors
+    targets:
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: ${ds}
+      expr: {{ printf "sum(rate(vmagent_remotewrite_kafka_messages_send_errors_total{job=~\"$job\",%s=~\"$cluster\"}[$__rate_interval])) by(job,%s)" $clusterLabel $clusterLabel }}
+      editorMode: code
+      legendFormat: Producer send errors
+      range: true
+      refId: A
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: ${ds}
+      expr: {{ printf "sum(rate(vmagent_remotewrite_kafka_messages_delivery_errors_total{job=~\"$job\",%s=~\"$cluster\"}[$__rate_interval])) by(job,%s)" $clusterLabel $clusterLabel }}
+      editorMode: code
+      legendFormat: Producer delivery errors
+      range: true
+      refId: B
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: $ds
+    description: |-
+      Kafka producer-side errors from vmagent remote write. This panel shows send errors and delivery errors reported by Kafka producers.
+
+      Kafka write docs: <a href="https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#writing-metrics" target="_blank">writing metrics</a>.
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          barWidthFactor: 0.6
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          showValues: false
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+          - color: green
+            value: 0
+          - color: red
+            value: 80
+        unit: ops
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 0
+      "y": 52
+    id: 167
+    links:
+    - title: 'Docs: writing metrics'
+      url: https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#writing-metrics
+    - title: 'Docs: reading metrics'
+      url: https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#reading-metrics
+    options:
+      legend:
+        calcs:
+        - mean
+        - lastNotNull
+        - max
+        displayMode: table
+        placement: bottom
+        showLegend: true
+      tooltip:
+        hideZeros: false
+        mode: multi
+        sort: none
+    pluginVersion: 12.2.0
+    type: timeseries
+  - title: Consumer errors
+    targets:
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: ${ds}
+      expr: {{ printf "sum(rate(vmagent_kafka_client_errors_total{job=~\"$job\",%s=~\"$cluster\"}[$__rate_interval])) by(job,%s)" $clusterLabel $clusterLabel }}
+      editorMode: code
+      legendFormat: Consumer client errors
+      range: true
+      refId: C
+    - datasource:
+        type: {{ $defaultDatasource }}
+        uid: ${ds}
+      expr: {{ printf "sum(rate(vmagent_kafka_ingest_errors_total{job=~\"$job\",%s=~\"$cluster\"}[$__rate_interval])) by(job,%s)" $clusterLabel $clusterLabel }}
+      editorMode: code
+      legendFormat: Consumer ingest errors
+      range: true
+      refId: D
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: $ds
+    description: |-
+      Kafka consumer-side errors from vmagent. This panel shows client errors and ingest errors reported while reading from Kafka and passing data further downstream.
+
+      Kafka read docs: <a href="https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#reading-metrics" target="_blank">reading metrics</a>.
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          barWidthFactor: 0.6
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          showValues: false
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+          - color: green
+            value: 0
+          - color: red
+            value: 80
+        unit: ops
+      overrides: []
+    gridPos:
+      h: 8
+      w: 12
+      x: 12
+      "y": 52
+    id: 168
+    links:
+    - title: 'Docs: reading metrics'
+      url: https://docs.victoriametrics.com/victoriametrics/integrations/kafka/#reading-metrics
+    options:
+      legend:
+        calcs:
+        - mean
+        - lastNotNull
+        - max
+        displayMode: table
+        placement: bottom
+        showLegend: true
+      tooltip:
+        hideZeros: false
+        mode: multi
+        sort: none
+    pluginVersion: 12.2.0
+    type: timeseries
+  collapsed: true
+  gridPos:
+    h: 1
+    w: 24
+    x: 0
+    "y": 43
+  id: 163
+  type: row
 - title: Drilldown
   panels:
   - fieldConfig:
@@ -6431,7 +6841,7 @@ panels:
     h: 1
     w: 24
     x: 0
-    "y": 43
+    "y": 60
   id: 113
   type: row
 condition: {{ ($Values.vmagent).enabled }}

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-apps.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-apps.yaml
@@ -18,7 +18,7 @@ rules:
   labels:
     severity: warning
 - alert: KubePodNotReady
-  expr: {{ printf "sum(max(kube_pod_status_phase{namespace=~\"%s\",job=\"kube-state-metrics\",phase=~\"Pending|Unknown\"}) by(namespace,pod,job,%s) * on(namespace,pod,%s) group_left(owner_kind) topk(1, max(kube_pod_owner{owner_kind!=\"Job\"}) by(namespace,pod,owner_kind,%s)) by(namespace,pod,%s)) by(namespace,pod,job,%s) > 0" .targetNamespace $groupLabels $groupLabels $groupLabels $groupLabels $groupLabels }}
+  expr: {{ printf "sum(max(kube_pod_status_phase{namespace=~\"%s\",job=\"kube-state-metrics\",phase=~\"Pending|Unknown\"}) by(namespace,pod,job,%s) * on(namespace,pod,%s) group_left() topk(1, max(kube_pod_owner{owner_kind!=\"Job\"}) by(namespace,pod,owner_kind,%s)) by(namespace,pod,%s)) by(namespace,pod,job,%s) > 0" .targetNamespace $groupLabels $groupLabels $groupLabels $groupLabels $groupLabels }}
   annotations:
     description: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} has been in a non-ready state for longer than 15 minutes on cluster {{`{{`}} $labels.{{ $clusterLabel }} {{`}}`}}.
     runbook_url: {{ $runbookUrl }}/kubernetes/kubepodnotready

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-apiserver.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-apiserver.yaml
@@ -57,6 +57,16 @@ rules:
   for: 15m
   labels:
     severity: critical
+- alert: KubeAPIInstanceUnreachable
+  expr: up{job="apiserver"} == 0
+  annotations:
+    description: A KubeAPI instance has been unreachable for more than 15 minutes.
+    runbook_url: {{ $runbookUrl }}/kubernetes/kubeapiinstanceunreachable
+    summary: KubeAPI instance is unreachable.
+  condition: true
+  for: 15m
+  labels:
+    severity: warning
 - alert: KubeAPITerminatedRequests
   expr: {{ printf "(sum(rate(apiserver_request_terminations_total{job=\"apiserver\"}[10m])) by(%s) / (sum(rate(apiserver_request_total{job=\"apiserver\"}[10m])) by(%s) + sum(rate(apiserver_request_terminations_total{job=\"apiserver\"}[10m])) by(%s))) > 0.20" $groupLabels $groupLabels $groupLabels }}
   annotations:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-controller-manager.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-controller-manager.yaml
@@ -17,4 +17,14 @@ rules:
   for: 15m
   labels:
     severity: critical
+- alert: KubeControllerManagerInstanceUnreachable
+  expr: up{job="kube-controller-manager"} == 0
+  annotations:
+    description: A KubeControllerManager instance has been unreachable for more than 15 minutes.
+    runbook_url: {{ $runbookUrl }}/kubernetes/kubecontrollermanagerinstanceunreachable
+    summary: KubeControllerManager instance is unreachable.
+  condition: true
+  for: 15m
+  labels:
+    severity: warning
 condition: {{ ($Values.kubeControllerManager).enabled }}

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-kubelet.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-kubelet.yaml
@@ -143,6 +143,16 @@ rules:
   for: 15m
   labels:
     severity: warning
+- alert: KubeletInstanceUnreachable
+  expr: up{job="kubelet",metrics_path="/metrics"} == 0
+  annotations:
+    description: A Kubelet instance has been unreachable for more than 15 minutes.
+    runbook_url: {{ $runbookUrl }}/kubernetes/kubeletinstanceunreachable
+    summary: Kubelet instance is unreachable.
+  condition: true
+  for: 15m
+  labels:
+    severity: warning
 - alert: KubeletDown
   expr: {{ printf "count(kube_node_info{job=\"kube-state-metrics\"}) by(%s) unless on(%s) count(up{job=\"kubelet\",metrics_path=\"/metrics\"} == 1) by(%s)" $groupLabels $groupLabels $groupLabels }}
   annotations:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-scheduler.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-scheduler.yaml
@@ -17,4 +17,14 @@ rules:
   for: 15m
   labels:
     severity: critical
+- alert: KubeSchedulerInstanceUnreachable
+  expr: up{job="kube-scheduler"} == 0
+  annotations:
+    description: A KubeScheduler instance has been unreachable for more than 15 minutes.
+    runbook_url: {{ $runbookUrl }}/kubernetes/kubeschedulerinstanceunreachable
+    summary: KubeScheduler instance is unreachable.
+  condition: true
+  for: 15m
+  labels:
+    severity: warning
 condition: {{ ($Values.kubeScheduler).enabled }}

--- a/hack/rules-and-dashboards/main.go
+++ b/hack/rules-and-dashboards/main.go
@@ -90,7 +90,7 @@ var alertsMap = map[string]string{
 
 // Dashboards map
 var dashboardsMap = map[string]string{
-	"vector-k8s-monitoring":         "",
+	"vector-k8s-monitoring":         "($Values.vector).enabled",
 	"victorialogs-single-node":      "($Values.vlogs).enabled",
 	"alertmanager-overview":         "($Values.alertmanager).enabled",
 	"kubernetes-system-api-server":  "($Values.kubeApiServer).enabled",


### PR DESCRIPTION
Fixes #2896 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only deploy the `vector-k8s-monitoring` dashboard when Vector is enabled by adding the `($Values.vector).enabled` condition. Regenerated dashboards and rules include a kubelet running-container filter, new control-plane unreachable alerts, VictoriaMetrics “Rows rate” with metadata tracking and Kafka panels, plus minor Grafana cleanup.

<sup>Written for commit ed517280b2bb1dcb833405a7efe72c7c2b981cc1. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2897?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

