### PR TITLE
victoria-logs-collector: fix VMPodScrape relabelConfigs and add missing podMonitor values

### DIFF
--- a/charts/victoria-logs-collector/templates/monitor.yaml
+++ b/charts/victoria-logs-collector/templates/monitor.yaml
@@ -34,10 +34,19 @@ spec:
       {{- with $podMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- if $podMonitor.vm }}
+      {{- with $podMonitor.relabelings }}
+      relabelConfigs: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $podMonitor.metricRelabelings }}
+      metricRelabelConfigs: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- else }}
       {{- with $podMonitor.relabelings }}
       relabelings: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with $podMonitor.metricRelabelings }}
       metricRelabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/victoria-logs-collector/values.yaml
+++ b/charts/victoria-logs-collector/values.yaml
@@ -218,6 +218,14 @@ podMonitor:
   annotations: {}
   # -- Whether to use [VMPodScrape](https://docs.victoriametrics.com/operator/resources/vmpodscrape/) from VM operator instead of PodMonitor.
   vm: false
+  # -- Scrape interval, for example 30s
+  interval: ""
+  # -- Scrape timeout, for example 10s
+  scrapeTimeout: ""
+  # -- Relabeling rules
+  relabelings: []
+  # -- Metric relabeling rules
+  metricRelabelings: []
 
 # -- vlagent extra command line arguments.
 extraArgs:


### PR DESCRIPTION
## Problem
When `podMonitor.vm` is `true`, the chart renders an invalid `VMPodScrape` spec. The template uses `relabelings` and `metricRelabelings` instead of the correct `relabelConfigs` and `metricRelabelConfigs` fields required by the VictoriaMetrics Operator.

Closes #2917 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid `VMPodScrape` specs when `podMonitor.vm` is true by using `relabelConfigs` and `metricRelabelConfigs`. Also adds missing `podMonitor` values for interval, scrapeTimeout, relabelings, and metricRelabelings.

- **Bug Fixes**
  - Use `relabelConfigs`/`metricRelabelConfigs` for `VMPodScrape`; keep `relabelings`/`metricRelabelings` for `PodMonitor`.

- **New Features**
  - Expose `podMonitor.interval`, `podMonitor.scrapeTimeout`, `podMonitor.relabelings`, and `podMonitor.metricRelabelings` in `values.yaml`.

<sup>Written for commit 7296c53a81df16c14ee45d15e66a1a836b56cf4f. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2918?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

