### PR TITLE
victorialogs: allow overriding the container command

### DIFF
--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added `.Values.<component>.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Item with `primary: true` on `vlstorage` is used for storageNode address resolution.
 - support `.Values.vlinsert.syslog.tcp` and `.Values.vlinsert.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings.
+- add ability to override VictoriaLogs container command.
 
 ## 0.1.5
 

--- a/charts/victoria-logs-cluster/templates/vlinsert-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlinsert-server.yaml
@@ -55,6 +55,9 @@ spec:
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vlinsert.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ tpl (toYaml .) $ctx | nindent 12 }}

--- a/charts/victoria-logs-cluster/templates/vlselect-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlselect-server.yaml
@@ -55,6 +55,9 @@ spec:
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vlselect.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ tpl (toYaml .) $ctx | nindent 12 }}

--- a/charts/victoria-logs-cluster/templates/vlstorage-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlstorage-server.yaml
@@ -54,6 +54,9 @@ spec:
           {{- with $app.lifecycle }}
           lifecycle: {{ . | toYaml | nindent 12 }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vlstorage.args" $ctx | nindent 12 }}
           ports:
             {{- range $app.http }}

--- a/charts/victoria-logs-cluster/tests/vlinsert_test.yaml
+++ b/charts/victoria-logs-cluster/tests/vlinsert_test.yaml
@@ -51,3 +51,13 @@ tests:
           content:
             configMapRef:
               name: RELEASE-NAME-config
+  - it: should render custom command
+    set:
+      vlinsert:
+        command:
+          - /custom/bin/victorialogs
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/victorialogs

--- a/charts/victoria-logs-cluster/tests/vlselect_test.yaml
+++ b/charts/victoria-logs-cluster/tests/vlselect_test.yaml
@@ -51,3 +51,13 @@ tests:
           content:
             configMapRef:
               name: RELEASE-NAME-config
+  - it: should render custom command
+    set:
+      vlselect:
+        command:
+          - /custom/bin/victorialogs
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/victorialogs

--- a/charts/victoria-logs-cluster/tests/vlstorage_test.yaml
+++ b/charts/victoria-logs-cluster/tests/vlstorage_test.yaml
@@ -44,3 +44,13 @@ tests:
           content:
             configMapRef:
               name: RELEASE-NAME-config
+  - it: should render custom command
+    set:
+      vlstorage:
+        command:
+          - /custom/bin/victorialogs
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/victorialogs

--- a/charts/victoria-logs-cluster/values.yaml
+++ b/charts/victoria-logs-cluster/values.yaml
@@ -68,6 +68,8 @@ vlselect:
     variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaLogs binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   # -- Name of Priority Class
@@ -376,6 +378,8 @@ vlinsert:
     variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaLogs binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   # -- Name of Priority Class
@@ -700,6 +704,8 @@ vlstorage:
     variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaLogs binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   # -- Name of Priority Class

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Update note 1**: `.Values.<component>.extraArgs.httpListenAddr` was replaced by `.Values.<component>.http` array of HTTP listen address configuration, where `<component>` is one of `vlselect`, `vmauth`.
 
 - added `.Values.<component>.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
+- add ability to override VictoriaLogs container command.
 
 ## 0.1.1
 

--- a/charts/victoria-logs-multilevel/templates/vlselect-server.yaml
+++ b/charts/victoria-logs-multilevel/templates/vlselect-server.yaml
@@ -55,6 +55,9 @@ spec:
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vlselect.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-logs-multilevel/tests/vlselect_test.yaml
+++ b/charts/victoria-logs-multilevel/tests/vlselect_test.yaml
@@ -31,4 +31,15 @@ tests:
         - test
     asserts:
       - matchSnapshot: {}
-
+  - it: should render custom command
+    set:
+      storageNodes:
+        - test
+      vlselect:
+        command:
+          - /custom/bin/victorialogs
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/victorialogs

--- a/charts/victoria-logs-multilevel/values.yaml
+++ b/charts/victoria-logs-multilevel/values.yaml
@@ -71,6 +71,8 @@ vlselect:
     variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaLogs binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   # -- Name of Priority Class

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
 - support `.Values.server.syslog.tcp` and `.Values.server.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings.
+- add ability to override VictoriaLogs container command.
 
 ## 0.12.5
 

--- a/charts/victoria-logs-single/templates/server.yaml
+++ b/charts/victoria-logs-single/templates/server.yaml
@@ -72,6 +72,9 @@ spec:
           {{- with $app.containerWorkingDir }}
           workingDir: {{ . }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vlogs.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ tpl (toYaml .) $ctx | nindent 12 }}

--- a/charts/victoria-logs-single/tests/server_test.yaml
+++ b/charts/victoria-logs-single/tests/server_test.yaml
@@ -51,3 +51,13 @@ tests:
           content:
             configMapRef:
               name: RELEASE-NAME-config
+  - it: should render custom command
+    set:
+      server:
+        command:
+          - /custom/bin/victorialogs
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/victorialogs

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -66,6 +66,8 @@ server:
     pullPolicy: IfNotPresent
   # -- Image pull secrets
   imagePullSecrets: []
+  # -- Override default container command. Use when the VictoriaLogs binary is available at a custom path
+  command: []
   # -- Replica count
   replicaCount: 1
   # -- Name of Priority Class


### PR DESCRIPTION
VictoriaLogs charts should allow overriding the command for the server so that they can be used with container images which may not have the VictoriaLogs binary as the default entrypoint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support to override the container command across VictoriaLogs Helm charts. This lets you run images where the VictoriaLogs binary isn’t the default entrypoint.

- **New Features**
  - New optional `command` values:
    - `victoria-logs-single`: `server.command`
    - `victoria-logs-cluster`: `vlinsert.command`, `vlselect.command`, `vlstorage.command`
    - `victoria-logs-multilevel`: `vlselect.command`
  - Templates render `command` only when set; defaults remain unchanged.

- **Migration**
  - To use a custom binary path, set the relevant value, e.g. `server.command: ["/custom/bin/victorialogs"]`.

<sup>Written for commit d4c02dc640ed993755e8019eb13371dee98a469a. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2927?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

