### PR TITLE
victoria-(logs|traces)-(single|cluster): support multiple HTTP and Syslog listen addresses configuration

### DIFF
--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Next release
 
-- TODO
+**Update note 1**: `.Values.<component>.extraArgs.httpListenAddr` was replaced by `.Values.<component>.http` array of HTTP listen address configuration, where `<component>` is one of `vlinsert`, `vlselect`, `vlstorage`, `vmauth`.
+
+- added `.Values.<component>.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Item with `primary: true` on `vlstorage` is used for storageNode address resolution.
+- support `.Values.vlinsert.syslog.tcp` and `.Values.vlinsert.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings.
 
 ## 0.1.5
 

--- a/charts/victoria-logs-cluster/Chart.lock
+++ b/charts/victoria-logs-cluster/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.52.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:2ed29f6e03ca10a4d2d316bdff3fbbea4c23229718ab7bc409a16055aa8abed8
-generated: "2026-04-23T05:14:26.335754154Z"
+  version: 0.3.1
+digest: sha256:8d1c6166fa42cb0d983c7e44c0bf8b4bb11dea9a1d6c964827454eed24d2decb
+generated: "2026-05-21T16:13:16.660527+03:00"

--- a/charts/victoria-logs-cluster/templates/_helpers.tpl
+++ b/charts/victoria-logs-cluster/templates/_helpers.tpl
@@ -1,15 +1,43 @@
+{{- define "vl.syslog.args" -}}
+  {{- $args := dict }}
+  {{- range $kind, $sls := . }}
+    {{- range $i, $sl := $sls -}}
+      {{- if not $sl.value -}}
+        {{- fail (printf "`value` is not set for `syslog.%s` idx %d" $kind $i) -}}
+      {{- end -}}
+      {{- range $slKey, $slValue := (omit $sl "name") -}}
+        {{- $key := ternary "listenAddr" $slKey (eq $slKey "value") -}}
+        {{- $key = ternary (printf "syslog.%s" $key) (printf "syslog.%s.%s" $key $kind) (hasPrefix "tls" $key) -}}
+        {{- $param := index $args $key | default list -}}
+        {{- if $slValue -}}
+          {{- range until (int (sub $i (len $param))) }}
+            {{- $param = append $param "" }}
+          {{- end }}
+          {{- $param = append $param $slValue }}
+          {{- $_ := set $args $key $param -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- toYaml $args -}}
+{{- end -}}
+
+
 {{- define "vlinsert.args" -}}
   {{- $Values := (.helm).Values | default .Values -}}
   {{- $app := $Values.vlinsert -}}
   {{- $args := dict "select.disable" "true" -}}
   {{- $ctx := dict "style" "plain" "appKey" "vlstorage" "helm" .helm }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" $ctx)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $app.syslog)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- $storage := $Values.vlstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
     {{- $fqdn := include "vm.fqdn" $ctx }}
-    {{- $port := include "vm.port.from.flag" (dict "flag" $Values.vlstorage.extraArgs.httpListenAddr "default" "9491") }}
+    {{- $port := include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" $Values.vlstorage.http) "default" "9491") }}
     {{- range $i := until ($storage.replicaCount | int) -}}
       {{- if not (has (float64 $i) $app.excludeStorageIDs) -}}
         {{- $_ := set $ctx "appIdx" $i }}
@@ -32,6 +60,8 @@
   {{- $args := dict -}}
   {{- $_ := set $args "auth.config" "/config/auth.yml" -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
@@ -42,12 +72,14 @@
   {{- $args := dict "insert.disable" "true" -}}
   {{- $ctx := dict "style" "plain" "appKey" "vlstorage" "helm" .helm }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- $storage := $Values.vlstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
     {{- $fqdn := include "vm.fqdn" $ctx }}
-    {{- $port := include "vm.port.from.flag" (dict "flag" $Values.vlstorage.extraArgs.httpListenAddr "default" "9491") }}
+    {{- $port := include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" $Values.vlstorage.http) "default" "9491") }}
     {{- range $i := until ($storage.replicaCount | int) -}}
       {{- $_ := set $ctx "appIdx" $i }}
       {{- $storageNode := include "vm.fqdn" $ctx -}}
@@ -85,17 +117,21 @@
   {{- end -}}
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
 
 {{- define "vlselect.ports" -}}
-{{- $service := .service }}
-{{- $extraArgs := .extraArgs -}}
-- name: http
-  port: {{ $service.servicePort }}
+{{- $service := .service -}}
+{{- range .http }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9471") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ $service.targetPort }}
+  targetPort: {{ .name }}
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}
@@ -105,12 +141,26 @@
 {{- end -}}
 
 {{- define "vlinsert.ports" -}}
-{{- $service := .service }}
-{{- $extraArgs := .extraArgs -}}
-- name: http
-  port: {{ $service.servicePort }}
+{{- $service := .service -}}
+{{- range .http }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9481") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ $service.targetPort }}
+  targetPort: {{ .name }}
+{{- end }}
+{{- range .syslog.tcp }}
+- name: {{ .name }}
+  port: {{ include "vm.port.from.flag" (dict "flag" .value) }}
+  protocol: TCP
+  targetPort: {{ .name }}
+{{- end }}
+{{- range .syslog.udp }}
+- name: {{ .name }}
+  port: {{ include "vm.port.from.flag" (dict "flag" .value) }}
+  protocol: UDP
+  targetPort: {{ .name }}
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}
@@ -121,10 +171,13 @@
 
 {{- define "vlstorage.ports" -}}
 {{- $service := .service -}}
-- port: {{ $service.servicePort }}
-  targetPort: http
+{{- range .http }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9491") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
   protocol: TCP
-  name: http
+  targetPort: {{ .name }}
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}
@@ -135,10 +188,13 @@
 
 {{- define "vmauth.ports" -}}
 {{- $service := .service -}}
-- port: {{ $service.servicePort }}
-  targetPort: http
-  protocol: TCP 
-  name: http 
+{{- range .http }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  protocol: TCP
+  targetPort: {{ .name }}
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}

--- a/charts/victoria-logs-cluster/templates/route.yaml
+++ b/charts/victoria-logs-cluster/templates/route.yaml
@@ -28,7 +28,7 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" ($app.extraArgs).httpListenAddr)) }}
+          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" $app.http))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-logs-cluster/templates/vlinsert-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlinsert-server.yaml
@@ -63,8 +63,19 @@ spec:
           env: {{ tpl (toYaml .) $ctx | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $app.ports.name  | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "9481") }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "9481") }}
+            {{- end }}
+            {{- range $app.syslog.tcp }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "514") }}
+            {{- end }}
+            {{- range $app.syslog.udp }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "514") }}
+              protocol: UDP
+            {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-logs-cluster/templates/vlselect-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlselect-server.yaml
@@ -63,8 +63,10 @@ spec:
           env: {{ tpl (toYaml .) $ctx | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $app.ports.name  | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "9481") }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "9471") }}
