### PR TITLE
release all logs and traces charts

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 **Update note 1**: `.Values.extraArgs.httpListenAddr` was replaced by `.Values.http` array of HTTP listen address configuration.
 
+**Update note 2**: `.Values.extraArgs["syslog.listenAddr.tcp"]` and `.Values.extraArgs["syslog.listenAddr.udp"]` were replaced by `.Values.syslog.tcp` and `.Values.syslog.udp` arrays of syslog listen address configuration.
+
 - added `.Values.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
 - support `.Values.syslog.tcp` and `.Values.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings.
 

--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 **Update note 2**: `.Values.extraArgs["syslog.listenAddr.tcp"]` and `.Values.extraArgs["syslog.listenAddr.udp"]` were replaced by `.Values.syslog.tcp` and `.Values.syslog.udp` arrays of syslog listen address configuration.
 
-- added `.Values.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
-- support `.Values.syslog.tcp` and `.Values.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings.
+- added `.Values.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Has higher priority than `extraArgs`.
+- support `.Values.syslog.tcp` and `.Values.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings. Has higher priority than `extraArgs`.
 
 ## 0.1.3
 

--- a/charts/victoria-logs-agent/Chart.lock
+++ b/charts/victoria-logs-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.1
-digest: sha256:6b3a43e93a5a4f9e38cdbbefa43841665b62b429f570e19d5e64c366fd2eabe7
-generated: "2026-05-26T21:26:25.365753+03:00"
+  version: 0.3.2
+digest: sha256:9522db9e9daa54b8a8cd0e743f76ed326229f7b7bfb67fcd98b3d914c9f0aacd
+generated: "2026-05-27T14:05:00.308895+03:00"

--- a/charts/victoria-logs-agent/Chart.yaml
+++ b/charts/victoria-logs-agent/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 name: victoria-logs-agent
 description: VictoriaLogs Agent - accepts logs from various protocols and replicates them across multiple VictoriaLogs instances.
-version: 0.1.3
+version: 0.2.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-agent/templates/_helpers.tpl
+++ b/charts/victoria-logs-agent/templates/_helpers.tpl
@@ -80,7 +80,7 @@
       {{- $_ := set $args $key $param }}
     {{- end }}
   {{- end }}
-  {{- include "vm.check.extraArgs" $Values.extraArgs -}}
+  {{- include "vl.check.extraArgs" $Values.extraArgs -}}
   {{- $args = mergeOverwrite $args $Values.extraArgs -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end }}

--- a/charts/victoria-logs-agent/templates/_helpers.tpl
+++ b/charts/victoria-logs-agent/templates/_helpers.tpl
@@ -32,8 +32,6 @@
   {{- $args := dict "tmpDataPath" "/vlagent-data" }}
   {{- $_ := set $args "remoteWrite.maxDiskUsagePerURL" $Values.maxDiskUsagePerURL -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $Values.http)) -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $Values.syslog)) -}}
 
   {{- $requiredParams := list "url" }}
 
@@ -82,5 +80,7 @@
   {{- end }}
   {{- include "vl.check.extraArgs" $Values.extraArgs -}}
   {{- $args = mergeOverwrite $args $Values.extraArgs -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $Values.http)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $Values.syslog)) -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end }}

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 **Update note 2**: `.Values.vlinsert.extraArgs["syslog.listenAddr.tcp"]` and `.Values.vlinsert.extraArgs["syslog.listenAddr.udp"]` were replaced by `.Values.vlinsert.syslog.tcp` and `.Values.vlinsert.syslog.udp` arrays of syslog listen address configuration.
 
