### PR TITLE
vlagent: support multiple HTTP and Syslog listen addresses configuration

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Next release
 
-- TODO
+**Update note 1**: `.Values.extraArgs.httpListenAddr` was replaced by `.Values.http` array of HTTP listen address configuration.
+
+- added `.Values.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
+- support `.Values.syslog.tcp` and `.Values.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings.
 
 ## 0.1.3
 

--- a/charts/victoria-logs-agent/Chart.lock
+++ b/charts/victoria-logs-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
-generated: "2026-04-16T10:13:05.105514128Z"
+  version: 0.3.1
+digest: sha256:6b3a43e93a5a4f9e38cdbbefa43841665b62b429f570e19d5e64c366fd2eabe7
+generated: "2026-05-26T21:26:25.365753+03:00"

--- a/charts/victoria-logs-agent/templates/_helpers.tpl
+++ b/charts/victoria-logs-agent/templates/_helpers.tpl
@@ -1,3 +1,28 @@
+{{- define "vl.syslog.args" -}}
+  {{- $args := dict }}
+  {{- range $kind, $sls := . }}
+    {{- range $i, $sl := $sls -}}
+      {{- if not $sl.value -}}
+        {{- fail (printf "`value` is not set for `syslog.%s` idx %d" $kind $i) -}}
+      {{- end -}}
+      {{- range $slKey, $slValue := (omit $sl "name") -}}
+        {{- $key := ternary "listenAddr" $slKey (eq $slKey "value") -}}
+        {{- $key = ternary (printf "syslog.%s" $key) (printf "syslog.%s.%s" $key $kind) (hasPrefix "tls" $key) -}}
+        {{- $param := index $args $key | default list -}}
+        {{- if $slValue -}}
+          {{- range until (int (sub $i (len $param))) }}
+            {{- $param = append $param "" }}
+          {{- end }}
+          {{- $param = append $param $slValue }}
+          {{- $_ := set $args $key $param -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- toYaml $args -}}
+{{- end -}}
+
+
 {{- define "vlagent.args" -}}
   {{- $Values := (.helm).Values | default .Values }}
   {{- if empty $Values.remoteWrite }}
@@ -7,6 +32,8 @@
   {{- $args := dict "tmpDataPath" "/vlagent-data" }}
   {{- $_ := set $args "remoteWrite.maxDiskUsagePerURL" $Values.maxDiskUsagePerURL -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $Values.http)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $Values.syslog)) -}}
 
   {{- $requiredParams := list "url" }}
 
@@ -53,6 +80,7 @@
       {{- $_ := set $args $key $param }}
     {{- end }}
   {{- end }}
+  {{- include "vm.check.extraArgs" $Values.extraArgs -}}
   {{- $args = mergeOverwrite $args $Values.extraArgs -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end }}

--- a/charts/victoria-logs-agent/templates/server.yaml
+++ b/charts/victoria-logs-agent/templates/server.yaml
@@ -66,17 +66,20 @@ spec:
           env: {{- toYaml . | nindent 12}}
           {{- end }}
           ports:
-            - name: http
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" .Values.extraArgs.httpListenAddr "default" "9429") }}
-            {{- with (index .Values.extraArgs "syslog.listenAddr.tcp") }}
-            - name: syslog-tcp
+            {{- range .Values.http }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "9429") }}
               protocol: TCP
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" .) }}
             {{- end }}
-            {{- with (index .Values.extraArgs "syslog.listenAddr.udp") }}
-            - name: syslog-udp
+            {{- range .Values.syslog.tcp }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value) }}
+              protocol: TCP
+            {{- end }}
+            {{- range .Values.syslog.udp }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value) }}
               protocol: UDP
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" .) }}
             {{- end }}
           volumeMounts:
             {{- with .Values.extraVolumeMounts }}

--- a/charts/victoria-logs-agent/templates/service.yaml
+++ b/charts/victoria-logs-agent/templates/service.yaml
@@ -48,21 +48,27 @@ spec:
   trafficDistribution: {{ . }}
   {{- end }}
   ports:
-    - port: 9429
-      targetPort: http
+    {{- range .Values.http }}
+    - name: {{ .name }}
+      {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9429") }}
+      port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
       protocol: TCP
-      name: http
-    {{- with (index .Values.extraArgs "syslog.listenAddr.udp") }}
-    - name: syslog-udp
-      protocol: UDP
-      port: {{ include "vm.port.from.flag" (dict "flag" .) }}
-      targetPort: syslog-udp
+      targetPort: {{ .name }}
+      {{- if and .primary $service.nodePort }}
+      nodePort: {{ $service.nodePort }}
+      {{- end }}
     {{- end }}
-    {{- with (index .Values.extraArgs "syslog.listenAddr.tcp") }}
-    - name: syslog-tcp
+    {{- range .Values.syslog.tcp }}
+    - name: {{ .name }}
+      port: {{ include "vm.port.from.flag" (dict "flag" .value) }}
       protocol: TCP
-      port: {{ include "vm.port.from.flag" (dict "flag" .) }}
-      targetPort: syslog-tcp
+      targetPort: {{ .name }}
+    {{- end }}
+    {{- range .Values.syslog.udp }}
+    - name: {{ .name }}
+      port: {{ include "vm.port.from.flag" (dict "flag" .value) }}
+      protocol: UDP
+      targetPort: {{ .name }}
     {{- end }}
     {{- range $service.extraPorts }}
     - name: {{ .name }}

--- a/charts/victoria-logs-agent/values.yaml
+++ b/charts/victoria-logs-agent/values.yaml
@@ -247,7 +247,7 @@ service:
   # -- Load balancer source range
   loadBalancerSourceRanges: []
   # -- Service port
-  servicePort: 8429
+  servicePort: ""
   # -- Target port
   targetPort: http
   # nodePort: 30000
@@ -272,6 +272,23 @@ service:
 
 # -- Add extra specs dynamically to this chart
 extraObjects: []
+
+# -- HTTP listen addresses configuration.
+# Each item configures an HTTP listen address with optional TLS settings.
+# Items are used for Pod ports, command line arguments and Service port generation.
+http:
+  - name: http
+    value: :9429
+    primary: true
+
+# -- Syslog TCP listen addresses configuration.
+syslog:
+  tcp: []
+  # - name: syslog-tcp
+  #   value: :514
+  udp: []
+  # - name: syslog-udp
+  #   value: :514
 
 # -- VLAgent extra command line arguments
 extraArgs:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for multiple HTTP and Syslog listen addresses in the `victoria-logs-agent` Helm chart. Pod ports, Service ports, and command-line args are now generated from these lists.

- **New Features**
  - New `http` array: each item has `name`, `value`, `primary`, and optional TLS; used for Pod ports, Service ports, and args.
  - New `syslog.tcp` and `syslog.udp` lists with optional TLS; used for ports and args.
  - Primary HTTP entry controls the Service port and optional `nodePort`.
  - Default Service port now follows the primary HTTP port. Define `service.servicePort` if you need a fixed external port.
  - Bumped `victoria-metrics-common` to `0.3.1`.

- **Migration**
  - Replace `extraArgs.httpListenAddr` with an item in `http` (e.g., `{ name: http, value: :9429, primary: true }`).
  - If you used `extraArgs["syslog.listenAddr.tcp"]` or `extraArgs["syslog.listenAddr.udp"]`, move them to `syslog.tcp[]` / `syslog.udp[]` to expose ports and generate args.
  - If you relied on Service port `8429`, set `service.servicePort: 8429` or adjust the primary HTTP `value`.

<sup>Written for commit 89de2b049030e1db2c7adb104cbe3142c37f64fc. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2932?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

