### PR TITLE
chore: add renovate markers for MCP images

### DIFF
--- a/charts/victoria-logs-mcp/Chart.yaml
+++ b/charts/victoria-logs-mcp/Chart.yaml
@@ -3,6 +3,7 @@ name: victoria-logs-mcp
 description: A Helm chart for VictoriaLogs MCP server
 type: application
 version: 0.1.0
+# renovate: image=ghcr.io/victoriametrics/mcp-victorialogs
 appVersion: v1.9.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts

--- a/charts/victoria-metrics-mcp/Chart.yaml
+++ b/charts/victoria-metrics-mcp/Chart.yaml
@@ -3,6 +3,7 @@ name: victoria-metrics-mcp
 description: A Helm chart for VictoriaMetrics MCP server
 type: application
 version: 0.2.0
+# renovate: image=ghcr.io/victoriametrics/mcp-victoriametrics
 appVersion: v1.19.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts


### PR DESCRIPTION
This would make Renovate create PRs to update charts when new MCP images released