-- added `.Values.<component>.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Item with `primary: true` on `vlstorage` is used for storageNode address resolution.
-- support `.Values.vlinsert.syslog.tcp` and `.Values.vlinsert.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings.
+- added `.Values.<component>.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Item with `primary: true` on `vlstorage` is used for storageNode address resolution. Has higher priority than `extraArgs`.
+- support `.Values.vlinsert.syslog.tcp` and `.Values.vlinsert.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings. Has higher priority than `extraArgs`.
 - add ability to override VictoriaLogs container command.
 
 ## 0.1.5

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 **Update note 1**: `.Values.<component>.extraArgs.httpListenAddr` was replaced by `.Values.<component>.http` array of HTTP listen address configuration, where `<component>` is one of `vlinsert`, `vlselect`, `vlstorage`, `vmauth`.
 
+**Update note 2**: `.Values.vlinsert.extraArgs["syslog.listenAddr.tcp"]` and `.Values.vlinsert.extraArgs["syslog.listenAddr.udp"]` were replaced by `.Values.vlinsert.syslog.tcp` and `.Values.vlinsert.syslog.udp` arrays of syslog listen address configuration.
+
 - added `.Values.<component>.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Item with `primary: true` on `vlstorage` is used for storageNode address resolution.
 - support `.Values.vlinsert.syslog.tcp` and `.Values.vlinsert.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings.
 - add ability to override VictoriaLogs container command.

--- a/charts/victoria-logs-cluster/Chart.lock
+++ b/charts/victoria-logs-cluster/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.52.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.1
-digest: sha256:8d1c6166fa42cb0d983c7e44c0bf8b4bb11dea9a1d6c964827454eed24d2decb
-generated: "2026-05-21T16:13:16.660527+03:00"
+  version: 0.3.2
+digest: sha256:f5c00dd9e7459174c6b1d5e6a3addf8b566630af3868d0988970ca601c25263f
+generated: "2026-05-27T14:05:12.114377+03:00"

--- a/charts/victoria-logs-cluster/Chart.yaml
+++ b/charts/victoria-logs-cluster/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs cluster Helm chart deploys VictoriaLogs cluster database in Kubernetes.
 name: victoria-logs-cluster
