### PR TITLE
k8s-stack: preparations before release

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Next release
 
-- add per-group additionalGroupByLabels, that replace defaultRules.additionalGroupByLabels. See [#2382](https://github.com/VictoriaMetrics/helm-charts/issues/2832).
+**Update note 1**: `defaultRules.create` is renamed to `defaultRules.enabled`; per-group `create` is renamed to `enabled`. Old `create` key is still respected as a fallback if `enabled` is not set.
+
+**Update note 2**: `defaultRules.additionalGroupByLabels` is renamed to `defaultRules.extraGroupByLabels`. Old `additionalGroupByLabels` is still respected as a fallback if `extraGroupByLabels` is not set.
+
+- rename `defaultRules.create` and per-group `create` to `enabled`, with fallback to `create` for backward compatibility.
+- add per-group extraGroupByLabels, that replace defaultRules.extraGroupByLabels (if absent defaults to defaultRules.additionalGroupByLabels). See [#2832](https://github.com/VictoriaMetrics/helm-charts/issues/2832).
 
 ## 0.80.0
 

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.80.0
+version: 0.81.0
 # renovate: image=victoriametrics/victoria-metrics
 appVersion: v1.144.0
 sources:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/alertmanager.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/alertmanager.rules.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: alertmanager.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/etcd.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/etcd.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: etcd
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/general.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/general.rules.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: general.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_limits.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_limits.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_cpu_limits
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_requests.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_requests.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_cpu_requests
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_usage_seconds_total.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_cpu_usage_seconds_total.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_cpu_usage_seconds_total
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_cache.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_cache.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_cache
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_limits.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_limits.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_limits
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_requests.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_requests.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_requests
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_rss.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_rss.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_rss
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_swap.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_swap.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_swap
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_working_set_bytes.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.container_memory_working_set_bytes.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.container_memory_working_set_bytes
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.pod_owner.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/k8s.rules.pod_owner.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: k8s.rules.pod_owner
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-availability.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-availability.rules.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-apiserver-availability.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-burnrate.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-burnrate.rules.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-apiserver-burnrate.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-histogram.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-histogram.rules.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-apiserver-histogram.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-slos.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-apiserver-slos.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-apiserver-slos
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-prometheus-node-recording.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-prometheus-node-recording.rules.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-prometheus-node-recording.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-scheduler.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-scheduler.rules.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-scheduler.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-state-metrics.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kube-state-metrics.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kube-state-metrics
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubelet.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubelet.rules.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubelet.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-apps.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-apps.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-apps
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-resources.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-resources.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-resources
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-storage.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-storage.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-storage
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-apiserver.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-apiserver.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-system-apiserver
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-controller-manager.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-controller-manager.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-system-controller-manager
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-kubelet.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-kubelet.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-system-kubelet
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-scheduler.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system-scheduler.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-system-scheduler
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/kubernetes-system.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: kubernetes-system
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/node-exporter.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/node-exporter.rules.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: node-exporter.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/node-exporter.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/node-exporter.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: node-exporter
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/node-network.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/node-network.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: node-network
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/node.rules.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/node.rules.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: node.rules
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vm-health.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vm-health.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: vm-health
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vmagent.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vmagent.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: vmagent
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vmalert.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vmalert.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: vmalert
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vmcluster.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vmcluster.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: vmcluster
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vmoperator.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vmoperator.yaml
@@ -2,12 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: vmoperator
 rules:

--- a/charts/victoria-metrics-k8s-stack/files/rules/generated/vmsingle.yaml
+++ b/charts/victoria-metrics-k8s-stack/files/rules/generated/vmsingle.yaml
@@ -2,8 +2,8 @@
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := append $Values.defaultRules.additionalGroupByLabels $clusterLabel }}
-{{- $groupLabels := join "," (uniq $additionalGroupByLabels) }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 name: vmsingle
 rules:
@@ -98,6 +98,36 @@ rules:
   for: 15m
   labels:
     severity: warning
+- alert: MetricNameStatsCacheUtilizationIsTooHigh
+  expr: (vm_cache_size_bytes{type="storage/metricNamesStatsTracker"} / vm_cache_size_max_bytes{type="storage/metricNamesStatsTracker"}) > 0.95
+  annotations:
+    description: 'Metric names usage cache stores information about unique metric names and how frequently they are queried - see https://docs.victoriametrics.com/victoriametrics/#track-ingested-metrics-usage. When cache is overutilized, it will stop tracking the new metric names. It has no other negative impact. Usually, the number of unique metric names is very limited (thousands). The cache can be overutilized only if metric names are changing too frequently or if the cache size is too low. There are following ways to mitigate cache overutilization: - disable cache via `--storage.trackMetricNamesStats=false` flag, so metric names usage will stop tracking - increase the cache size via `--storage.cacheSizeMetricNamesStats` flag - reset the cache (see docs for details)'
+    summary: Cache capacity for tracking metric names usage on {{`{{`}} $labels.instance {{`}}`}} (job={{`{{`}} $labels.job {{`}}`}}) is utilized for more than 95% during the last 15min
+  condition: true
+  for: 15m
+  labels:
+    severity: warning
+- alert: IndexDBRecordsDrop
+  expr: increase(vm_indexdb_items_dropped_total[5m]) > 0
+  annotations:
+    description: "VictoriaMetrics could skip registering new timeseries during ingestion if they fail the validation process. \nFor example, `reason=too_long_item` means that time series cannot exceed 64KB. Please, reduce the number \nof labels or label values for such series. Or enforce these limits via `-maxLabelsPerTimeseries` and \n`-maxLabelValueLen` command-line flags.\n"
+    summary: IndexDB skipped registering items during data ingestion with reason={{`{{`}} $labels.reason {{`}}`}}.
+  condition: true
+  labels:
+    severity: critical
+- alert: TooManyTSIDMisses
+  expr: increase(vm_missing_tsids_for_metric_id_total[5m]) > 0
+  annotations:
+    description: |-
+      Unexpected TSID misses for \"{{`{{`}} $labels.job {{`}}`}}\" ({{`{{`}} $labels.instance {{`}}`}}) for the last 15 minutes.
+      If this happens after unclean shutdown of VictoriaMetrics process (via \"kill -9\", OOM or power off),
+      then this is OK - the alert must go away in a few minutes after the restart.
+      Otherwise this may point to the corruption of index data.
+    summary: Unexpected TSID misses for job "{{`{{`}} $labels.job {{`}}`}}" ({{`{{`}} $labels.instance {{`}}`}}) for the last 15 minutes
+  condition: true
+  for: 15m
+  labels:
+    severity: critical
 concurrency: 2
 condition: true
 interval: 30s

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/rule.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/rule.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.defaultRules.create }}
+{{- if (dig "enabled" (dig "create" true .Values.defaultRules) .Values.defaultRules) }}
 
 {{- /*
 Default rules alias
@@ -48,10 +48,11 @@ Get group data from file
 {{- $groupCtx := mergeOverwrite $ctx $group }}
 
 {{- /*
-Resolve effectiveGroupByLabels: per-group additionalGroupByLabels overrides global if set
+Resolve extraGroupByLabels: per-group extraGroupByLabels overrides global if set
 */}}
