### PR TITLE
victoria-metrics-{agent,alert,gateway,single,cluster,auth}: support section for multiple HTTP listen address configuration

### DIFF
--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Next release
 
+**Update note 1**: `.Values.extraArgs.httpListenAddr` was replaced by `.Values.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-agent/#http-listen-address) for details.
+
+- `serviceMonitor` port now defaults to the primary `http` list item name; added explicit `port` field to override it without using `targetPort`.
+- fixed HTTPRoute backend `port` field being rendered on the same line as `name` due to incorrect whitespace trimming in the route template.
+
+- added `.Values.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Has higher priority than `extraArgs`.
 - add ability to override container command.
 
 ## 0.40.0

--- a/charts/victoria-metrics-agent/_index.md.gotmpl
+++ b/charts/victoria-metrics-agent/_index.md.gotmpl
@@ -217,6 +217,38 @@ config:
           target_label: node
 ```
 
+### HTTP listen address
+
+The chart configures the HTTP listen address via `.Values.http` list.
+Each entry in the list configures a separate HTTP listener.
+The primary listener (marked with `primary: true`) is used for Pod health checks and Service port generation.
+
+To enable TLS on the HTTP listener:
+
+```yaml
+http:
+  - name: https
+    primary: true
+    value: :8429
+    tls: true
+    tlsCertFile: /path/to/tls.crt
+    tlsKeyFile: /path/to/tls.key
+```
+
+To expose an additional listener on a different port:
+
+```yaml
+http:
+  - name: http
+    primary: true
+    value: :8429
+  - name: https
+    value: :8430
+    tls: true
+    tlsCertFile: /path/to/tls.crt
+    tlsKeyFile: /path/to/tls.key
+```
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-agent/templates/_helpers.tpl
+++ b/charts/victoria-metrics-agent/templates/_helpers.tpl
@@ -23,7 +23,11 @@
   {{- end -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.args.positional" $rwItems)) -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args $Values.extraArgs -}}
+  {{- $extraArgs := $Values.extraArgs | default dict }}
+  {{- $args = mergeOverwrite $args $extraArgs -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
+    {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $Values.http)) -}}
+  {{- end -}}
   {{- if and (eq $Values.mode "statefulSet") $Values.statefulSet.clusterMode }}
     {{- $_ := set $args "promscrape.cluster.membersCount" $Values.replicaCount -}}
     {{- $_ := set $args "promscrape.cluster.replicationFactor" $Values.statefulSet.replicationFactor -}}

--- a/charts/victoria-metrics-agent/templates/monitor.yaml
+++ b/charts/victoria-metrics-agent/templates/monitor.yaml
@@ -3,6 +3,12 @@
 {{- $ctx := dict "helm" . }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
+{{- $port := "http" -}}
+{{- range .Values.http -}}
+  {{- if .primary -}}
+    {{- $port = .name -}}
+  {{- end -}}
+{{- end -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -23,7 +29,12 @@ spec:
   selector:
     matchLabels: {{ include "vm.commonLabels" $ctx | nindent 6 }}
   endpoints:
-    - port: http
+    -
+      {{- with $serviceMonitor.targetPort }}
+      targetPort: {{ . }}
+      {{- else }}
+      port: {{ $serviceMonitor.port | default $port }}
+      {{- end }}
       {{- with $serviceMonitor.basicAuth }}
       basicAuth: {{ toYaml . | nindent 8 }}
       {{- end }}
@@ -44,8 +55,5 @@ spec:
       {{- end }}
       {{- with $serviceMonitor.metricRelabelings }}
       metricRelabelings: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with $serviceMonitor.targetPort }}
-      targetPort: {{ . }}
       {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-agent/templates/route.yaml
+++ b/charts/victoria-metrics-agent/templates/route.yaml
@@ -29,7 +29,11 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" ($app.extraArgs).httpListenAddr)) }}
+          {{- $addrFlag := ($app.extraArgs | default dict).httpListenAddr }}
+          {{- if empty $addrFlag }}
+            {{- $addrFlag = include "vm.addr.primary" $app.http }}
+          {{- end }}
+          port: {{ $route.port | default ($app.service.servicePort | default (include "vm.port.from.flag" (dict "flag" $addrFlag))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-metrics-agent/templates/server.yaml
+++ b/charts/victoria-metrics-agent/templates/server.yaml
@@ -90,8 +90,11 @@ spec:
             {{ toYaml .| nindent 12 }}
             {{- end }}
           ports:
-            - name: http
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8429") }}
+            {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+            {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr)) (empty $httpAddr) }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8429") }}
+            {{- end }}
             {{- with $app.extraArgs.graphiteListenAddr }}
             - name: graphite-tcp
               protocol: TCP

--- a/charts/victoria-metrics-agent/templates/service.yaml
+++ b/charts/victoria-metrics-agent/templates/service.yaml
@@ -49,13 +49,17 @@ spec:
   trafficDistribution: {{ . }}
   {{- end }}
   ports:
-    - name: http
-      port: {{ $service.servicePort }}
+    {{- $httpAddr := (.Values.extraArgs | default dict).httpListenAddr -}}
+    {{- range ternary .Values.http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
+    - name: {{ .name }}
+      {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8429") }}
+      port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
       protocol: TCP
-      targetPort: {{ $service.targetPort }}
-      {{- with $service.nodePort }}
-      nodePort: {{ . }}
+      targetPort: {{ .name }}
+      {{- if and .primary $service.nodePort }}
+      nodePort: {{ $service.nodePort }}
       {{- end }}
+    {{- end }}
     {{- with .Values.extraArgs.graphiteListenAddr }}
     - name: graphite-tcp
       protocol: TCP

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -135,12 +135,17 @@ remoteWrite: []
 #       regex: "dev"
 # - url: http://prometheus:8480/insert/0/prometheus
 
+# -- HTTP listen address configuration. See https://docs.victoriametrics.com/victoriametrics/#http-listen-address for details.
+http:
+  - name: http
+    value: :8429
+    primary: true
+
 # -- VMAgent extra command line arguments
 extraArgs:
   envflag.enable: true
   envflag.prefix: VM_
   loggerFormat: json
-  httpListenAddr: :8429
   # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
   # enableTCP6: true
   # promscrape.maxScrapeSize: "167772160"
@@ -240,9 +245,7 @@ service:
   # -- Load balancer source range
   loadBalancerSourceRanges: []
   # -- Service port
-  servicePort: 8429
-  # -- Target port
-  targetPort: http
+  servicePort: ""
   # nodePort: 30000
   # -- Service type
   type: ClusterIP
@@ -372,8 +375,10 @@ serviceMonitor:
   basicAuth: {}
   # -- Service Monitor metricRelabelings
   metricRelabelings: []
-  # -- Service Monitor targetPort
-  targetPort: http
+  # -- Service Monitor port. Uses primary http item name by default
+  port: ""
+  # -- Service Monitor target port. Overrides port when set
+  targetPort: ""
   # interval: 15s
   # scrapeTimeout: 5s
   # -- Commented. HTTP scheme to use for scraping.

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next release
 
+**Update note 1**: `.Values.server.extraArgs.httpListenAddr` was replaced by `.Values.server.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-alert/#http-listen-address) for details.
+
+- added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Has higher priority than `extraArgs`.
 - add ability to override container command.
 
 ## 0.41.0

