### PR TITLE
feat: add ability to override container command

### DIFF
--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add ability to override container command.
 
 ## 0.39.0
 

--- a/charts/victoria-metrics-agent/templates/server.yaml
+++ b/charts/victoria-metrics-agent/templates/server.yaml
@@ -74,6 +74,9 @@ spec:
           {{- with $app.containerWorkingDir }}
           workingDir: {{ . }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vmagent.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-metrics-agent/tests/server_test.yaml
+++ b/charts/victoria-metrics-agent/tests/server_test.yaml
@@ -40,3 +40,16 @@ tests:
         - url: http://vm-insert:8480/insert/0/prometheus
     asserts:
       - matchSnapshot: {}
+  - it: should render custom command
+    set:
+      remoteWrite:
+        - url: http://vm-insert:8480/insert/0/prometheus
+      command:
+        - /custom/bin/vmagent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/vmagent
+        template: server.yaml
+        documentIndex: 0

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -65,6 +65,8 @@ image:
   variant: ""
   # -- Image pull policy
   pullPolicy: IfNotPresent
+# -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+command: []
 
 # -- Image pull secrets
 imagePullSecrets: []

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add ability to override container command.
 
 ## 0.40.0
 

--- a/charts/victoria-metrics-alert/templates/alert-server.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-server.yaml
@@ -56,6 +56,9 @@ spec:
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
           image: {{ include "vm.image" $ctx }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vmalert.args" $ctx | nindent 12 }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           {{- with $app.envFrom }}

--- a/charts/victoria-metrics-alert/templates/alertmanager-server.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-server.yaml
@@ -55,6 +55,9 @@ spec:
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
           image: {{ include "vm.image" $ctx }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "alertmanager.args" $ctx | nindent 12 }}
           ports:
             - name: web

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -42,6 +42,8 @@ server:
     # e.g. enterprise, scratch
     variant: ""
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+  command: []
   # -- Override vmalert resources fullname
   fullnameOverride: ""
   # -- Image pull secrets
@@ -414,6 +416,8 @@ alertmanager:
     registry: ""
     repository: prom/alertmanager
     tag: v0.32.1
+  # -- Override default container command. Use when the alertmanager binary is available at a custom path
+  command: []
   # -- Alertmanager retention
   retention: 120h
   # -- Replica count

--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - fix VMPodMonitor relabelling configuration rendering. See [#2917](https://github.com/VictoriaMetrics/helm-charts/issues/2917).
+- add ability to override container command.
 
 ## 1.12.12
 

--- a/charts/victoria-metrics-anomaly/templates/server.yaml
+++ b/charts/victoria-metrics-anomaly/templates/server.yaml
@@ -67,6 +67,9 @@ spec:
               name: http
             {{- end }}
           {{- end }}
+          {{- with .Values.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vmanomaly.args" $ctx | nindent 12 }}
           {{- with .Values.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -24,6 +24,8 @@ image:
   tag: "" # rewrites Chart.AppVersion
   # -- Pull policy of Docker image
   pullPolicy: IfNotPresent
+# -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+command: []
 
 # -- Image pull secrets
 imagePullSecrets: []

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add ability to override container command.
 
 ## 0.32.0
 

--- a/charts/victoria-metrics-auth/templates/server.yaml
+++ b/charts/victoria-metrics-auth/templates/server.yaml
@@ -63,6 +63,9 @@ spec:
           {{- if $app.containerWorkingDir }}
           workingDir: {{ $app.containerWorkingDir }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vmauth.args" $ctx | nindent 12 }}
           {{- with $app.lifecycle }}
           lifecycle: {{ . | toYaml | nindent 12 }}

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -33,6 +33,8 @@ image:
   variant: ""
   # -- Pull policy of Docker image
   pullPolicy: IfNotPresent
+# -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+command: []
 
 # -- Image pull secrets
 imagePullSecrets: []

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add ability to override container command.
 
 ## 0.42.0
 

--- a/charts/victoria-metrics-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmauth-server.yaml
@@ -60,6 +60,9 @@ spec:
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vmauth.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
@@ -56,6 +56,9 @@ spec:
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vminsert.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-server.yaml
@@ -73,6 +73,9 @@ spec:
           {{- with $app.containerWorkingDir }}
           workingDir: {{ . }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vmselect.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
@@ -95,6 +95,9 @@ spec:
           {{- with $app.lifecycle }}
           lifecycle: {{ . | toYaml | nindent 12 }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vmstorage.args" $ctx | nindent 12 }}
           ports:
             - name: {{ $app.ports.name | default "http" }}

--- a/charts/victoria-metrics-cluster/tests/vmauth_test.yaml
+++ b/charts/victoria-metrics-cluster/tests/vmauth_test.yaml
@@ -26,3 +26,14 @@ tests:
           podLabelName: podLabelValue
     asserts:
       - matchSnapshot: {}
+  - it: should render custom command
+    set:
+      vmauth:
+        enabled: true
+        command:
+          - /custom/bin/vmauth
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/vmauth

--- a/charts/victoria-metrics-cluster/tests/vminsert_test.yaml
+++ b/charts/victoria-metrics-cluster/tests/vminsert_test.yaml
@@ -19,3 +19,13 @@ tests:
           podLabelName: podLabelValue
     asserts:
       - matchSnapshot: {}
+  - it: should render custom command
+    set:
+      vminsert:
+        command:
+          - /custom/bin/vminsert
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/vminsert

--- a/charts/victoria-metrics-cluster/tests/vmselect_test.yaml
+++ b/charts/victoria-metrics-cluster/tests/vmselect_test.yaml
@@ -37,3 +37,13 @@ tests:
           podLabelName: podLabelValue
     asserts:
       - matchSnapshot: {}
+  - it: should render custom command
+    set:
+      vmselect:
+        command:
+          - /custom/bin/vmselect
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/vmselect

--- a/charts/victoria-metrics-cluster/tests/vmstorage_test.yaml
+++ b/charts/victoria-metrics-cluster/tests/vmstorage_test.yaml
@@ -19,3 +19,13 @@ tests:
           podLabelName: podLabelValue
     asserts:
       - matchSnapshot: {}
+  - it: should render custom command
+    set:
+      vmstorage:
+        command:
+          - /custom/bin/vmstorage
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/vmstorage

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -78,6 +78,8 @@ vmselect:
     # -- Variant of the image to use.
     # e.g. cluster, enterprise-cluster
     variant: cluster
+  # -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   ports: 
@@ -441,6 +443,8 @@ vminsert:
     variant: cluster
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   ports:
@@ -770,6 +774,8 @@ vmauth:
     variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   ports:
@@ -1061,6 +1067,8 @@ vmstorage:
     variant: cluster
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   ports: 

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add ability to override container command.
 
 ## 0.30.0
 

--- a/charts/victoria-metrics-gateway/templates/server.yaml
+++ b/charts/victoria-metrics-gateway/templates/server.yaml
@@ -69,6 +69,9 @@ spec:
           {{- end }}
           image: {{ include "vm.image" $ctx }}
           workingDir: {{ .Values.containerWorkingDir }}
+          {{- with .Values.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vmgateway.args" $ctx | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -31,6 +31,8 @@ image:
   variant: ""
   # -- Pull policy of Docker image
   pullPolicy: IfNotPresent
+# -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+command: []
 
 # -- Image pull secrets
 imagePullSecrets: []

--- a/charts/victoria-metrics-mcp/CHANGELOG.md
+++ b/charts/victoria-metrics-mcp/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add ability to override container command.
 
 ## 0.3.0
 

--- a/charts/victoria-metrics-mcp/templates/deployment.yaml
+++ b/charts/victoria-metrics-mcp/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
           {{- end }}
           image: "{{ $repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: MCP_LISTEN_ADDR
               value: "0.0.0.0:{{  .Values.service.port }}"

--- a/charts/victoria-metrics-mcp/values.yaml
+++ b/charts/victoria-metrics-mcp/values.yaml
@@ -6,6 +6,8 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+# -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+command: []
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add ability to override container command.
 
 ## 0.63.1
 

--- a/charts/victoria-metrics-operator/templates/server.yaml
+++ b/charts/victoria-metrics-operator/templates/server.yaml
@@ -100,6 +100,9 @@ spec:
             {{- end }}
             - name: VM_ENABLEDPROMETHEUSCONVERTEROWNERREFERENCES
               value: {{ .Values.operator.enable_converter_ownership | quote}}
+          {{- with .Values.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - --zap-log-level={{ .Values.logLevel }}
             - --leader-elect

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -28,6 +28,8 @@ image:
   variant: ""
   # -- Image pull policy
   pullPolicy: IfNotPresent
+# -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+command: []
 
 configReloader:
   image: {}

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add ability to override container command.
 
 ## 0.38.0
 

--- a/charts/victoria-metrics-single/templates/server.yaml
+++ b/charts/victoria-metrics-single/templates/server.yaml
@@ -105,6 +105,9 @@ spec:
           {{- if $app.containerWorkingDir }}
           workingDir: {{ $app.containerWorkingDir }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vmsingle.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-metrics-single/tests/server_test.yaml
+++ b/charts/victoria-metrics-single/tests/server_test.yaml
@@ -30,3 +30,13 @@ tests:
           enabled: true
     asserts:
       - matchSnapshot: {}
+  - it: should render custom command
+    set:
+      server:
+        command:
+          - /custom/bin/victoriametrics
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/victoriametrics

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -79,6 +79,8 @@ server:
     variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+  command: []
   # -- Image pull secrets
   imagePullSecrets: []
   # -- Specify pod lifecycle

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Update note 1**: `.Values.<component>.extraArgs.httpListenAddr` was replaced by `.Values.<component>.http` array of HTTP listen address configuration, where `<component>` is one of `vtinsert`, `vtselect`, `vtstorage`, `vmauth`.
 
 - added `.Values.<component>.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Item with `primary: true` on `vtstorage` is used for storageNode address resolution.
+- add ability to override container command.
 
 ## 0.1.3
 

--- a/charts/victoria-traces-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vmauth-server.yaml
@@ -60,6 +60,9 @@ spec:
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vmauth.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-traces-cluster/templates/vtinsert-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtinsert-server.yaml
@@ -55,6 +55,9 @@ spec:
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vtinsert.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-traces-cluster/templates/vtselect-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtselect-server.yaml
@@ -55,6 +55,9 @@ spec:
           {{- if $app.securityContext.enabled }}
           securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 12 }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vtselect.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-traces-cluster/templates/vtstorage-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtstorage-server.yaml
@@ -54,6 +54,9 @@ spec:
           {{- with $app.lifecycle }}
           lifecycle: {{ . | toYaml | nindent 12 }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vtstorage.args" $ctx | nindent 12 }}
           ports:
             {{- range $app.http }}

--- a/charts/victoria-traces-cluster/tests/vmauth_test.yaml
+++ b/charts/victoria-traces-cluster/tests/vmauth_test.yaml
@@ -30,3 +30,14 @@ tests:
           podLabelName: podLabelValue
     asserts:
       - matchSnapshot: {}
+  - it: should render custom command
+    set:
+      vmauth:
+        enabled: true
+        command:
+          - /custom/bin/vmauth
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/vmauth

--- a/charts/victoria-traces-cluster/tests/vtinsert_test.yaml
+++ b/charts/victoria-traces-cluster/tests/vtinsert_test.yaml
@@ -31,3 +31,13 @@ tests:
             primary: true
     asserts:
       - matchSnapshot: {}
+  - it: should render custom command
+    set:
+      vtinsert:
+        command:
+          - /custom/bin/vtinsert
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/vtinsert

--- a/charts/victoria-traces-cluster/tests/vtselect_test.yaml
+++ b/charts/victoria-traces-cluster/tests/vtselect_test.yaml
@@ -31,4 +31,14 @@ tests:
             primary: true
     asserts:
       - matchSnapshot: {}
+  - it: should render custom command
+    set:
+      vtselect:
+        command:
+          - /custom/bin/vtselect
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/vtselect
 

--- a/charts/victoria-traces-cluster/tests/vtstorage_test.yaml
+++ b/charts/victoria-traces-cluster/tests/vtstorage_test.yaml
@@ -24,3 +24,13 @@ tests:
             primary: true
     asserts:
       - matchSnapshot: {}
+  - it: should render custom command
+    set:
+      vtstorage:
+        command:
+          - /custom/bin/vtstorage
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/vtstorage

--- a/charts/victoria-traces-cluster/values.yaml
+++ b/charts/victoria-traces-cluster/values.yaml
@@ -68,6 +68,8 @@ vtselect:
     variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaTraces binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   # -- Name of Priority Class
@@ -375,6 +377,8 @@ vtinsert:
     variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaTraces binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   # -- Name of Priority Class
@@ -679,6 +683,8 @@ vtstorage:
     variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaTraces binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   # -- Name of Priority Class
@@ -968,6 +974,8 @@ vmauth:
     tag: "v1.143.0"
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaMetrics binary is available at a custom path
+  command: []
   # -- Specify pod lifecycle
   lifecycle: {}
   # -- Name of Priority Class

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Update note 1**: `.Values.server.extraArgs.httpListenAddr` was replaced by `.Values.server.http` array of HTTP listen address configuration.
 
 - added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
+- add ability to override container command.
 
 ## 0.0.9
 

--- a/charts/victoria-traces-single/templates/server.yaml
+++ b/charts/victoria-traces-single/templates/server.yaml
@@ -72,6 +72,9 @@ spec:
           {{- with $app.containerWorkingDir }}
           workingDir: {{ . }}
           {{- end }}
+          {{- with $app.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args: {{ include "vtraces.args" $ctx | nindent 12 }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}

--- a/charts/victoria-traces-single/tests/server_test.yaml
+++ b/charts/victoria-traces-single/tests/server_test.yaml
@@ -30,3 +30,13 @@ tests:
           enabled: true
     asserts:
       - matchSnapshot: {}
+  - it: should render custom command
+    set:
+      server:
+        command:
+          - /custom/bin/vtraces
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /custom/bin/vtraces

--- a/charts/victoria-traces-single/values.yaml
+++ b/charts/victoria-traces-single/values.yaml
@@ -64,6 +64,8 @@ server:
     variant: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- Override default container command. Use when the VictoriaTraces binary is available at a custom path
+  command: []
   # -- Image pull secrets
   imagePullSecrets: []
   # -- Replica count


### PR DESCRIPTION
Users may want to run custom images or run different commands, the charts should allow overriding the entrypoint.

This is a followup for https://github.com/VictoriaMetrics/helm-charts/pull/2927, covering remaining charts