-{{- $additionalGroupByLabels := dig "additionalGroupByLabels" $defaultRules.additionalGroupByLabels $group }}
-{{- $_ := set $groupCtx "additionalGroupByLabels" $additionalGroupByLabels }}
+{{- $globalExtraGroupByLabels := $defaultRules.extraGroupByLabels | default $defaultRules.additionalGroupByLabels | default list }}
+{{- $extraGroupByLabels := dig "extraGroupByLabels" $globalExtraGroupByLabels $group }}
+{{- $_ := set $groupCtx "extraGroupByLabels" $extraGroupByLabels }}
 
 {{- $groupData := fromYaml (tpl ($.Files.Get $groupFile) $groupCtx) -}}
 
@@ -95,7 +96,7 @@ Filter out ignore rules
   {{- $defaultRule := deepCopy (index $defaultRules $ruleKey) }}
   {{- $defaultInGroup := deepCopy (index $group $ruleKey | default dict) }}
   {{- $resultRule := mergeOverwrite (deepCopy $commonRule) $defaultRule $commonInGroupRule $defaultInGroup $exactRule }}
-  {{- if (and (dig "create" true $resultRule) $ruleCondition) }}
+  {{- if (and (dig "enabled" (dig "create" true $resultRule) $resultRule) $ruleCondition) }}
     {{- $ruleSpec := mergeOverwrite (deepCopy $ruleSpec) (dig "spec" (dict) $resultRule) }}
     {{- $filteredRulesSpec = append $filteredRulesSpec $ruleSpec }}
   {{- end }}