--- a/charts/victoria-metrics-alert/Chart.lock
+++ b/charts/victoria-metrics-alert/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
-generated: "2026-04-16T10:13:29.482231209Z"
+  version: 0.3.8
+digest: sha256:58b69be359c7b95c45d44fbe49cdb62625b21a73530526de4006849135022819
+generated: "2026-06-01T15:10:19.459240439Z"

--- a/charts/victoria-metrics-alert/_index.md.gotmpl
+++ b/charts/victoria-metrics-alert/_index.md.gotmpl
@@ -31,6 +31,40 @@ To enable the HA configuration, you can use:
 
 {{ include "chart.uninstallSection" . }}
 
+### HTTP listen address
+
+The chart configures the VMAlert HTTP listen address via `.Values.server.http` list.
+Each entry in the list configures a separate HTTP listener.
+The primary listener (marked with `primary: true`) is used for Pod health checks and Service port generation.
+
+To enable TLS on the HTTP listener:
+
+```yaml
+server:
+  http:
+    - name: https
+      primary: true
+      value: :8880
+      tls: true
+      tlsCertFile: /path/to/tls.crt
+      tlsKeyFile: /path/to/tls.key
+```
+
+To expose an additional listener on a different port:
+
+```yaml
+server:
+  http:
+    - name: http
+      primary: true
+      value: :8880
+    - name: https
+      value: :8881
+      tls: true
+      tlsCertFile: /path/to/tls.crt
+      tlsKeyFile: /path/to/tls.key
+```
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-alert/templates/_helpers.tpl
+++ b/charts/victoria-metrics-alert/templates/_helpers.tpl
@@ -156,8 +156,12 @@
   {{- end }}
   {{- $args := dict }}
   {{- include "vmalert.subargs" (dict "args" $args "datasource" $datasource "remoteWrite" $remoteWrite "remoteRead" $remoteRead "notifier" $notifiers) }}
+  {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args $extraArgs -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
+    {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
 

--- a/charts/victoria-metrics-alert/templates/alert-route.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-route.yaml
@@ -29,7 +29,11 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" ($app.extraArgs).httpListenAddr)) }}
+          {{- $addrFlag := ($app.extraArgs | default dict).httpListenAddr }}
+          {{- if empty $addrFlag }}
+            {{- $addrFlag = include "vm.addr.primary" $app.http }}
+          {{- end }}
+          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" $addrFlag)) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-metrics-alert/templates/alert-server.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-server.yaml
@@ -68,8 +68,11 @@ spec:
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: http
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8880") }}
+            {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+            {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr)) (empty $httpAddr) }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8880") }}
+            {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-metrics-alert/templates/alert-service.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-service.yaml
@@ -44,11 +44,15 @@ spec:
   ipFamilies: {{ toYaml . | nindent 4 }}
   {{- end }}
   ports:
-    - name: http
-      port: {{ $service.servicePort }}
-      targetPort: http
+    {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+    {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
+    - name: {{ .name }}
+      {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8880") }}
+      port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
+      targetPort: {{ .name }}
       protocol: TCP
-      {{- with $service.nodePort }}
-      nodePort: {{ . }}
+      {{- if and .primary $service.nodePort }}
+      nodePort: {{ $service.nodePort }}
       {{- end }}
+    {{- end }}
   selector: {{ include "vm.selectorLabels" $ctx | nindent 4 }}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -163,12 +163,17 @@ server:
     #   bearerTokenFile: ""
 
 
+  # -- HTTP listen address configuration. See https://docs.victoriametrics.com/victoriametrics/#http-listen-address for details.
+  http:
+    - name: http
+      value: :8880
+      primary: true
+
   # -- Extra command line arguments for container of component
   extraArgs:
     envflag.enable: true
     envflag.prefix: VM_
     loggerFormat: json
-    httpListenAddr: :8880
     # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
     rule:
@@ -218,7 +223,7 @@ server:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 8880
+    servicePort: ""
     # nodePort: 30000
     # -- Service type
     type: ClusterIP

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Next release
 
+**Update note 1**: `.Values.extraArgs.httpListenAddr` was replaced by `.Values.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-auth/#http-listen-address) for details.
+
+- `serviceMonitor` port now defaults to the primary `http` list item name; added explicit `port` field to override it without using `targetPort`.
+- fixed HTTPRoute backend `port` field being rendered on the same line as `name` due to incorrect whitespace trimming in the route template.
+
+- added `.Values.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Has higher priority than `extraArgs`.
 - add ability to override container command.
 
 ## 0.33.0

--- a/charts/victoria-metrics-auth/Chart.lock
+++ b/charts/victoria-metrics-auth/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
-generated: "2026-04-16T10:13:36.166870712Z"
+  version: 0.3.8
+digest: sha256:58b69be359c7b95c45d44fbe49cdb62625b21a73530526de4006849135022819
+generated: "2026-06-01T15:10:25.056146674Z"

--- a/charts/victoria-metrics-auth/_index.md.gotmpl
+++ b/charts/victoria-metrics-auth/_index.md.gotmpl
@@ -24,6 +24,38 @@ tags:
 
 {{ include "chart.uninstallSection" . }}
 
+### HTTP listen address
+
+The chart configures the HTTP listen address via `.Values.http` list.
+Each entry in the list configures a separate HTTP listener.
+The primary listener (marked with `primary: true`) is used for Pod health checks and Service port generation.
+
+To enable TLS on the HTTP listener:
+
+```yaml
+http:
+  - name: https
+    primary: true
+    value: :8427
+    tls: true
+    tlsCertFile: /path/to/tls.crt
+    tlsKeyFile: /path/to/tls.key
+```
+
+To expose an additional listener on a different port:
+
+```yaml
+http:
+  - name: http
+    primary: true
+    value: :8427
+  - name: https
+    value: :8428
+    tls: true
+    tlsCertFile: /path/to/tls.crt
+    tlsKeyFile: /path/to/tls.key
+```
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-auth/templates/NOTES.txt
+++ b/charts/victoria-metrics-auth/templates/NOTES.txt
@@ -3,7 +3,7 @@
 {{- $ns := include "vm.namespace" $ctx }}
 Write API:
 
-The Victoria Metrics Auth can be accessed via port {{ .Values.service.servicePort }} on the following DNS name from within your cluster:
+The Victoria Metrics Auth can be accessed via port {{ .Values.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.http) "default" "8427")) }} on the following DNS name from within your cluster:
 {{ $fullname }}
 
 Get the Victoria Metrics Auth service URL by running these commands in the same shell:
@@ -16,10 +16,10 @@ Get the Victoria Metrics Auth service URL by running these commands in the same 
         You can watch the status of by running 'kubectl get svc --namespace {{ $ns }} -w {{ $fullname }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ $ns }} {{ $fullname }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.servicePort }}
+  echo http://$SERVICE_IP:{{ .Values.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.http) "default" "8427")) }}
 {{- else if contains "ClusterIP"  .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ $ns }} -l "app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl --namespace {{ $ns }} port-forward $POD_NAME {{ .Values.service.servicePort }}
+  kubectl --namespace {{ $ns }} port-forward $POD_NAME {{ .Values.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.http) "default" "8427")) }}
 {{- end }}
 
 You need to update your prometheus configuration file and add next lines into it:
@@ -44,7 +44,7 @@ You need to update specify select service URL in your Grafana:
 Input for URL field in Grafana
 
 ```
-http://<select-service>:{{ .Values.service.servicePort }}/select/0/prometheus/
+http://<select-service>:{{ .Values.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.http) "default" "8427")) }}/select/0/prometheus/
 ```
 
 for e.g. inside the kubernetes cluster:

--- a/charts/victoria-metrics-auth/templates/_helpers.tpl
+++ b/charts/victoria-metrics-auth/templates/_helpers.tpl
@@ -2,7 +2,11 @@
   {{- $args := dict -}}
   {{- $Values := (.helm).Values | default .Values }}
   {{- $_ := set $args "auth.config" "/config/auth.yml" -}}
+  {{- $extraArgs := $Values.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args $Values.extraArgs -}}
+  {{- $args = mergeOverwrite $args $extraArgs -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
+    {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $Values.http)) -}}
+  {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}

--- a/charts/victoria-metrics-auth/templates/monitor.yaml
+++ b/charts/victoria-metrics-auth/templates/monitor.yaml
@@ -2,6 +2,12 @@
 {{- $serviceMonitor := .Values.serviceMonitor -}}
 {{- $ctx := dict "helm" . }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
+{{- $port := "http" -}}
+{{- range .Values.http -}}
+  {{- if .primary -}}
+    {{- $port = .name -}}
+  {{- end -}}
+{{- end -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -22,7 +28,12 @@ spec:
   selector:
     matchLabels: {{ include "vm.commonLabels" $ctx | nindent 6 }}
   endpoints:
-    - port: http
+    -
+      {{- with $serviceMonitor.targetPort }}
+      targetPort: {{ . }}
+      {{- else }}
+      port: {{ $serviceMonitor.port | default $port }}
+      {{- end }}
       {{- with $serviceMonitor.basicAuth }}
       basicAuth: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-metrics-auth/templates/route.yaml
+++ b/charts/victoria-metrics-auth/templates/route.yaml
@@ -29,7 +29,11 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" ($app.extraArgs).httpListenAddr)) }}
+          {{- $addrFlag := ($app.extraArgs | default dict).httpListenAddr }}
+          {{- if empty $addrFlag }}
+            {{- $addrFlag = include "vm.addr.primary" $app.http }}
+          {{- end }}
+          port: {{ $route.port | default ($app.service.servicePort | default (include "vm.port.from.flag" (dict "flag" $addrFlag))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-metrics-auth/templates/server.yaml
+++ b/charts/victoria-metrics-auth/templates/server.yaml
@@ -71,8 +71,11 @@ spec:
           lifecycle: {{ . | toYaml | nindent 12 }}
           {{- end }}
           ports:
-            - name: http
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8427") }}
+            {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+            {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr)) (empty $httpAddr) }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
+            {{- end }}
           {{- with $app.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-metrics-auth/templates/service.yaml
+++ b/charts/victoria-metrics-auth/templates/service.yaml
@@ -44,12 +44,16 @@ spec:
   ipFamilies: {{ toYaml . | nindent 4 }}
   {{- end }}
   ports:
-    - name: http
-      port: {{ $service.servicePort }}
+    {{- $httpAddr := (.Values.extraArgs | default dict).httpListenAddr -}}
+    {{- range ternary .Values.http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
+    - name: {{ .name }}
+      {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
+      port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
       protocol: TCP
-      targetPort: http
-      {{- with $service.nodePort }}
-      nodePort: {{ . }}
+      targetPort: {{ .name }}
+      {{- if and .primary $service.nodePort }}
+      nodePort: {{ $service.nodePort }}
       {{- end }}
+    {{- end }}
   selector: {{ include "vm.selectorLabels" $ctx | nindent 4 }}
 {{- end }}

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -73,12 +73,17 @@ podDisruptionBudget:
   unhealthyPodEvictionPolicy:
   labels: {}
 
+# -- HTTP listen address configuration. See https://docs.victoriametrics.com/victoriametrics/#http-listen-address for details.
+http:
+  - name: http
+    value: :8427
+    primary: true
+
 # -- Extra command line arguments for container of component
 extraArgs:
   envflag.enable: true
   envflag.prefix: VM_
   loggerFormat: json
-  httpListenAddr: :8427
   # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
   # enableTCP6: true
 
@@ -154,7 +159,7 @@ service:
   # -- Load balancer source range
   loadBalancerSourceRanges: []
   # -- Service port
-  servicePort: 8427
+  servicePort: ""
   # nodePort: 30000
   # -- Service type
   type: ClusterIP
@@ -310,6 +315,10 @@ serviceMonitor:
   basicAuth: {}
   # -- Service Monitor metricRelabelings
   metricRelabelings: []
+  # -- Service Monitor port. Uses primary http item name by default
+  port: ""
+  # -- Service Monitor target port. Overrides port when set
+  targetPort: ""
 #    interval: 15s
 #    scrapeTimeout: 5s
   # -- Commented. HTTP scheme to use for scraping.

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Next release
 
+**Update note 1**: `.Values.{vminsert,vmselect,vmstorage,vmauth}.extraArgs.httpListenAddr` was replaced by `.Values.{vminsert,vmselect,vmstorage,vmauth}.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-cluster/#http-listen-address) for details.
+
+- `serviceMonitor` port for each component now defaults to the primary `http` list item name; added explicit `port` field to override it without using `targetPort`.
+- fixed HTTPRoute backend `port` field being rendered on the same line as `name` due to incorrect whitespace trimming in the route template.
+
+- added `.Values.{vminsert,vmselect,vmstorage,vmauth}.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Has higher priority than `extraArgs`.
 - add ability to override container command.
 
 ## 0.43.0

--- a/charts/victoria-metrics-cluster/Chart.lock
+++ b/charts/victoria-metrics-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
-generated: "2026-04-16T10:13:39.389936005Z"
+  version: 0.3.8
+digest: sha256:58b69be359c7b95c45d44fbe49cdb62625b21a73530526de4006849135022819
+generated: "2026-06-01T15:10:27.826699741Z"

--- a/charts/victoria-metrics-cluster/_index.md.gotmpl
+++ b/charts/victoria-metrics-cluster/_index.md.gotmpl
@@ -27,6 +27,41 @@ Note: this chart installs VictoriaMetrics cluster components such as vminsert, v
 
 {{ include "chart.uninstallSection" . }}
 
+### HTTP listen address
+
+Each cluster component configures its HTTP listen address via a per-component `http` list:
+`.Values.vminsert.http`, `.Values.vmselect.http`, `.Values.vmstorage.http`, `.Values.vmauth.http`.
+Each entry in the list configures a separate HTTP listener.
+The primary listener (marked with `primary: true`) is used for Pod health checks and Service port generation.
+
+To enable TLS on a component's HTTP listener (e.g. vminsert):
+
+```yaml
+vminsert:
+  http:
+    - name: https
+      primary: true
+      value: :8480
+      tls: true
+      tlsCertFile: /path/to/tls.crt
+      tlsKeyFile: /path/to/tls.key
+```
+
+To expose an additional listener on a different port:
+
+```yaml
+vminsert:
+  http:
+    - name: http
+      primary: true
+      value: :8480
+    - name: https
+      value: :8481
+      tls: true
+      tlsCertFile: /path/to/tls.crt
+      tlsKeyFile: /path/to/tls.key
+```
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-cluster/templates/NOTES.txt
+++ b/charts/victoria-metrics-cluster/templates/NOTES.txt
@@ -10,7 +10,7 @@
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 Write API:
 
-The Victoria Metrics write api can be accessed via port {{ .Values.vminsert.service.servicePort }} with the following DNS name from within your cluster:
+The Victoria Metrics write api can be accessed via port {{ .Values.vminsert.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.vminsert.http) "default" "8480")) }} with the following DNS name from within your cluster:
 {{ include "vm.fqdn" $ctx }}
 
 Get the Victoria Metrics insert service URL by running these commands in the same shell:
@@ -23,10 +23,10 @@ Get the Victoria Metrics insert service URL by running these commands in the sam
         You can watch the status of by running 'kubectl get svc --namespace {{ $ns }} -w {{ $fullname }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ $ns }} {{ $fullname }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.vminsert.service.servicePort }}
+  echo http://$SERVICE_IP:{{ .Values.vminsert.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.vminsert.http) "default" "8480")) }}
 {{- else if contains "ClusterIP"  .Values.vminsert.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ $ns }} -l "app.kubernetes.io/component={{ include "vm.app.name" $ctx }}" -l "app.kubernetes.io/instance={{ include "vm.release" $ctx }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl --namespace {{ $ns }} port-forward $POD_NAME {{ .Values.vminsert.service.servicePort }}
+  kubectl --namespace {{ $ns }} port-forward $POD_NAME {{ .Values.vminsert.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.vminsert.http) "default" "8480")) }}
 {{- end }}
 
 You need to update your Prometheus configuration file and add the following lines to it:
@@ -52,7 +52,7 @@ for example -  inside the Kubernetes cluster:
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 Read API:
 
-The VictoriaMetrics read api can be accessed via port {{ .Values.vmselect.service.servicePort }} with the following DNS name from within your cluster:
+The VictoriaMetrics read api can be accessed via port {{ .Values.vmselect.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.vmselect.http) "default" "8481")) }} with the following DNS name from within your cluster:
 {{ include "vm.fqdn" $ctx }}
 
 Get the VictoriaMetrics select service URL by running these commands in the same shell:
@@ -65,10 +65,10 @@ Get the VictoriaMetrics select service URL by running these commands in the same
         You can watch the status of by running 'kubectl get svc --namespace {{ $ns }} -w {{ $fullname }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ $ns }} {{ $fullname }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.vmselect.service.servicePort }}
+  echo http://$SERVICE_IP:{{ .Values.vmselect.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.vmselect.http) "default" "8481")) }}
 {{- else if contains "ClusterIP"  .Values.vmselect.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ $ns }} -l "app.kubernetes.io/component={{ include "vm.app.name" $ctx }}" -l "app.kubernetes.io/instance={{ include "vm.release" $ctx }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl --namespace {{ $ns }} port-forward $POD_NAME {{ .Values.vmselect.service.servicePort }}
+  kubectl --namespace {{ $ns }} port-forward $POD_NAME {{ .Values.vmselect.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.vmselect.http) "default" "8481")) }}
 {{- end }}
 
 You need to specify select service URL into your Grafana:

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -10,8 +10,12 @@
   {{- $app := $Values.vminsert -}}
   {{- $args := dict -}}
   {{- $ctx := dict "style" "plain" "appKey" "vmstorage" "helm" .helm }}
