### PR TITLE
k8s-stack: added per-group additionalGroupByLabels

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add per-group additionalGroupByLabels, that override defaultRules.additionalGroupByLabels. See [#2382](https://github.com/VictoriaMetrics/helm-charts/issues/2832).
 
 ## 0.80.0
 

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- add per-group additionalGroupByLabels, that override defaultRules.additionalGroupByLabels. See [#2382](https://github.com/VictoriaMetrics/helm-charts/issues/2832).
+- add per-group additionalGroupByLabels, that replace defaultRules.additionalGroupByLabels. See [#2382](https://github.com/VictoriaMetrics/helm-charts/issues/2832).
 
 ## 0.80.0
 

--- a/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-cluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-cluster.yaml
@@ -2500,7 +2500,6 @@ panels:
             mode: none
           thresholdsStyle:
             mode: "off"
-        decimals: 0
         links: []
         mappings: []
         min: 0

--- a/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-single-node.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-single-node.yaml
@@ -2668,7 +2668,6 @@ panels:
             mode: none
           thresholdsStyle:
             mode: "off"
-        decimals: 0
         links: []
         mappings: []
         min: 0

--- a/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-vmagent.yaml
@@ -2276,7 +2276,6 @@ panels:
             mode: none
           thresholdsStyle:
             mode: "off"
-        decimals: 0
         links: []
         mappings: []
         min: 0

--- a/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-vmalert.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/dashboards/generated/victoriametrics-vmalert.yaml
@@ -1859,7 +1859,6 @@ panels:
             mode: none
           thresholdsStyle:
             mode: "off"
-        decimals: 0
         links: []
         mappings: []
         min: 0

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/alertmanager.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/alertmanager.rules.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: alertmanager.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/etcd.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/etcd.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: etcd
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/general.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/general.rules.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: general.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_limits.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_limits.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_cpu_limits
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_requests.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_requests.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_cpu_requests
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_usage_seconds_total.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_usage_seconds_total.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_cpu_usage_seconds_total
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_cache.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_cache.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_cache
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_limits.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_limits.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_limits
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_requests.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_requests.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_requests
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_rss.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_rss.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_rss
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_swap.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_swap.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_swap
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_working_set_bytes.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_working_set_bytes.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_working_set_bytes
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.pod_owner.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.pod_owner.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.pod_owner
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-availability.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-availability.rules.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-apiserver-availability.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-burnrate.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-burnrate.rules.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-apiserver-burnrate.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-histogram.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-histogram.rules.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-apiserver-histogram.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-slos.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-slos.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-apiserver-slos
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-prometheus-node-recording.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-prometheus-node-recording.rules.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-prometheus-node-recording.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-scheduler.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-scheduler.rules.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-scheduler.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-state-metrics.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-state-metrics.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-state-metrics
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubelet.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubelet.rules.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubelet.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-apps.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-apps.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-apps
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-resources.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-resources.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-resources
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-storage.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-storage.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-storage
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-apiserver.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-apiserver.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-system-apiserver
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-controller-manager.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-controller-manager.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-system-controller-manager
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-kubelet.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-kubelet.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-system-kubelet
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-scheduler.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-scheduler.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-system-scheduler
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-system
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/node-exporter.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/node-exporter.rules.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: node-exporter.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/node-exporter.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/node-exporter.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: node-exporter
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/node-network.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/node-network.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: node-network
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/node.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/node.rules.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: node.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vm-health.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vm-health.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: vm-health
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vmagent.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: vmagent
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vmalert.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vmalert.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: vmalert
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vmcluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vmcluster.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: vmcluster
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vmoperator.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vmoperator.yaml
@@ -2,8 +2,12 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: vmoperator
 rules:

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/rule.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/rule.yaml
@@ -46,6 +46,13 @@ Merge common group with a group data of a current iteration
 Get group data from file
 */}}
 {{- $groupCtx := mergeOverwrite $ctx $group }}
+
+{{- /*
+Resolve effectiveGroupByLabels: per-group additionalGroupByLabels overrides global if set
+*/}}
+{{- $additionalGroupByLabels := dig "additionalGroupByLabels" $defaultRules.additionalGroupByLabels $group }}
+{{- $_ := set $groupCtx "additionalGroupByLabels" $additionalGroupByLabels }}
+
 {{- $groupData := fromYaml (tpl ($.Files.Get $groupFile) $groupCtx) -}}
 
 {{- /*

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -114,6 +114,8 @@ defaultRules:
   groups:
     etcd:
       create: true
+      # -- Per-group override for additionalGroupByLabels. When set, replaces the global additionalGroupByLabels for this group only.
+      # additionalGroupByLabels: []
       # -- Common properties for all rules in a group
       rules: {}
       # spec:

--- a/hack/rules-and-dashboards/main.go
+++ b/hack/rules-and-dashboards/main.go
@@ -49,8 +49,12 @@ var headers = map[string]string{
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
+{{- if hasKey . "additionalGroupByLabels" }}
+  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
+{{- end }}
+{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $additionalGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 `,
 }


### PR DESCRIPTION
added additionalGroupByLabels variable that overrides defaultRules.additionalGroupByLabels
fixes https://github.com/VictoriaMetrics/helm-charts/issues/2832

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-group `additionalGroupByLabels` for k8s-stack rule groups. You can now set group_by labels per group, replacing the global defaults for that group.

- **New Features**
  - Add `defaultRules.groups.<group>.additionalGroupByLabels` to replace `defaultRules.additionalGroupByLabels` for that group.
  - Templates/codegen use the per-group list when set, always append the `cluster` label, and dedupe labels.
  - Regenerated rule files to use the new behavior; minor dashboard cleanup and `values.yaml` docs.

- **Migration**
  - No changes required. To use, set `defaultRules.groups.<group>.additionalGroupByLabels` for the groups you want to override.

<sup>Written for commit 6b2e2d754d626d574288ee30594ecbf6a780a1ba. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2931?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

