### PR TITLE
.github: enforce least priviledge permissions for action jobs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,11 +16,12 @@ on:
       - '**/_index.md.gotmpl'
       - '.github/workflows/docs.yaml'
 
+permissions: {}
+
 jobs:
   publish-readme:
     permissions:
       contents: write
-      id-token: write
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -4,9 +4,12 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   release:
     permissions:
+      contents: read
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,12 @@ env:
   HELM_VERSION: 4.1.3
   YQ_VERSION: 4.44.2
 
+permissions: {}
+
 jobs:
   release:
     permissions:
-      contents: write
+      contents: read
       packages: write
       id-token: write
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   release:
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
     runs-on: ubuntu-latest

--- a/.github/workflows/run-lint.yaml
+++ b/.github/workflows/run-lint.yaml
@@ -19,6 +19,8 @@ on:
 env:
   HELM_VERSION: 3.15.1
 
+permissions: {}
+
 jobs:
   lint-charts:
     name: Lint Charts

--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -27,6 +27,8 @@ on:
 env:
   HELM_VERSION: 3.17.4
 
+permissions: {}
+
 jobs:
   chart-tests:
     name: Run chart tests

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -3,11 +3,12 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   stale:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899  # v10.3.0


### PR DESCRIPTION
Scope permissions to jobs and set `permissions: {}` for workflow level.