+  {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" $ctx)) -}}
-  {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args $extraArgs -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
+    {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- end -}}
   {{- $storage := $Values.vmstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
@@ -48,9 +52,13 @@
   {{- $Values := (.helm).Values | default .Values }}
   {{- $app := $Values.vmauth -}}
   {{- $args := dict -}}
+  {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $_ := set $args "auth.config" "/config/auth.yml" -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args $extraArgs -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
+    {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
 
@@ -60,8 +68,12 @@
   {{- $args := dict -}}
   {{- $ctx := dict "style" "plain" "appKey" "vmstorage" "helm" .helm }}
   {{- $_ := set $args "cacheDataPath" $app.cacheMountPath -}}
+  {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" $ctx)) -}}
-  {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args $extraArgs -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
+    {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- end -}}
   {{- $storage := $Values.vmstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
@@ -88,10 +100,11 @@
     {{- $selectNodes := list }}
     {{- $_ := set $ctx "appKey" "vmselect" }}
     {{- $fqdn := include "vm.fqdn" $ctx }}
-    {{- $port := "8481" }}
-    {{- with $app.extraArgs.httpListenAddr }}
-      {{- $port = regexReplaceAll ".*:(\\d+)" . "${1}" }}
+    {{- $addrFlag := $extraArgs.httpListenAddr -}}
+    {{- if empty $addrFlag -}}
+      {{- $addrFlag = include "vm.addr.primary" $app.http -}}
     {{- end -}}
+    {{- $port := include "vm.port.from.flag" (dict "flag" $addrFlag "default" "8481") }}
     {{- range $i := until ($app.replicaCount | int) -}}
       {{- $_ := set $ctx "appIdx" $i }}
       {{- $selectNode := include "vm.fqdn" $ctx -}}
@@ -112,8 +125,12 @@
   {{- $args := dict -}}
   {{- $_ := set $args "retentionPeriod" (toString $app.retentionPeriod) -}}
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
+  {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args $extraArgs -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
+    {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
 
@@ -154,11 +171,15 @@
 
 {{- define "vmselect.ports" -}}
 {{- $service := .service }}
-{{- $extraArgs := .extraArgs -}}
-- name: http
-  port: {{ $service.servicePort }}
+{{- $extraArgs := .extraArgs | default dict -}}
+{{- $httpAddr := $extraArgs.httpListenAddr -}}
+{{- range ternary .http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8481") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ $service.targetPort }}
+  targetPort: {{ .name }}
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}
@@ -175,11 +196,15 @@
 
 {{- define "vminsert.ports" -}}
 {{- $service := .service }}
-{{- $extraArgs := .extraArgs -}}
-- name: http
-  port: {{ $service.servicePort }}
+{{- $extraArgs := .extraArgs | default dict -}}
+{{- $httpAddr := $extraArgs.httpListenAddr -}}
+{{- range ternary .http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8480") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ $service.targetPort }}
+  targetPort: {{ .name }}
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}
@@ -233,10 +258,15 @@
 
 {{- define "vmstorage.ports" -}}
 {{- $service := .service -}}
-- port: {{ $service.servicePort }}
-  targetPort: http
+{{- $extraArgs := .extraArgs | default dict -}}
+{{- $httpAddr := $extraArgs.httpListenAddr -}}
+{{- range ternary .http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8482") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
+  targetPort: {{ .name }}
   protocol: TCP
-  name: http
+{{- end }}
 - port: {{ $service.vmselectPort }}
   targetPort: vmselect
   protocol: TCP
@@ -255,10 +285,15 @@
 
 {{- define "vmauth.ports" -}}
 {{- $service := .service -}}
-- port: {{ $service.servicePort }}
-  targetPort: http
-  protocol: TCP 
-  name: http 
+{{- $extraArgs := .extraArgs | default dict -}}
+{{- $httpAddr := $extraArgs.httpListenAddr -}}
+{{- range ternary .http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
+- name: {{ .name }}
+  {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
+  targetPort: {{ .name }}
+  protocol: TCP
+{{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
   port: {{ .port }}

--- a/charts/victoria-metrics-cluster/templates/monitor.yaml
+++ b/charts/victoria-metrics-cluster/templates/monitor.yaml
@@ -5,6 +5,12 @@
 {{- $_ := set $ctx "extraLabels" $serviceMonitor.extraLabels }}
 {{- $_ := set $ctx "appKey" $name }}
 {{ $fullname := include "vm.plain.fullname" $ctx }}
+{{- $port := "http" -}}
+{{- range $app.http -}}
+  {{- if .primary -}}
+    {{- $port = .name -}}
+  {{- end -}}
+{{- end -}}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -25,7 +31,12 @@ spec:
   selector:
     matchLabels: {{ include "vm.commonLabels" $ctx | nindent 6 }}
   endpoints:
-    - port: http
+    -
+      {{- with $serviceMonitor.targetPort }}
+      targetPort: {{ . }}
+      {{- else }}
+      port: {{ $serviceMonitor.port | default $port }}
+      {{- end }}
       {{- with $serviceMonitor.basicAuth }}
       basicAuth: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-metrics-cluster/templates/route.yaml
+++ b/charts/victoria-metrics-cluster/templates/route.yaml
@@ -28,7 +28,11 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" ($app.extraArgs).httpListenAddr)) }}
+          {{- $addrFlag := ($app.extraArgs | default dict).httpListenAddr }}
+          {{- if empty $addrFlag }}
+            {{- $addrFlag = include "vm.addr.primary" $app.http }}
+          {{- end }}
+          port: {{ $route.port | default ($app.service.servicePort | default (include "vm.port.from.flag" (dict "flag" $addrFlag))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-metrics-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmauth-server.yaml
@@ -71,8 +71,11 @@ spec:
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $app.ports.name  | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8427") }}
+            {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+            {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr)) (empty $httpAddr) }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
+            {{- end }}
           {{- with (fromYaml (include "vm.probe" (dict "app" $app "type" "readiness"))) }}
           readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
@@ -67,8 +67,11 @@ spec:
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $app.ports.name  | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8480") }}
+            {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+            {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr)) (empty $httpAddr) }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8480") }}
+            {{- end }}
             {{- with $app.extraArgs.clusternativeListenAddr }}
             - name: cluster-tcp
               protocol: TCP

--- a/charts/victoria-metrics-cluster/templates/vmselect-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-server.yaml
@@ -84,8 +84,11 @@ spec:
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ $app.ports.name | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8481") }}
+            {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+            {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr)) (empty $httpAddr) }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8481") }}
+            {{- end }}
             {{- with $app.extraArgs.clusternativeListenAddr }}
             - name: cluster-tcp
               protocol: TCP

--- a/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
@@ -100,8 +100,11 @@ spec:
           {{- end }}
           args: {{ include "vmstorage.args" $ctx | nindent 12 }}
           ports:
-            - name: {{ $app.ports.name | default "http" }}
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8482") }}
+            {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+            {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr)) (empty $httpAddr) }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8482") }}
+            {{- end }}
             - name: vminsert
               containerPort: 8400
             - name: vmselect

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -82,9 +82,6 @@ vmselect:
   command: []
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports: 
-    # -- VMSelect http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vmselect component
@@ -93,12 +90,26 @@ vmselect:
   suppressStorageFQDNsRender: false
   # -- Pod's termination grace period in seconds
   terminationGracePeriodSeconds: 60
+  # -- HTTP listen address configuration. See https://docs.victoriametrics.com/victoriametrics/#http-listen-address for details.
+  http:
+    - name: http
+      value: :8481
+      primary: true
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
+
   # -- Extra command line arguments for vmselect component
   extraArgs:
     envflag.enable: true
     envflag.prefix: VM_
     loggerFormat: json
-    httpListenAddr: :8481
     # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
   # -- StatefulSet/Deployment annotations
@@ -272,9 +283,7 @@ vmselect:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 8481
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -416,6 +425,10 @@ vmselect:
     relabelings: []
     # -- Service Monitor metricRelabelings
     metricRelabelings: []
+    # -- Service Monitor port. Uses primary http item name by default
+    port: ""
+    # -- Service Monitor target port. Overrides port when set
+    targetPort: ""
 
 vminsert:
   # -- Enable deployment of vminsert component. Deployment is used
@@ -447,19 +460,30 @@ vminsert:
   command: []
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports:
-    # -- VMInsert http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vminsert component
   fullnameOverride: ""
+  # -- HTTP listen address configuration. See https://docs.victoriametrics.com/victoriametrics/#http-listen-address for details.
+  http:
+    - name: http
+      value: :8480
+      primary: true
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
+
   # -- Extra command line arguments for vminsert component
   extraArgs:
     envflag.enable: true
     envflag.prefix: VM_
     loggerFormat: json
-    httpListenAddr: :8480
     # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
   # -- StatefulSet/Deployment annotations
@@ -633,9 +657,7 @@ vminsert:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 8480
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Service type
     type: ClusterIP
     # -- Enable UDP port. used if you have `spec.opentsdbListenAddr` specified
@@ -731,6 +753,10 @@ vminsert:
     relabelings: []
     # -- Service Monitor metricRelabelings
     metricRelabelings: []
+    # -- Service Monitor port. Uses primary http item name by default
+    port: ""
+    # -- Service Monitor target port. Overrides port when set
+    targetPort: ""
 
 vmauth:
   # -- Enable deployment of vmauth component.
@@ -778,19 +804,30 @@ vmauth:
   command: []
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports:
-    # -- VMAuth http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vmauth component
   fullnameOverride: ""
+  # -- HTTP listen address configuration. See https://docs.victoriametrics.com/victoriametrics/#http-listen-address for details.
+  http:
+    - name: http
+      value: :8427
+      primary: true
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
+
   # -- Extra command line arguments for vmauth component
   extraArgs:
     envflag.enable: true
     envflag.prefix: VM_
     loggerFormat: json
-    httpListenAddr: :8427
     # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
   # -- VMAuth annotations
@@ -955,9 +992,7 @@ vmauth:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 8427
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Service type
     type: ClusterIP
     # -- Enable UDP port. used if you have `spec.opentsdbListenAddr` specified
@@ -1048,6 +1083,10 @@ vmauth:
     relabelings: []
     # -- Service Monitor metricRelabelings
     metricRelabelings: []
+    # -- Service Monitor port. Uses primary http item name by default
+    port: ""
+    # -- Service Monitor target port. Overrides port when set
+    targetPort: ""
 
 vmstorage:
   # -- Enable deployment of vmstorage component. StatefulSet is used
@@ -1071,9 +1110,6 @@ vmstorage:
   command: []
   # -- Specify pod lifecycle
   lifecycle: {}
-  ports: 
-    # -- VMStorage http port name
-    name: "http"
   # -- Name of Priority Class
   priorityClassName: ""
   # -- Overrides the full name of vmstorage component
@@ -1089,12 +1125,26 @@ vmstorage:
 
   # -- Data retention period. Possible units character: h(ours), d(ays), w(eeks), y(ears), if no unit character specified - month. The minimum retention period is 24h. See these [docs](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention)
   retentionPeriod: 1
+  # -- HTTP listen address configuration. See https://docs.victoriametrics.com/victoriametrics/#http-listen-address for details.
+  http:
+    - name: http
+      value: :8482
+      primary: true
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
+
   # -- Additional vmstorage container arguments. Extra command line arguments for vmstorage component
   extraArgs:
     envflag.enable: true
     envflag.prefix: VM_
     loggerFormat: json
-    httpListenAddr: :8482
     # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
 
@@ -1258,7 +1308,7 @@ vmstorage:
     # -- Service labels
     labels: {}
     # -- Service port
-    servicePort: 8482
+    servicePort: ""
     # -- Port for accepting connections from vminsert
     vminsertPort: 8400
     # -- Port for accepting connections from vmselect
@@ -1427,6 +1477,10 @@ vmstorage:
     relabelings: []
     # -- Service Monitor metricRelabelings
     metricRelabelings: []
+    # -- Service Monitor port. Uses primary http item name by default
+    port: ""
+    # -- Service Monitor target port. Overrides port when set
+    targetPort: ""
 
 # -- Enterprise license key configuration for VictoriaMetrics enterprise.
 # Required only for VictoriaMetrics enterprise. Check docs [here](https://docs.victoriametrics.com/victoriametrics/enterprise/),

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next release
 
+**Update note 1**: `.Values.extraArgs.httpListenAddr` was replaced by `.Values.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-gateway/#http-listen-address) for details.
+
+- added `.Values.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Has higher priority than `extraArgs`.
 - add ability to override container command.
 
 ## 0.31.0

--- a/charts/victoria-metrics-gateway/Chart.lock
+++ b/charts/victoria-metrics-gateway/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
-generated: "2026-04-16T10:13:51.823846928Z"
+  version: 0.3.8
+digest: sha256:58b69be359c7b95c45d44fbe49cdb62625b21a73530526de4006849135022819
+generated: "2026-06-01T15:10:37.913247383Z"

--- a/charts/victoria-metrics-gateway/_index.md.gotmpl
+++ b/charts/victoria-metrics-gateway/_index.md.gotmpl
@@ -90,6 +90,38 @@ Please, refer to [this](https://kubernetes.io/docs/reference/generated/kubernete
 
 {{ include "chart.uninstallSection" . }}
 
+### HTTP listen address
+
+The chart configures the HTTP listen address via `.Values.http` list.
+Each entry in the list configures a separate HTTP listener.
+The primary listener (marked with `primary: true`) is used for Pod health checks and Service port generation.
+
+To enable TLS on the HTTP listener:
+
+```yaml
+http:
+  - name: https
+    primary: true
+    value: :8431
+    tls: true
+    tlsCertFile: /path/to/tls.crt
+    tlsKeyFile: /path/to/tls.key
+```
+
+To expose an additional listener on a different port:
+
+```yaml
+http:
+  - name: http
+    primary: true
+    value: :8431
+  - name: https
+    value: :8432
+    tls: true
+    tlsCertFile: /path/to/tls.crt
+    tlsKeyFile: /path/to/tls.key
+```
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-gateway/templates/_helpers.tpl
+++ b/charts/victoria-metrics-gateway/templates/_helpers.tpl
@@ -13,8 +13,12 @@
   {{- $_ := set $args "enable.auth" $Values.auth.enabled -}}
   {{- $_ := set $args "read.url" $Values.read.url -}}
   {{- $_ := set $args "write.url" $Values.write.url -}}
+  {{- $extraArgs := $Values.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args $Values.extraArgs -}}
+  {{- $args = mergeOverwrite $args $extraArgs -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
+    {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $Values.http)) -}}
+  {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
 

--- a/charts/victoria-metrics-gateway/templates/server.yaml
+++ b/charts/victoria-metrics-gateway/templates/server.yaml
@@ -75,8 +75,11 @@ spec:
           args: {{ include "vmgateway.args" $ctx | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" .Values.extraArgs.httpListenAddr "default" "8431") }}
+            {{- $httpAddr := (.Values.extraArgs | default dict).httpListenAddr -}}
+            {{- range ternary .Values.http (list (dict "name" "http" "value" $httpAddr)) (empty $httpAddr) }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8431") }}
+            {{- end }}
           {{- with .Values.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-metrics-gateway/templates/service.yaml
+++ b/charts/victoria-metrics-gateway/templates/service.yaml
@@ -44,12 +44,16 @@ spec:
   ipFamilies: {{ toYaml . | nindent 4 }}
   {{- end }}
   ports:
-    - name: http
-      port: {{ $service.servicePort }}
+    {{- $httpAddr := (.Values.extraArgs | default dict).httpListenAddr -}}
+    {{- range ternary .Values.http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
+    - name: {{ .name }}
+      {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8431") }}
+      port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
       protocol: TCP
-      targetPort: http
-      {{- with $service.nodePort }}
-      nodePort: {{ . }}
+      targetPort: {{ .name }}
+      {{- if and .primary $service.nodePort }}
+      nodePort: {{ $service.nodePort }}
       {{- end }}
+    {{- end }}
   selector: {{ include "vm.selectorLabels" $ctx | nindent 4 }}
 {{- end }}

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -69,12 +69,17 @@ podDisruptionBudget:
   unhealthyPodEvictionPolicy:
   labels: {}
 
+# -- HTTP listen address configuration. See https://docs.victoriametrics.com/victoriametrics/#http-listen-address for details.
+http:
+  - name: http
+    value: :8431
+    primary: true
+
 # -- Extra command line arguments for container of component
 extraArgs:
   envflag.enable: true
   envflag.prefix: VM_
   loggerFormat: json
-  httpListenAddr: :8431
   # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
   # enableTCP6: true
 
@@ -146,7 +151,7 @@ service:
   # -- Load balancer source range
   loadBalancerSourceRanges: []
   # -- Service port
-  servicePort: 8431
+  servicePort: ""
   # nodePort: 30000
   # -- Service type
   type: ClusterIP

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Next release
 
+**Update note 1**: `.Values.server.extraArgs.httpListenAddr` was replaced by `.Values.server.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-single/#http-listen-address) for details.
+
+- `serviceMonitor` port now defaults to the primary `http` list item name; added explicit `port` field to override it without using `targetPort`.
+- fixed HTTPRoute backend `port` field being rendered on the same line as `name` due to incorrect whitespace trimming in the route template.
+
+- added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Has higher priority than `extraArgs`.
 - add ability to override container command.
 
 ## 0.39.0

--- a/charts/victoria-metrics-single/Chart.lock
+++ b/charts/victoria-metrics-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
-generated: "2026-04-16T10:14:17.281581384Z"
+  version: 0.3.8
+digest: sha256:58b69be359c7b95c45d44fbe49cdb62625b21a73530526de4006849135022819
+generated: "2026-06-01T15:11:04.597503047Z"

--- a/charts/victoria-metrics-single/_index.md.gotmpl
+++ b/charts/victoria-metrics-single/_index.md.gotmpl
@@ -29,6 +29,40 @@ This chart will do the following:
 
 {{ include "chart.uninstallSection" . }}
 
+### HTTP listen address
+
+The chart configures the HTTP listen address via `.Values.server.http` list.
+Each entry in the list configures a separate HTTP listener.
+The primary listener (marked with `primary: true`) is used for Pod health checks and Service port generation.
+
+To enable TLS on the HTTP listener:
+
+```yaml
+server:
+  http:
+    - name: https
+      primary: true
+      value: :8428
+      tls: true
+      tlsCertFile: /path/to/tls.crt
+      tlsKeyFile: /path/to/tls.key
+```
+
+To expose an additional listener on a different port:
+
+```yaml
+server:
+  http:
+    - name: http
+      primary: true
+      value: :8428
+    - name: https
+      value: :8429
+      tls: true
+      tlsCertFile: /path/to/tls.crt
+      tlsKeyFile: /path/to/tls.key
+```
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-single/templates/NOTES.txt
+++ b/charts/victoria-metrics-single/templates/NOTES.txt
@@ -3,7 +3,7 @@
 {{- $ctx := dict "helm" . "appKey" "server" "style" "plain" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
-The VictoriaMetrics write api can be accessed via port {{ .Values.server.service.servicePort }} on the following DNS name from within your cluster:
+The VictoriaMetrics write api can be accessed via port {{ .Values.server.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.server.http) "default" "8428")) }} on the following DNS name from within your cluster:
     {{ include "vm.fqdn" $ctx }}
 
 Metrics Ingestion:
@@ -18,10 +18,10 @@ Metrics Ingestion:
       You can watch the status of by running 'kubectl get svc --namespace {{ $ns }} -w {{ $fullname }}'
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ $ns }} {{ $fullname }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    echo http://$SERVICE_IP:{{ .Values.server.service.servicePort }}
+    echo http://$SERVICE_IP:{{ .Values.server.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.server.http) "default" "8428")) }}
 {{- else if contains "ClusterIP"  .Values.server.service.type }}
     export POD_NAME=$(kubectl get pods --namespace {{ $ns }} -l "app.kubernetes.io/component={{ include "vm.app.name" $ctx }}" -l "app.kubernetes.io/instance={{ include "vm.release" $ctx }}" -o jsonpath="{.items[0].metadata.name}")
-    kubectl --namespace {{ $ns }} port-forward $POD_NAME {{ .Values.server.service.servicePort }}
+    kubectl --namespace {{ $ns }} port-forward $POD_NAME {{ .Values.server.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.server.http) "default" "8428")) }}
 {{- end }}
 
   Write URL inside the kubernetes cluster:

--- a/charts/victoria-metrics-single/templates/_helpers.tpl
+++ b/charts/victoria-metrics-single/templates/_helpers.tpl
@@ -22,8 +22,12 @@
   {{- if $app.relabel.enabled -}}
     {{- $_ := set $args "relabelConfig" "/relabelconfig/relabel.yml" -}}
   {{- end -}}
+  {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
-  {{- $args = mergeOverwrite $args $app.extraArgs -}}
+  {{- $args = mergeOverwrite $args $extraArgs -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
+    {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
+  {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
 {{- end -}}
 

--- a/charts/victoria-metrics-single/templates/monitor.yaml
+++ b/charts/victoria-metrics-single/templates/monitor.yaml
@@ -3,6 +3,12 @@
 {{- $serviceMonitor := $app.serviceMonitor -}}
 {{- $ctx := dict "helm" . "appKey" "server" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
+{{- $port := "http" -}}
+{{- range $app.http -}}
+  {{- if .primary -}}
+    {{- $port = .name -}}
+  {{- end -}}
+{{- end -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -23,7 +29,12 @@ spec:
   selector:
     matchLabels: {{ include "vm.commonLabels" $ctx | nindent 6 }} 
   endpoints:
-    - port: http
+    -
+      {{- with $serviceMonitor.targetPort }}
+      targetPort: {{ . }}
+      {{- else }}
+      port: {{ $serviceMonitor.port | default $port }}
+      {{- end }}
       {{- with $serviceMonitor.basicAuth }}
       basicAuth: {{ toYaml . | nindent 8 }}
       {{- end }}
@@ -44,8 +55,5 @@ spec:
       {{- end }}
       {{- with $serviceMonitor.metricRelabelings }}
       metricRelabelings: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with $serviceMonitor.targetPort }}
-      targetPort: {{ . }}
       {{- end }}
 {{- end }}

--- a/charts/victoria-metrics-single/templates/route.yaml
+++ b/charts/victoria-metrics-single/templates/route.yaml
@@ -29,7 +29,11 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" ($app.extraArgs).httpListenAddr)) }}
+          {{- $addrFlag := ($app.extraArgs | default dict).httpListenAddr }}
+          {{- if empty $addrFlag }}
+            {{- $addrFlag = include "vm.addr.primary" $app.http }}
+          {{- end }}
+          port: {{ $route.port | default ($app.service.servicePort | default (include "vm.port.from.flag" (dict "flag" $addrFlag))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-metrics-single/templates/server.yaml
+++ b/charts/victoria-metrics-single/templates/server.yaml
@@ -116,8 +116,11 @@ spec:
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: http
-              containerPort: {{ include "vm.port.from.flag" (dict "flag" $app.extraArgs.httpListenAddr "default" "8428") }}
+            {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+            {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr)) (empty $httpAddr) }}
+            - name: {{ .name }}
+              containerPort: {{ include "vm.port.from.flag" (dict "flag" .value "default" "8428") }}
+            {{- end }}
             {{- with $app.extraArgs.graphiteListenAddr }}
             - name: graphite-tcp
               protocol: TCP

--- a/charts/victoria-metrics-single/templates/service.yaml
+++ b/charts/victoria-metrics-single/templates/service.yaml
@@ -51,13 +51,17 @@ spec:
   ipFamilies: {{ toYaml . | nindent 4 }}
   {{- end }}
   ports:
-    - name: http
-      port: {{ $service.servicePort }}
+    {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr -}}
+    {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
+    - name: {{ .name }}
+      {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8428") }}
+      port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
       protocol: TCP
-      targetPort: {{ $service.targetPort }}
-      {{- with $service.nodePort }}
-      nodePort: {{ . }}
+      targetPort: {{ .name }}
+      {{- if and .primary $service.nodePort }}
+      nodePort: {{ $service.nodePort }}
       {{- end }}
+    {{- end }}
     {{- with $app.extraArgs.graphiteListenAddr }}
     - name: graphite-tcp
       protocol: TCP

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -93,12 +93,26 @@ server:
   fullnameOverride:
   # -- Data retention period. Possible units character: h(ours), d(ays), w(eeks), y(ears), if no unit character specified - month. The minimum retention period is 24h. See these [docs](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention)
   retentionPeriod: 1
+  # -- HTTP listen address configuration. See https://docs.victoriametrics.com/victoriametrics/#http-listen-address for details.
+  http:
+    - name: http
+      value: :8428
+      primary: true
+      tls: false
+      tlsCertFile: ""
+      tlsKeyFile: ""
+      tlsMinVersion: ""
+      tlsAutocertHosts: ""
+      tlsAutocertEmail: ""
+      tlsAutocertCacheDir: ""
+      mtls: false
+      mtlsCAFile: ""
+
   # -- Extra command line arguments for container of component
   extraArgs:
     envflag.enable: true
     envflag.prefix: VM_
     loggerFormat: json
-    httpListenAddr: :8428
     # Enable IPv6 support. Useful for running in IPv6-only Kubernetes clusters
     # enableTCP6: true
 
@@ -402,9 +416,7 @@ server:
     # -- Load balancer source range
     loadBalancerSourceRanges: []
     # -- Service port
-    servicePort: 8428
-    # -- Target port
-    targetPort: http
+    servicePort: ""
     # -- Node port
     # nodePort: 30000
     # -- Service type
@@ -461,8 +473,10 @@ server:
     relabelings: []
     # -- Service Monitor metricRelabelings
     metricRelabelings: []
-    # -- Service Monitor target port
-    targetPort: http
+    # -- Service Monitor port. Uses primary http item name by default
+    port: ""
+    # -- Service Monitor target port. Overrides port when set
+    targetPort: ""
 
   # -- Global relabel configuration
   relabel:


### PR DESCRIPTION
propagate change from https://github.com/VictoriaMetrics/helm-charts/pull/2921 to victoria-metrics-* charts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-listener HTTP support across VictoriaMetrics Helm charts via new `.http` lists. Primary listeners now drive health checks, container/Service ports, ServiceMonitors, Routes, and NOTES; docs add HTTP sections with TLS examples, HTTPRoute port formatting is fixed, and `victoria-metrics-common` is bumped to `0.3.8`.

- **New Features**
  - Introduced `.http[]` for HTTP listeners with optional TLS; `primary: true` selects health checks and the Service/nodePort/Route backend.
  - Applied to `victoria-metrics-agent`, `victoria-metrics-alert` (`server.http`), `victoria-metrics-gateway`, `victoria-metrics-single` (`server.http`), `victoria-metrics-cluster` (`vminsert`, `vmselect`, `vmstorage`, `vmauth`), and `victoria-metrics-auth`.
  - Container/Service ports are generated from `.http`; each listener maps to a named container port and Service targetPort. `service.servicePort` now defaults to empty and falls back to the primary listener’s port; nodePort set only on the primary. Routes/NOTES use `service.servicePort` when set, otherwise the primary listener’s port.
  - ServiceMonitor endpoints now default to the primary listener name; added `serviceMonitor.port` and `serviceMonitor.targetPort` to override.
  - Precedence: if `extraArgs.httpListenAddr` is set it wins; otherwise `.http` drives flags and ports.

- **Migration**
  - Move from `{extraArgs,httpListenAddr}` to the new `.http` lists (`.http`, `server.http`, or per-component in cluster). Keep/remove the old flag to control precedence during rollout.

<sup>Written for commit 7ea52de2d17b34b7c4a033d89fff0bdc12ee30d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