@@ -105,7 +106,7 @@ Filter out ignore rules
 {{- /*
 Check if group is enabled
 */}}
-{{- if (and $rulesSpec (dig "create" true $group) $groupCondition) }}
+{{- if (and $rulesSpec (dig "enabled" (dig "create" true $group) $group) $groupCondition) }}
 {{- $ruleName := (include "vm-k8s-stack.rulegroup.name" $ctx) }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -69,8 +69,8 @@ defaultDashboards:
 # -- Create default rules for monitoring the cluster
 defaultRules:
   # -- Labels, which are used for grouping results of the queries. Note that these labels are joined with `.Values.global.clusterLabel`
-  additionalGroupByLabels: []
-  create: true
+  extraGroupByLabels: []
+  enabled: true
 
   # -- Common properties for VMRule groups
   group:
@@ -105,7 +105,7 @@ defaultRules:
   # -- Per rule properties
   rules: {}
     # CPUThrottlingHigh:
-    #   create: true
+    #   enabled: true
     #   spec:
     #     for: 15m
     #     labels:
@@ -113,9 +113,10 @@ defaultRules:
   # -- Rule group properties
   groups:
     etcd:
-      create: true
-      # -- Per-group override for additionalGroupByLabels. When set, replaces the global additionalGroupByLabels for this group only.
-      # additionalGroupByLabels: []
+      # -- Enable/disable rule group
+      enabled: true
+      # -- Per-group override for extraGroupByLabels. When set, replaces the global extraGroupByLabels for this group only.
+      # extraGroupByLabels: []
       # -- Common properties for all rules in a group
       rules: {}
       # spec:
@@ -132,120 +133,82 @@ defaultRules:
       #   annotations:
       #     dashboard: https://example.com/dashboard/1
     general:
-      create: true
       rules: {}
     k8sContainerCpuLimits:
-      create: true
       rules: {}
     k8sContainerCpuRequests:
-      create: true
       rules: {}
     k8sContainerCpuUsageSecondsTotal:
-      create: true
       rules: {}
     k8sContainerMemoryLimits:
-      create: true
       rules: {}
     k8sContainerMemoryRequests:
-      create: true
       rules: {}
     k8sContainerMemoryRss:
-      create: true
       rules: {}
     k8sContainerMemoryCache:
-      create: true
       rules: {}
     k8sContainerMemoryWorkingSetBytes:
-      create: true
       rules: {}
     k8sContainerMemorySwap:
-      create: true
       rules: {}
     k8sPodOwner:
-      create: true
       rules: {}
     k8sContainerResource:
-      create: true
       rules: {}
     kubeApiserver:
-      create: true
       rules: {}
     kubeApiserverAvailability:
-      create: true
       rules: {}
     kubeApiserverBurnrate:
-      create: true
       rules: {}
     kubeApiserverHistogram:
-      create: true
       rules: {}
     kubeApiserverSlos:
-      create: true
       rules: {}
     kubelet:
-      create: true
       rules: {}
     kubePrometheusGeneral:
-      create: true
       rules: {}
     kubePrometheusNodeRecording:
-      create: true
       rules: {}
     kubernetesApps:
-      create: true
       rules: {}
       targetNamespace: ".*"
     kubernetesResources:
-      create: true
       rules: {}
     kubernetesStorage:
-      create: true
       rules: {}
       targetNamespace: ".*"
     kubernetesSystem:
-      create: true
       rules: {}
     kubernetesSystemKubelet:
-      create: true
       rules: {}
     kubernetesSystemApiserver:
-      create: true
       rules: {}
     kubernetesSystemControllerManager:
-      create: true
       rules: {}
     kubeScheduler:
-      create: true
       rules: {}
     kubernetesSystemScheduler:
-      create: true
       rules: {}
     kubeStateMetrics:
-      create: true
       rules: {}
     nodeNetwork:
-      create: true
       rules: {}
     node:
-      create: true
       rules: {}
     vmagent:
-      create: true
       rules: {}
     vmsingle:
-      create: true
       rules: {}
     vmcluster:
-      create: true
       rules: {}
     vmHealth:
-      create: true
       rules: {}
     vmoperator:
-      create: true
       rules: {}
     alertmanager:
-      create: true
       rules: {}
 
   # -- Runbook url prefix for default rules

--- a/hack/rules-and-dashboards/main.go
+++ b/hack/rules-and-dashboards/main.go
@@ -49,12 +49,8 @@ var headers = map[string]string{
 {{- $Values := (.helm).Values | default .Values }}
 {{- $runbookUrl := ($Values.defaultRules).runbookUrl | default "https://runbooks.prometheus-operator.dev/runbooks" }}
 {{- $clusterLabel := ($Values.global).clusterLabel | default "cluster" }}
-{{- $additionalGroupByLabels := $Values.defaultRules.additionalGroupByLabels }}
-{{- if hasKey . "additionalGroupByLabels" }}
-  {{- $additionalGroupByLabels = .additionalGroupByLabels }}
-{{- end }}
-{{- $additionalGroupByLabels := uniq (append $additionalGroupByLabels $clusterLabel) }}
-{{- $groupLabels := join "," $additionalGroupByLabels }}
+{{- $extraGroupByLabels := uniq (append .extraGroupByLabels $clusterLabel) }}
+{{- $groupLabels := join "," $extraGroupByLabels }}
 {{- $grafanaAddr := include "vm-k8s-stack.grafana.addr" . }}
 `,
 }
@@ -402,7 +398,7 @@ common.grafanaDashboards
 		},
 	},
 	{
-		url:  "https://raw.githubusercontent.com/VictoriaMetrics/VictoriaMetrics/master/deployment/docker/rules/alerts.yml",
+		url:  "https://raw.githubusercontent.com/VictoriaMetrics/VictoriaMetrics/master/deployment/docker/rules/alerts-single-node.yml",
 		kind: "rules",
 		charts: []string{
 			"victoria-metrics-k8s-stack",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare `victoria-metrics-k8s-stack` for release by renaming rule toggles to `enabled` and switching to `extraGroupByLabels`, with fallbacks for backward compatibility. Bumps chart to 0.81.0, updates the generator to use upstream single-node alerts, and regenerates rule files (including new `vmsingle` alerts).

- **Refactors**
  - Append `cluster` to `extraGroupByLabels`; allow per-group override with fallback to the old key.
  - Use alerts from `alerts-single-node`; add `MetricNameStatsCacheUtilizationIsTooHigh`, `IndexDBRecordsDrop`, and `TooManyTSIDMisses` to `vmsingle`; simplify `values.yaml`; update templates and `CHANGELOG.md`.

- **Migration**
  - In `values.yaml`, use `defaultRules.enabled` instead of `defaultRules.create`.
  - For groups and rules, use `enabled` instead of `create` (old key still works).
  - Rename `additionalGroupByLabels` to `extraGroupByLabels` (global and per-group).

<sup>Written for commit f4efbc56b99cb5c67ab0622f9776bca49c3e6c67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2938?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