-version: 0.1.5
+version: 0.2.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-cluster/templates/_helpers.tpl
+++ b/charts/victoria-logs-cluster/templates/_helpers.tpl
@@ -31,7 +31,7 @@
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" $ctx)) -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $app.syslog)) -}}
-  {{- include "vm.check.extraArgs" $app.extraArgs -}}
+  {{- include "vl.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- $storage := $Values.vlstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}

--- a/charts/victoria-logs-cluster/templates/_helpers.tpl
+++ b/charts/victoria-logs-cluster/templates/_helpers.tpl
@@ -29,10 +29,10 @@
   {{- $args := dict "select.disable" "true" -}}
   {{- $ctx := dict "style" "plain" "appKey" "vlstorage" "helm" .helm }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" $ctx)) -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $app.syslog)) -}}
   {{- include "vl.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $app.syslog)) -}}
   {{- $storage := $Values.vlstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
@@ -60,9 +60,9 @@
   {{- $args := dict -}}
   {{- $_ := set $args "auth.config" "/config/auth.yml" -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
 
@@ -72,9 +72,9 @@
   {{- $args := dict "insert.disable" "true" -}}
   {{- $ctx := dict "style" "plain" "appKey" "vlstorage" "helm" .helm }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- $storage := $Values.vlstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
@@ -117,9 +117,9 @@
   {{- end -}}
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
 

--- a/charts/victoria-logs-multilevel/Chart.lock
+++ b/charts/victoria-logs-multilevel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.1
-digest: sha256:6b3a43e93a5a4f9e38cdbbefa43841665b62b429f570e19d5e64c366fd2eabe7
-generated: "2026-05-21T16:13:52.029079+03:00"
+  version: 0.3.2
+digest: sha256:9522db9e9daa54b8a8cd0e743f76ed326229f7b7bfb67fcd98b3d914c9f0aacd
+generated: "2026-05-27T14:05:44.382273+03:00"

--- a/charts/victoria-logs-multilevel/Chart.yaml
+++ b/charts/victoria-logs-multilevel/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs multilevel Helm chart deploys global read for multiple storage groups.
 name: victoria-logs-multilevel
-version: 0.1.1
+version: 0.2.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 **Update note 1**: `.Values.server.extraArgs.httpListenAddr` was replaced by `.Values.server.http` array of HTTP listen address configuration.
 
+**Update note 2**: `.Values.server.extraArgs["syslog.listenAddr.tcp"]` and `.Values.server.extraArgs["syslog.listenAddr.udp"]` were replaced by `.Values.server.syslog.tcp` and `.Values.server.syslog.udp` arrays of syslog listen address configuration.
+
 - added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
 - support `.Values.server.syslog.tcp` and `.Values.server.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings.
 - add ability to override VictoriaLogs container command.

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 **Update note 2**: `.Values.server.extraArgs["syslog.listenAddr.tcp"]` and `.Values.server.extraArgs["syslog.listenAddr.udp"]` were replaced by `.Values.server.syslog.tcp` and `.Values.server.syslog.udp` arrays of syslog listen address configuration.
 
-- added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
-- support `.Values.server.syslog.tcp` and `.Values.server.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings.
+- added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Has higher priority than `extraArgs`.
+- support `.Values.server.syslog.tcp` and `.Values.server.syslog.udp` lists for configuring syslog TCP/UDP listen addresses with optional TLS settings. Has higher priority than `extraArgs`.
 - add ability to override VictoriaLogs container command.
 
 ## 0.12.5

--- a/charts/victoria-logs-single/Chart.lock
+++ b/charts/victoria-logs-single/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.52.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.1
-digest: sha256:8d1c6166fa42cb0d983c7e44c0bf8b4bb11dea9a1d6c964827454eed24d2decb
-generated: "2026-05-21T16:13:25.975028+03:00"
+  version: 0.3.2
+digest: sha256:f5c00dd9e7459174c6b1d5e6a3addf8b566630af3868d0988970ca601c25263f
+generated: "2026-05-27T14:05:57.153032+03:00"

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs single Helm chart deploys VictoriaLogs database in Kubernetes.
 name: victoria-logs-single
-version: 0.12.5
+version: 0.13.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/templates/_helpers.tpl
+++ b/charts/victoria-logs-single/templates/_helpers.tpl
@@ -46,9 +46,9 @@
   {{- end -}}
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $app.syslog)) -}}
   {{- include "vl.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $app.syslog)) -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}

--- a/charts/victoria-logs-single/templates/_helpers.tpl
+++ b/charts/victoria-logs-single/templates/_helpers.tpl
@@ -48,7 +48,7 @@
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $app.syslog)) -}}
-  {{- include "vm.check.extraArgs" $app.extraArgs -}}
+  {{- include "vl.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Update note 1**: `.Values.<component>.extraArgs.httpListenAddr` was replaced by `.Values.<component>.http` array of HTTP listen address configuration, where `<component>` is one of `vtinsert`, `vtselect`, `vtstorage`, `vmauth`.
 
-- added `.Values.<component>.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Item with `primary: true` on `vtstorage` is used for storageNode address resolution.
+- added `.Values.<component>.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Item with `primary: true` on `vtstorage` is used for storageNode address resolution. Has higher priority than `extraArgs`.
 - add ability to override container command.
 
 ## 0.1.3

--- a/charts/victoria-traces-cluster/Chart.lock
+++ b/charts/victoria-traces-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.1
-digest: sha256:6b3a43e93a5a4f9e38cdbbefa43841665b62b429f570e19d5e64c366fd2eabe7
-generated: "2026-05-21T16:13:43.043749+03:00"
+  version: 0.3.2
+digest: sha256:9522db9e9daa54b8a8cd0e743f76ed326229f7b7bfb67fcd98b3d914c9f0aacd
+generated: "2026-05-27T14:06:05.730425+03:00"

--- a/charts/victoria-traces-cluster/Chart.yaml
+++ b/charts/victoria-traces-cluster/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v0.9.0
 description: The VictoriaTraces cluster Helm chart deploys VictoriaTraces cluster database in Kubernetes.
 name: victoria-traces-cluster
-version: 0.1.3
+version: 0.2.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-traces-cluster/templates/_helpers.tpl
+++ b/charts/victoria-traces-cluster/templates/_helpers.tpl
@@ -4,9 +4,9 @@
   {{- $app := $Values.vtinsert -}}
   {{- $args := dict -}}
   {{- $ctx := dict "style" "plain" "appKey" "vtstorage" "helm" .helm }}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- $storage := $Values.vtstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
@@ -33,9 +33,9 @@
   {{- $app := $Values.vmauth -}}
   {{- $args := dict -}}
   {{- $_ := set $args "auth.config" "/config/auth.yml" -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
 
@@ -44,9 +44,9 @@
   {{- $app := $Values.vtselect -}}
   {{- $args := dict -}}
   {{- $ctx := dict "style" "plain" "appKey" "vtstorage" "helm" .helm }}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- $storage := $Values.vtstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
@@ -85,9 +85,9 @@
     {{- end -}}
   {{- end -}}
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
 

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Update note 1**: `.Values.server.extraArgs.httpListenAddr` was replaced by `.Values.server.http` array of HTTP listen address configuration.
 
-- added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation.
+- added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Has higher priority than `extraArgs`.
 - add ability to override container command.
 
 ## 0.0.9

--- a/charts/victoria-traces-single/Chart.lock
+++ b/charts/victoria-traces-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.1
-digest: sha256:6b3a43e93a5a4f9e38cdbbefa43841665b62b429f570e19d5e64c366fd2eabe7
-generated: "2026-05-21T16:13:35.325254+03:00"
+  version: 0.3.2
+digest: sha256:9522db9e9daa54b8a8cd0e743f76ed326229f7b7bfb67fcd98b3d914c9f0aacd
+generated: "2026-05-27T14:06:13.429957+03:00"

--- a/charts/victoria-traces-single/Chart.yaml
+++ b/charts/victoria-traces-single/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v0.9.0
 description: The VictoriaTraces single Helm chart deploys VictoriaTraces database in Kubernetes.
 name: victoria-traces-single
-version: 0.0.9
+version: 0.1.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-traces-single/templates/_helpers.tpl
+++ b/charts/victoria-traces-single/templates/_helpers.tpl
@@ -19,8 +19,8 @@
   {{- end -}}
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- include "vm.check.extraArgs" $app.extraArgs -}}
   {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}


### PR DESCRIPTION
additionally prohibit using syslog.listenAddr.tcp and syslog.listenAddr.udp in extraArgs and made priority of command line arguments generated by `http` and `syslog` sections higher than extraArgs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release new versions of all VictoriaLogs and VictoriaTraces charts. HTTP and syslog config sections now override `extraArgs`, and using `syslog.listenAddr.tcp/udp` in `extraArgs` is blocked to prevent conflicts.

- **New Features**
  - HTTP and syslog settings take priority over `extraArgs` in all charts.
  - Block `extraArgs["syslog.listenAddr.tcp"]` and `extraArgs["syslog.listenAddr.udp"]`; use `.syslog.tcp` / `.syslog.udp` arrays instead.
  - Bump `victoria-metrics-common` to `0.3.2`.

- **Migration**
  - Move syslog listen addresses from `extraArgs` to `.syslog.tcp` / `.syslog.udp` under the relevant component (e.g., `.Values.server`, `.Values.vlinsert`, `.Values.http`).
  - Remove duplicate flags from `extraArgs` if also set in `.http` or `.syslog`; those sections now win.

<sup>Written for commit 8115cfcfd9a776f3d10a7acdf0874d035640ae52. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2936?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

