### PR TITLE
logs and traces: fix invalid YAML in route.yaml backendRef

### DIFF
--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- fix invalid YAML rendered by `templates/route.yaml` when `vlinsert.route.enabled=true` or `vlselect.route.enabled=true`. The `$httpAddr` variable assignment was trimming the newline before `port:`, causing `helm template` to fail with `mapping values are not allowed in this context`. See [#2939](https://github.com/VictoriaMetrics/helm-charts/issues/2939).
 
 ## 0.2.0
 

--- a/charts/victoria-logs-cluster/templates/route.yaml
+++ b/charts/victoria-logs-cluster/templates/route.yaml
@@ -28,7 +28,7 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr }}
           port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $app.http) $httpAddr (empty $httpAddr)))) }}
           group: ''
           kind: Service

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- fix invalid YAML rendered by `templates/route.yaml` when `server.route.enabled=true`. The `$httpAddr` variable assignment was trimming the newline before `port:`, causing `helm template` to fail with `mapping values are not allowed in this context`. See [#2939](https://github.com/VictoriaMetrics/helm-charts/issues/2939).
 
 ## 0.13.0
 

--- a/charts/victoria-logs-single/templates/route.yaml
+++ b/charts/victoria-logs-single/templates/route.yaml
@@ -29,7 +29,7 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr }}
           port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $app.http) $httpAddr (empty $httpAddr)))) }}
           group: ''
           kind: Service

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- fix invalid YAML rendered by `templates/route.yaml` when route is enabled on `vtinsert`/`vtselect`/`vtstorage`/`vmauth`. The `$httpAddr` variable assignment was trimming the newline before `port:`, causing `helm template` to fail with `mapping values are not allowed in this context`. See [#2939](https://github.com/VictoriaMetrics/helm-charts/issues/2939).
 
 ## 0.2.0
 

--- a/charts/victoria-traces-cluster/templates/route.yaml
+++ b/charts/victoria-traces-cluster/templates/route.yaml
@@ -28,7 +28,7 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr }}
           port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $app.http) $httpAddr (empty $httpAddr)))) }}
           group: ''
           kind: Service


### PR DESCRIPTION
## Summary

Fixes #2939.

Commit 94b8fa3 introduced a `$httpAddr` variable assignment inside the `backendRefs` block of `route.yaml` with trailing whitespace trimming (`-}}`). That stripped the newline between `- name:` and `port:`, collapsing them onto one line:

```yaml
backendRefs:
  - name: victoria-logs-single-serverport: 9428
    group: ''
    kind: Service
    weight: 1
```

`helm template` then fails with:

```
YAML parse error on victoria-logs-single/templates/route.yaml:
error converting YAML to JSON: yaml: line 32: mapping values are not allowed in this context
```

Same template pattern is duplicated in three charts, so all three are affected.

## Fix

Drop the trailing `-` from the variable-assignment tag so the newline before `port:` survives:

```diff
-          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr }}
```

Applied to:
- `charts/victoria-logs-single/templates/route.yaml`
- `charts/victoria-logs-cluster/templates/route.yaml`
- `charts/victoria-traces-cluster/templates/route.yaml`

## Test plan

- [x] `helm template` of `victoria-logs-single` with `server.route.enabled=true` renders valid YAML (port resolves to `9428` from `server.http`)
- [x] Same chart with `server.extraArgs.httpListenAddr=:9999` still renders valid YAML and uses the extraArgs path (port `9999`)
- [x] `helm template` of `victoria-logs-cluster` with `vlinsert.route.enabled=true` / `vlselect.route.enabled=true` renders valid YAML
- [x] `helm template` of `victoria-traces-cluster` with `vtinsert.route.enabled=true` / `vtselect.route.enabled=true` renders valid YAML

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed invalid YAML in HTTPRoute backendRefs by preserving the newline before `port:` in `route.yaml`, so `helm template` renders correctly. Fixes #2939.

- **Bug Fixes**
  - Dropped `-}}` from the `$httpAddr` assignment to keep `- name:` and `port:` on separate lines.
  - Applied to `victoria-logs-single`, `victoria-logs-cluster`, and `victoria-traces-cluster` charts.

<sup>Written for commit 0af504b48f2160b166f70f2422c73d812fe32d23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2941?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