+            {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-logs-cluster/templates/vlstorage-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlstorage-server.yaml
@@ -56,8 +56,10 @@ spec:
           {{- end }}
           args: {{ include "vlstorage.args" $ctx | nindent 12 }}
           ports:
-            - name: {{ $app.ports.name | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "9491") }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "9491") }}
+            {{- end }}
           {{- with $app.envFrom }}
           envFrom: {{ tpl (toYaml .) $ctx | nindent 12 }}
           {{- end }}

--- a/charts/victoria-logs-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vmauth-server.yaml
@@ -70,8 +70,10 @@ spec:
           env: {{ tpl (toYaml .) $ctx | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $app.ports.name  | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8427") }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
+            {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-logs-cluster/tests/vlinsert_test.yaml
+++ b/charts/victoria-logs-cluster/tests/vlinsert_test.yaml
@@ -25,8 +25,10 @@ tests:
             cpu: 100m
             memory: 200Mi
       vlstorage:
-        extraArgs:
-          httpListenAddr: :9492
+        http:
+          - name: http
+            value: :9492
+            primary: true
     asserts:
       - matchSnapshot: {}
   - it: should render tpl in env and envFrom

--- a/charts/victoria-logs-cluster/tests/vlselect_test.yaml
+++ b/charts/victoria-logs-cluster/tests/vlselect_test.yaml
@@ -25,8 +25,10 @@ tests:
             cpu: 100m
             memory: 200Mi
       vlstorage:
-        extraArgs:
-          httpListenAddr: :9492
+        http:
+          - name: http
+            value: :9492
+            primary: true
     asserts:
       - matchSnapshot: {}
   - it: should render tpl in env and envFrom

--- a/charts/victoria-logs-cluster/tests/vlstorage_test.yaml
+++ b/charts/victoria-logs-cluster/tests/vlstorage_test.yaml
@@ -18,8 +18,10 @@ tests:
         podLabels:
           podLabelName: podLabelValue
         retentionDiskSpaceUsage: 100
-        extraArgs:
-          httpListenAddr: :9492
+        http:
+          - name: http
+            primary: true
+            value: :9492
     asserts:
       - matchSnapshot: {}
   - it: should render tpl in env and envFrom

--- a/charts/victoria-logs-cluster/values.yaml
+++ b/charts/victoria-logs-cluster/values.yaml
@@ -70,20 +70,31 @@ vlselect:
     pullPolicy: IfNotPresent
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports: 
-    # -- vlselect http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vlselect component
   fullnameOverride: ""
   # -- Suppress rendering `--storageNode` FQDNs based on `vlstorage.replicaCount` value. If true suppress rendering `--storageNode`, they can be re-defined in extraArgs
   suppressStorageFQDNsRender: false
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :9471
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
+
   # -- Extra command line arguments for vlselect component
   extraArgs:
     envflag.enable: true
     loggerFormat: json
-    httpListenAddr: :9471
     http.shutdownDelay: 15s
   # -- Pod's termination grace period in seconds
   terminationGracePeriodSeconds: 60
@@ -259,9 +270,7 @@ vlselect:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 9471
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
     healthCheckNodePort: ""
     # -- Service external traffic policy. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -361,7 +370,7 @@ vlinsert:
     # -- Image repository
     repository: victoriametrics/victoria-logs
     # -- Image tag
-    # override Chart.AppVersion    
+    # override Chart.AppVersion
     tag: ""
     # -- Image tag suffix, which is appended to `Chart.AppVersion` if no `server.image.tag` is defined
     variant: ""
@@ -369,18 +378,46 @@ vlinsert:
     pullPolicy: IfNotPresent
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports:
-    # -- vlinsert http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vlinsert component
   fullnameOverride: ""
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :9481
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
+  # -- List of Syslog listen addresses
+  syslog:
+    udp: []
+    tcp: []
+    #  - name: syslog-tcp
+    #    value: :514
+    #    tls: false
+    #    tlsCertFile: ""
+    #    tlsKeyFile: ""
+    #    tlsMinVersion: ""
+    #    streamFields: ""
+    #    ignoreFields: ""
+    #    decolorizeFields: ""
+    #    extraFields: ""
+    #    tenantID: ""
+    #    compressMethod: ""
+    #    useLocalTimestamp: false
+    #    useRemoteIP: false
   # -- Extra command line arguments for vlinsert component
   extraArgs:
     envflag.enable: true
     loggerFormat: json
-    httpListenAddr: :9481
     http.shutdownDelay: 15s
   # -- Deployment annotations
   annotations: {}
@@ -561,9 +598,7 @@ vlinsert:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 9481
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
     healthCheckNodePort: ""
     # -- Service external traffic policy. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -667,9 +702,6 @@ vlstorage:
     pullPolicy: IfNotPresent
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports: 
-    # -- vlstorage http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vlstorage component
@@ -689,12 +721,24 @@ vlstorage:
   retentionDiskSpaceUsage: ""
   # -- Data retention max percentile capacity. See these [docs](https://docs.victoriametrics.com/victorialogs/#percentage-based-disk-space-limit)
   retentionMaxDiskUsagePercent: ""
-  
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :9491
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
   # -- Additional vlstorage container arguments. Extra command line arguments for vlstorage component
   extraArgs:
     envflag.enable: true
     loggerFormat: json
-    httpListenAddr: :9491
     http.shutdownDelay: 15s
   # -- Extra Volumes for the pod
   extraVolumes:
@@ -758,7 +802,7 @@ vlstorage:
     accessModes:
       - ReadWriteOnce
 
-    # -- VolumeClassAttribute to user for persistent volume 
+    # -- VolumeClassAttribute to user for persistent volume
     volumeAttributesClassName:
 
     # -- Persistent volume annotations
@@ -832,9 +876,7 @@ vlstorage:
     # -- Service labels
     labels: {}
     # -- Service port
-    servicePort: 9491
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Extra service ports
     extraPorts: []
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -951,18 +993,28 @@ vmauth:
     pullPolicy: IfNotPresent
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports:
-    # -- VMAuth http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vmauth component
   fullnameOverride: ""
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :8427
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
   # -- Extra command line arguments for vmauth component
   extraArgs:
     envflag.enable: true
     loggerFormat: json
-    httpListenAddr: :8427
     http.shutdownDelay: 15s
   # -- VMAuth annotations
   annotations: {}
@@ -1135,9 +1187,7 @@ vmauth:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 8427
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update note 1**: `.Values.<component>.extraArgs.httpListenAddr` was replaced by `.Values.<component>.http` array of HTTP listen address configuration, where `<component>` is one of `vlselect`, `vmauth`.
+
+- added `.Values.<component>.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
 
 ## 0.1.1
 

--- a/charts/victoria-logs-multilevel/Chart.lock
+++ b/charts/victoria-logs-multilevel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
-generated: "2026-04-16T10:13:18.912481552Z"
+  version: 0.3.1
+digest: sha256:6b3a43e93a5a4f9e38cdbbefa43841665b62b429f570e19d5e64c366fd2eabe7
+generated: "2026-05-21T16:13:52.029079+03:00"

--- a/charts/victoria-logs-multilevel/templates/_helpers.tpl
+++ b/charts/victoria-logs-multilevel/templates/_helpers.tpl
@@ -4,6 +4,8 @@
   {{- $args := dict -}}
   {{- $_ := set $args "auth.config" "/config/auth.yml" -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
@@ -13,6 +15,8 @@
   {{- $app := $Values.vlselect -}}
   {{- $args := dict -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- $storageNodes := $args.storageNodes | default list }}
   {{- with $Values.storageNodes }}
@@ -26,12 +30,14 @@
 {{- end -}}
 
 {{- define "vlselect.ports" -}}
-{{- $service := .service }}
-{{- $extraArgs := .extraArgs -}}
-- name: http
-  port: {{ $service.servicePort }}
+{{- $service := .service -}}
+{{- range .http }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9471") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ $service.targetPort }}
+  targetPort: {{ .name }}
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}
@@ -42,11 +48,14 @@
 
 {{- define "vmauth.ports" -}}
 {{- $service := .service -}}
-- port: {{ $service.servicePort }}
-  targetPort: http
-  protocol: TCP 
-  name: http 
-{{- range $service.extraPorts }}
+{{- range .http }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  protocol: TCP
+  targetPort: {{ .name }}
+{{- end }}
+{{- range $service.extraPorts }} 
 - name: {{ .name }}
   port: {{ .port }}
   protocol: TCP

--- a/charts/victoria-logs-multilevel/templates/route.yaml
+++ b/charts/victoria-logs-multilevel/templates/route.yaml
@@ -28,7 +28,7 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" ($app.extraArgs).httpListenAddr)) }}
+          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" $app.http))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-logs-multilevel/templates/vlselect-server.yaml
+++ b/charts/victoria-logs-multilevel/templates/vlselect-server.yaml
@@ -63,8 +63,10 @@ spec:
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $app.ports.name  | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "9481") }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "9481") }}
+            {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-logs-multilevel/templates/vmauth-server.yaml
+++ b/charts/victoria-logs-multilevel/templates/vmauth-server.yaml
@@ -70,8 +70,10 @@ spec:
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $app.ports.name  | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8427") }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
+            {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-logs-multilevel/values.yaml
+++ b/charts/victoria-logs-multilevel/values.yaml
@@ -73,18 +73,28 @@ vlselect:
     pullPolicy: IfNotPresent
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports: 
-    # -- vlselect http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vlselect component
   fullnameOverride: ""
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :9471
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
   # -- Extra command line arguments for vlselect component
   extraArgs:
     envflag.enable: true
     loggerFormat: json
-    httpListenAddr: :9471
     http.shutdownDelay: 15s
   # -- Pod's termination grace period in seconds
   terminationGracePeriodSeconds: 60
@@ -256,9 +266,7 @@ vlselect:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 9471
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -372,18 +380,28 @@ vmauth:
     pullPolicy: IfNotPresent
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports:
-    # -- VMAuth http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vmauth component
   fullnameOverride: ""
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :8427
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
   # -- Extra command line arguments for vmauth component
   extraArgs:
     envflag.enable: true
     loggerFormat: json
-    httpListenAddr: :8427
     http.shutdownDelay: 15s
   # -- VMAuth annotations
   annotations: {}
@@ -554,9 +572,7 @@ vmauth:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 8427
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Next release
 
-- TODO
+**Update note 1**: `.Values.server.extraArgs.httpListenAddr` was replaced by `.Values.server.http` array of HTTP listen address configuration.
+
+- added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
+- support `.Values.server.syslog.tcp` and `.Values.server.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings.
 
 ## 0.12.5
 

--- a/charts/victoria-logs-single/Chart.lock
+++ b/charts/victoria-logs-single/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.52.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:2ed29f6e03ca10a4d2d316bdff3fbbea4c23229718ab7bc409a16055aa8abed8
-generated: "2026-04-23T05:14:38.628820141Z"
+  version: 0.3.1
+digest: sha256:8d1c6166fa42cb0d983c7e44c0bf8b4bb11dea9a1d6c964827454eed24d2decb
+generated: "2026-05-21T16:13:25.975028+03:00"

--- a/charts/victoria-logs-single/templates/_helpers.tpl
+++ b/charts/victoria-logs-single/templates/_helpers.tpl
@@ -1,3 +1,28 @@
+
+{{- define "vl.syslog.args" -}}
+  {{- $args := dict }}
+  {{- range $kind, $sls := . }}
+    {{- range $i, $sl := $sls -}}
+      {{- if not $sl.value -}}
+        {{- fail (printf "`value` is not set for `syslog.%s` idx %d" $kind $i) -}}
+      {{- end -}}
+      {{- range $slKey, $slValue := (omit $sl "name") -}}
+        {{- $key := ternary "listenAddr" $slKey (eq $slKey "value") -}}
+        {{- $key = ternary (printf "syslog.%s" $key) (printf "syslog.%s.%s" $key $kind) (hasPrefix "tls" $key) -}}
+        {{- $param := index $args $key | default list -}}
+        {{- if $slValue -}}
+          {{- range until (int (sub $i (len $param))) }}
+            {{- $param = append $param "" }}
+          {{- end }}
+          {{- $param = append $param $slValue }}
+          {{- $_ := set $args $key $param -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- toYaml $args -}}
+{{- end -}}
+
 {{- define "vlogs.args" -}}
   {{- $Values := (.helm).Values | default .Values }}
   {{- $app := $Values.server -}}
@@ -21,6 +46,9 @@
   {{- end -}}
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $app.syslog)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}

--- a/charts/victoria-logs-single/templates/route.yaml
+++ b/charts/victoria-logs-single/templates/route.yaml
@@ -29,7 +29,7 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" ($app.extraArgs).httpListenAddr)) }}
+          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" $app.http))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-logs-single/templates/server.yaml
+++ b/charts/victoria-logs-single/templates/server.yaml
@@ -80,8 +80,19 @@ spec:
           env: {{ tpl (toYaml .) $ctx | nindent 12 }}
           {{- end }}
           ports:
-            - name: http
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "9428") }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "9428") }}
+            {{- end }}
+            {{- range $app.syslog.tcp }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "514") }}
+            {{- end }}
+            {{- range $app.syslog.udp }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "514") }}
+              protocol: UDP
+            {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-logs-single/templates/service.yaml
+++ b/charts/victoria-logs-single/templates/service.yaml
@@ -54,13 +54,28 @@ spec:
   ipFamilies: {{ toYaml . | nindent 4 }}
   {{- end }}
   ports:
-    - name: http
-      port: {{ $service.servicePort }}
+    {{- range $app.http }}
+    - name: {{ .name }}
+      {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9428") }}
+      port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
       protocol: TCP
-      targetPort: {{ $service.targetPort }}
-      {{- with $service.nodePort }}
-      nodePort: {{ . }}
+      targetPort: {{ .name }}
+      {{- if and .primary $service.nodePort }}
+      nodePort: {{ $service.nodePort }}
       {{- end }}
+    {{- end }}
+    {{- range $app.syslog.tcp }}
+    - name: {{ .name }}
+      port: {{ include "vm.port.from.flag" (dict "flag" .value) }}
+      protocol: TCP
+      targetPort: {{ .name }}
+    {{- end }}
+    {{- range $app.syslog.udp }}
+    - name: {{ .name }}
+      port: {{ include "vm.port.from.flag" (dict "flag" .value) }}
+      protocol: UDP
+      targetPort: {{ .name }}
+    {{- end }}
     {{- range $service.extraPorts }}
     - name: {{ .name }}
       port: {{ .port }}

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -78,12 +78,43 @@ server:
   retentionDiskSpaceUsage: ""
   # -- Data retention max percentile capacity. See these [docs](https://docs.victoriametrics.com/victorialogs/#percentage-based-disk-space-limit)
   retentionMaxDiskUsagePercent: ""
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :9428
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
+  # -- List of Syslog listen addresses
+  syslog:
+    udp: []
+    tcp: []
+    #  - name: syslog-tcp
+    #    value: :514
+    #    tls: false
+    #    tlsCertFile: ""
+    #    tlsKeyFile: ""
+    #    tlsMinVersion: ""
+    #    streamFields: ""
+    #    ignoreFields: ""
+    #    decolorizeFields: ""
+    #    extraFields: ""
+    #    tenantID: ""
+    #    compressMethod: ""
+    #    useLocalTimestamp: false
+    #    useRemoteIP: false
   # -- Extra command line arguments for container of component
   extraArgs:
     envflag.enable: true
     envflag.prefix: VM_
     loggerFormat: json
-    httpListenAddr: :9428
     http.shutdownDelay: 15s
   # -- Specify pod lifecycle
   lifecycle: {}
@@ -318,10 +349,8 @@ server:
     loadBalancerIP: ""
     # -- Load balancer source range
     loadBalancerSourceRanges: []
-    # -- Target port
-    targetPort: http
     # -- Service port
-    servicePort: 9428
+    servicePort: ""
     # -- Node port
     # nodePort: 30000
     # -- Service type

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update note 1**: `.Values.<component>.extraArgs.httpListenAddr` was replaced by `.Values.<component>.http` array of HTTP listen address configuration, where `<component>` is one of `vtinsert`, `vtselect`, `vtstorage`, `vmauth`.
+
+- added `.Values.<component>.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Item with `primary: true` on `vtstorage` is used for storageNode address resolution.
 
 ## 0.1.3
 

--- a/charts/victoria-traces-cluster/Chart.lock
+++ b/charts/victoria-traces-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
-generated: "2026-04-16T10:14:22.242227845Z"
+  version: 0.3.1
+digest: sha256:6b3a43e93a5a4f9e38cdbbefa43841665b62b429f570e19d5e64c366fd2eabe7
+generated: "2026-05-21T16:13:43.043749+03:00"

--- a/charts/victoria-traces-cluster/templates/_helpers.tpl
+++ b/charts/victoria-traces-cluster/templates/_helpers.tpl
@@ -1,14 +1,17 @@
+
 {{- define "vtinsert.args" -}}
   {{- $Values := (.helm).Values | default .Values -}}
   {{- $app := $Values.vtinsert -}}
   {{- $args := dict -}}
   {{- $ctx := dict "style" "plain" "appKey" "vtstorage" "helm" .helm }}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- $storage := $Values.vtstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
     {{- $fqdn := include "vm.fqdn" $ctx }}
-    {{- $port := include "vm.port.from.flag" (dict "flag" $Values.vtstorage.extraArgs.httpListenAddr "default" "10491") }}
+    {{- $port := include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" $Values.vtstorage.http) "default" "10491") }}
     {{- range $i := until ($storage.replicaCount | int) -}}
       {{- if not (has (float64 $i) $app.excludeStorageIDs) -}}
         {{- $_ := set $ctx "appIdx" $i }}
@@ -30,6 +33,8 @@
   {{- $app := $Values.vmauth -}}
   {{- $args := dict -}}
   {{- $_ := set $args "auth.config" "/config/auth.yml" -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
@@ -39,12 +44,14 @@
   {{- $app := $Values.vtselect -}}
   {{- $args := dict -}}
   {{- $ctx := dict "style" "plain" "appKey" "vtstorage" "helm" .helm }}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- $storage := $Values.vtstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
     {{- $fqdn := include "vm.fqdn" $ctx }}
-    {{- $port := include "vm.port.from.flag" (dict "flag" $Values.vtstorage.extraArgs.httpListenAddr "default" "10491") }}
+    {{- $port := include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" $Values.vtstorage.http) "default" "10491") }}
     {{- range $i := until ($storage.replicaCount | int) -}}
       {{- $_ := set $ctx "appIdx" $i }}
       {{- $storageNode := include "vm.fqdn" $ctx -}}
@@ -76,19 +83,23 @@
     {{- else -}}
       {{- $_ := set $args "retention.maxDiskSpaceUsageBytes" $app.retentionDiskSpaceUsage -}}
     {{- end -}}
-  {{- end -}}  
+  {{- end -}}
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
 
 {{- define "vtselect.ports" -}}
-{{- $service := .service }}
-{{- $extraArgs := .extraArgs -}}
-- name: http
-  port: {{ $service.servicePort }}
+{{- $service := .service -}}
+{{- range .http }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10471") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ $service.targetPort }}
+  targetPort: {{ .name }}
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}
@@ -98,32 +109,37 @@
 {{- end -}}
 
 {{- define "vtinsert.ports" -}}
-{{- $service := .service }}
-{{- $extraArgs := .extraArgs -}}
-- name: http
-  port: {{ $service.servicePort }}
+{{- $service := .service -}}
+{{- range .http }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10481") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ $service.targetPort }}
+  targetPort: {{ .name }}
+{{- end }}
+{{- with .extraArgs.otlpGRPCListenAddr }}
+- name: otlpgrpc-tcp
+  protocol: TCP
+  port: {{ include "vm.port.from.flag" (dict "flag" .) }}
+  targetPort: otlpgrpc-tcp
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}
   protocol: {{ .protocol | default "TCP" }}
   targetPort: {{ .targetPort }}
 {{- end }}
-{{- with $extraArgs.otlpGRPCListenAddr }}
-- name: otlpgrpc-tcp
-  protocol: TCP
-  port: {{ include "vm.port.from.flag" (dict "flag" .) }}
-  targetPort: otlpgrpc-tcp
-{{- end }}
 {{- end -}}
 
 {{- define "vtstorage.ports" -}}
 {{- $service := .service -}}
-- port: {{ $service.servicePort }}
-  targetPort: http
+{{- range .http }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10491") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
   protocol: TCP
-  name: http
+  targetPort: {{ .name }}
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}
@@ -134,10 +150,13 @@
 
 {{- define "vmauth.ports" -}}
 {{- $service := .service -}}
-- port: {{ $service.servicePort }}
-  targetPort: http
-  protocol: TCP 
-  name: http 
+{{- range .http }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  targetPort: {{ .name }}
+  protocol: TCP
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}

--- a/charts/victoria-traces-cluster/templates/route.yaml
+++ b/charts/victoria-traces-cluster/templates/route.yaml
@@ -28,7 +28,7 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" ($app.extraArgs).httpListenAddr)) }}
+          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" $app.http))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-traces-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vmauth-server.yaml
@@ -68,8 +68,10 @@ spec:
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $app.ports.name  | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8427") }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
+            {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-traces-cluster/templates/vtinsert-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtinsert-server.yaml
@@ -63,8 +63,10 @@ spec:
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $app.ports.name  | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "10481") }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "10481") }}
+            {{- end }}
             {{- with $app.extraArgs.otlpGRPCListenAddr }}
             - name: otlpgrpc-tcp
               protocol: TCP

--- a/charts/victoria-traces-cluster/templates/vtselect-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtselect-server.yaml
@@ -63,8 +63,10 @@ spec:
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $app.ports.name  | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "10481") }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "10471") }}
+            {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-traces-cluster/templates/vtstorage-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtstorage-server.yaml
@@ -56,8 +56,10 @@ spec:
           {{- end }}
           args: {{ include "vtstorage.args" $ctx | nindent 12 }}
           ports:
-            - name: {{ $app.ports.name | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "10491") }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "10491") }}
+            {{- end }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-traces-cluster/tests/vtinsert_test.yaml
+++ b/charts/victoria-traces-cluster/tests/vtinsert_test.yaml
@@ -25,7 +25,9 @@ tests:
             cpu: 100m
             memory: 200Mi
       vtstorage:
-        extraArgs:
-          httpListenAddr: :10492
+        http:
+          - name: http
+            value: :10492
+            primary: true
     asserts:
       - matchSnapshot: {}

--- a/charts/victoria-traces-cluster/tests/vtselect_test.yaml
+++ b/charts/victoria-traces-cluster/tests/vtselect_test.yaml
@@ -25,8 +25,10 @@ tests:
             cpu: 100m
             memory: 200Mi
       vtstorage:
-        extraArgs:
-          httpListenAddr: :10492
+        http:
+          - name: http
+            value: :10492
+            primary: true
     asserts:
       - matchSnapshot: {}
 

--- a/charts/victoria-traces-cluster/tests/vtstorage_test.yaml
+++ b/charts/victoria-traces-cluster/tests/vtstorage_test.yaml
@@ -18,7 +18,9 @@ tests:
         podLabels:
           podLabelName: podLabelValue
         retentionDiskSpaceUsage: 100
-        extraArgs:
-          httpListenAddr: :10492
+        http:
+          - name: http
+            value: :10492
+            primary: true
     asserts:
       - matchSnapshot: {}

--- a/charts/victoria-traces-cluster/values.yaml
+++ b/charts/victoria-traces-cluster/values.yaml
@@ -70,20 +70,30 @@ vtselect:
     pullPolicy: IfNotPresent
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports: 
-    # -- vtselect http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vtselect component
   fullnameOverride: ""
   # -- Suppress rendering `--storageNode` FQDNs based on `vtstorage.replicaCount` value. If true suppress rendering `--storageNode`, they can be re-defined in extraArgs
   suppressStorageFQDNsRender: false
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :10471
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
   # -- Extra command line arguments for vtselect component
   extraArgs:
     envflag.enable: true
     loggerFormat: json
-    httpListenAddr: :10471
     http.shutdownDelay: 15s
   # -- Pod's termination grace period in seconds
   terminationGracePeriodSeconds: 60
@@ -256,9 +266,7 @@ vtselect:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 10471
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -369,18 +377,28 @@ vtinsert:
     pullPolicy: IfNotPresent
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports:
-    # -- vtinsert http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vtinsert component
   fullnameOverride: ""
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :10481
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
   # -- Extra command line arguments for vtinsert component
   extraArgs:
     envflag.enable: true
     loggerFormat: json
-    httpListenAddr: :10481
     http.shutdownDelay: 15s
   # -- Deployment annotations
   annotations: {}
@@ -557,9 +575,7 @@ vtinsert:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 10481
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -665,9 +681,6 @@ vtstorage:
     pullPolicy: IfNotPresent
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports: 
-    # -- vtstorage http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vtstorage component
@@ -686,11 +699,24 @@ vtstorage:
   # -- Data retention max capacity. Default unit is GiB. See these [docs](https://docs.victoriametrics.com/victoriatraces/#retention-by-disk-space-usage)
   retentionDiskSpaceUsage: ""
   
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :10491
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
   # -- Additional vtstorage container arguments. Extra command line arguments for vtstorage component
   extraArgs:
     envflag.enable: true
     loggerFormat: json
-    httpListenAddr: :10491
     http.shutdownDelay: 15s
   # -- Extra Volumes for the pod
   extraVolumes:
@@ -826,9 +852,7 @@ vtstorage:
     # -- Service labels
     labels: {}
     # -- Service port
-    servicePort: 10491
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Extra service ports
     extraPorts: []
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -946,18 +970,28 @@ vmauth:
     pullPolicy: IfNotPresent
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports:
-    # -- VMAuth http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vmauth component
   fullnameOverride: ""
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :8427
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
   # -- Extra command line arguments for vmauth component
   extraArgs:
     envflag.enable: true
     loggerFormat: json
-    httpListenAddr: :8427
     http.shutdownDelay: 15s
   # -- VMAuth annotations
   annotations: {}
@@ -1128,9 +1162,7 @@ vmauth:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 8427
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+**Update note 1**: `.Values.server.extraArgs.httpListenAddr` was replaced by `.Values.server.http` array of HTTP listen address configuration.
+
+- added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
 
 ## 0.0.9
 

--- a/charts/victoria-traces-single/Chart.lock
+++ b/charts/victoria-traces-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
-generated: "2026-04-16T10:14:26.247647222Z"
+  version: 0.3.1
+digest: sha256:6b3a43e93a5a4f9e38cdbbefa43841665b62b429f570e19d5e64c366fd2eabe7
+generated: "2026-05-21T16:13:35.325254+03:00"

--- a/charts/victoria-traces-single/templates/_helpers.tpl
+++ b/charts/victoria-traces-single/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+
 {{- define "vtraces.args" -}}
   {{- $Values := (.helm).Values | default .Values }}
   {{- $app := $Values.server -}}
@@ -18,6 +19,8 @@
   {{- end -}}
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}

--- a/charts/victoria-traces-single/templates/route.yaml
+++ b/charts/victoria-traces-single/templates/route.yaml
@@ -29,7 +29,7 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" ($app.extraArgs).httpListenAddr)) }}
+          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" $app.http))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-traces-single/templates/server.yaml
+++ b/charts/victoria-traces-single/templates/server.yaml
@@ -80,9 +80,11 @@ spec:
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: http
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "10428") }}
-          {{- with $app.extraArgs.otlpGRPCListenAddr }}
+            {{- range $app.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "10428") }}
+            {{- end }}
+            {{- with $app.extraArgs.otlpGRPCListenAddr }}
             - name: otlpgrpc-tcp
               protocol: TCP
               containerPort: {{ include "vm.port.from.flag" (dict "flag" .) }}

--- a/charts/victoria-traces-single/templates/service.yaml
+++ b/charts/victoria-traces-single/templates/service.yaml
@@ -54,13 +54,16 @@ spec:
   ipFamilies: {{ toYaml . | nindent 4 }}
   {{- end }}
   ports:
-    - name: http
-      port: {{ $service.servicePort }}
+    {{- range $app.http }}
+    - name: {{ .name }}
+      {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10428") }}
+      port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
       protocol: TCP
-      targetPort: {{ $service.targetPort }}
-      {{- with $service.nodePort }}
-      nodePort: {{ . }}
+      targetPort: {{ .name }}
+      {{- if and .primary $service.nodePort }}
+      nodePort: {{ $service.nodePort }}
       {{- end }}
+    {{- end }}
     {{- with $app.extraArgs.otlpGRPCListenAddr }}
     - name: otlpgrpc-tcp
       protocol: TCP

--- a/charts/victoria-traces-single/values.yaml
+++ b/charts/victoria-traces-single/values.yaml
@@ -76,12 +76,25 @@ server:
   retentionPeriod: 1
   # -- Data retention max capacity. Default unit is GiB. See these [docs](https://docs.victoriametrics.com/victoriatraces/#retention-by-disk-space-usage)
   retentionDiskSpaceUsage: ""
+  # -- List of HTTP listen addresses
+  http:
+    - name: http
+      primary: true
+      value: :10428
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
   # -- Extra command line arguments for container of component
   extraArgs:
     envflag.enable: true
     envflag.prefix: VM_
     loggerFormat: json
-    httpListenAddr: :10428
     http.shutdownDelay: 15s
   # -- Specify pod lifecycle
   lifecycle: {}
@@ -314,10 +327,8 @@ server:
     loadBalancerIP: ""
     # -- Load balancer source range
     loadBalancerSourceRanges: []
-    # -- Target port
-    targetPort: http
     # -- Service port
-    servicePort: 10428
+    servicePort: ""
     # -- Node port
     # nodePort: 30000
     # -- Service type


### PR DESCRIPTION
related issues #2894, #2881, #2826

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for multiple HTTP listen addresses with optional TLS/mTLS across `victoria-logs-*` (single, cluster, multilevel) and `victoria-traces-*` (single, cluster), plus multiple Syslog TCP/UDP listeners with optional TLS for logs. Service ports and Routes derive from `http[]`/`syslog[]`; a primary HTTP address selects Route backend ports and NodePort on single charts.

- **New Features**
  - `.Values.<component>.http[]` for repeated `--httpListenAddr`, container/Service ports, and Route backendRefs. On `vlstorage`/`vtstorage`, `primary: true` is used for `--storageNode`. Adds `vm.addr.primary` and `vm.http.args` from `victoria-metrics-common@0.3.1`.
  - Logs: `.Values.vlinsert.syslog.{tcp,udp}[]` (cluster) and `.Values.server.syslog.{tcp,udp}[]` (single) create matching Pod/Service ports; TLS supported.

- **Migration**
  - Replace `extraArgs.httpListenAddr` with `.Values.<component>.http[]` (set one item `primary: true`). Using `extraArgs.httpListenAddr` now errors with a clear message.
  - Service ports come from `.http[]`; `service.servicePort`/`targetPort` are removed or ignored. On single charts, `nodePort` applies to the primary HTTP port only.

<sup>Written for commit 76be3b8f6287081ed56f90e61087ba454388e8d7. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2921?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

