### PR TITLE
release logs and traces charts with new common dependency

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.2 -> 0.3.4
 
 ## 0.2.0
 

--- a/charts/victoria-logs-agent/Chart.lock
+++ b/charts/victoria-logs-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.2
-digest: sha256:9522db9e9daa54b8a8cd0e743f76ed326229f7b7bfb67fcd98b3d914c9f0aacd
-generated: "2026-05-27T14:05:00.308895+03:00"
+  version: 0.3.4
+digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
+generated: "2026-05-30T03:37:43.592800223Z"

--- a/charts/victoria-logs-agent/Chart.yaml
+++ b/charts/victoria-logs-agent/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 name: victoria-logs-agent
 description: VictoriaLogs Agent - accepts logs from various protocols and replicates them across multiple VictoriaLogs instances.
-version: 0.2.0
+version: 0.2.1
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-agent/templates/_helpers.tpl
+++ b/charts/victoria-logs-agent/templates/_helpers.tpl
@@ -80,10 +80,10 @@
   {{- end }}
   {{- $extraArgs := $Values.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $Values.http)) -}}
   {{- end -}}
-  {{- if not (or (hasKey $extraArgs "syslog.listenAddr.tcp") (hasKey $extraArgs "syslog.listenAddr.udp")) -}}
+  {{- if and (empty (index $extraArgs "syslog.listenAddr.tcp")) (empty (index $extraArgs "syslog.listenAddr.udp")) -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $Values.syslog)) -}}
   {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.2 -> 0.3.4
 
 ## 0.2.1
 

--- a/charts/victoria-logs-cluster/Chart.lock
+++ b/charts/victoria-logs-cluster/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.52.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.2
-digest: sha256:f5c00dd9e7459174c6b1d5e6a3addf8b566630af3868d0988970ca601c25263f
-generated: "2026-05-27T14:05:12.114377+03:00"
+  version: 0.3.4
+digest: sha256:bedb651b94ba2c0cf8e627612f5d4f60362224f89adf888c181380b42d163989
+generated: "2026-05-30T03:37:46.519347714Z"

--- a/charts/victoria-logs-cluster/Chart.yaml
+++ b/charts/victoria-logs-cluster/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs cluster Helm chart deploys VictoriaLogs cluster database in Kubernetes.
 name: victoria-logs-cluster
-version: 0.2.1
+version: 0.2.2
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-cluster/templates/_helpers.tpl
+++ b/charts/victoria-logs-cluster/templates/_helpers.tpl
@@ -31,18 +31,21 @@
   {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" $ctx)) -}}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
-  {{- if not (or (hasKey $extraArgs "syslog.listenAddr.tcp") (hasKey $extraArgs "syslog.listenAddr.udp")) -}}
+  {{- if and (empty (index $extraArgs "syslog.listenAddr.tcp")) (empty (index $extraArgs "syslog.listenAddr.udp")) -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $app.syslog)) -}}
   {{- end -}}
   {{- $storage := $Values.vlstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
     {{- $fqdn := include "vm.fqdn" $ctx }}
-    {{- $storageHttpAddr := ($Values.vlstorage.extraArgs | default dict).httpListenAddr -}}
-    {{- $port := include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $Values.vlstorage.http) $storageHttpAddr (empty $storageHttpAddr)) "default" "9491") }}
+    {{- $addrFlag := ($Values.vlstorage.extraArgs | default dict).httpListenAddr -}}
+    {{- if empty $addrFlag -}}
+      {{- $addrFlag = include "vm.addr.primary" $Values.vlstorage.http -}}
+    {{- end -}}
+    {{- $port := include "vm.port.from.flag" (dict "flag" $addrFlag "default" "9491") }}
     {{- range $i := until ($storage.replicaCount | int) -}}
       {{- if not (has (float64 $i) $app.excludeStorageIDs) -}}
         {{- $_ := set $ctx "appIdx" $i }}
@@ -67,7 +70,7 @@
   {{- $_ := set $args "auth.config" "/config/auth.yml" -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
@@ -81,15 +84,18 @@
   {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
   {{- $storage := $Values.vlstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
     {{- $fqdn := include "vm.fqdn" $ctx }}
-    {{- $storageHttpAddr := ($Values.vlstorage.extraArgs | default dict).httpListenAddr -}}
-    {{- $port := include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $Values.vlstorage.http) $storageHttpAddr (empty $storageHttpAddr)) "default" "9491") }}
+    {{- $addrFlag := ($Values.vlstorage.extraArgs | default dict).httpListenAddr -}}
+    {{- if empty $addrFlag -}}
+      {{- $addrFlag = include "vm.addr.primary" $Values.vlstorage.http -}}
+    {{- end -}}
+    {{- $port := include "vm.port.from.flag" (dict "flag" $addrFlag "default" "9491") }}
     {{- range $i := until ($storage.replicaCount | int) -}}
       {{- $_ := set $ctx "appIdx" $i }}
       {{- $storageNode := include "vm.fqdn" $ctx -}}
@@ -129,7 +135,7 @@
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}

--- a/charts/victoria-logs-cluster/templates/route.yaml
+++ b/charts/victoria-logs-cluster/templates/route.yaml
@@ -28,8 +28,11 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $app.http) $httpAddr (empty $httpAddr)))) }}
+          {{- $addrFlag := ($app.extraArgs | default dict).httpListenAddr }}
+          {{- if empty $addrFlag }}
+            {{- $addrFlag = include "vm.addr.primary" $app.http }}
+          {{- end }}
+          port: {{ $route.port | default ($app.service.servicePort | default (include "vm.port.from.flag" (dict "flag" $addrFlag))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-logs-collector/Chart.lock
+++ b/charts/victoria-logs-collector/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
-generated: "2026-04-16T10:13:11.850169506Z"
+  version: 0.3.4
+digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
+generated: "2026-05-30T03:37:49.552803298Z"

--- a/charts/victoria-logs-mcp/Chart.lock
+++ b/charts/victoria-logs-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.0
-digest: sha256:cadb4ced35cde20c5f8437f6ff223ded677542490848e1b3a3b5f330f3069ebc
-generated: "2026-04-16T10:13:15.135343925Z"
+  version: 0.3.4
+digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
+generated: "2026-05-30T03:37:52.170359323Z"

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.2 -> 0.3.4
 
 ## 0.2.1
 

--- a/charts/victoria-logs-multilevel/Chart.lock
+++ b/charts/victoria-logs-multilevel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.2
-digest: sha256:9522db9e9daa54b8a8cd0e743f76ed326229f7b7bfb67fcd98b3d914c9f0aacd
-generated: "2026-05-27T14:05:44.382273+03:00"
+  version: 0.3.4
+digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
+generated: "2026-05-30T03:37:55.083483308Z"

--- a/charts/victoria-logs-multilevel/Chart.yaml
+++ b/charts/victoria-logs-multilevel/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs multilevel Helm chart deploys global read for multiple storage groups.
 name: victoria-logs-multilevel
-version: 0.2.1
+version: 0.2.2
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-multilevel/templates/_helpers.tpl
+++ b/charts/victoria-logs-multilevel/templates/_helpers.tpl
@@ -6,7 +6,7 @@
   {{- $_ := set $args "auth.config" "/config/auth.yml" -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
@@ -19,7 +19,7 @@
   {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
   {{- $storageNodes := $args.storageNodes | default list }}

--- a/charts/victoria-logs-multilevel/templates/route.yaml
+++ b/charts/victoria-logs-multilevel/templates/route.yaml
@@ -28,8 +28,11 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $app.http) $httpAddr (empty $httpAddr)))) }}
+          {{- $addrFlag := ($app.extraArgs | default dict).httpListenAddr }}
+          {{- if empty $addrFlag }}
+            {{- $addrFlag = include "vm.addr.primary" $app.http }}
+          {{- end }}
+          port: {{ $route.port | default ($app.service.servicePort | default (include "vm.port.from.flag" (dict "flag" $addrFlag))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.2 -> 0.3.4
 
 ## 0.13.1
 

--- a/charts/victoria-logs-single/Chart.lock
+++ b/charts/victoria-logs-single/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.52.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.2
-digest: sha256:f5c00dd9e7459174c6b1d5e6a3addf8b566630af3868d0988970ca601c25263f
-generated: "2026-05-27T14:05:57.153032+03:00"
+  version: 0.3.4
+digest: sha256:bedb651b94ba2c0cf8e627612f5d4f60362224f89adf888c181380b42d163989
+generated: "2026-05-30T03:37:57.648895712Z"

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs single Helm chart deploys VictoriaLogs database in Kubernetes.
 name: victoria-logs-single
-version: 0.13.1
+version: 0.13.2
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/templates/_helpers.tpl
+++ b/charts/victoria-logs-single/templates/_helpers.tpl
@@ -48,10 +48,10 @@
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
-  {{- if not (or (hasKey $extraArgs "syslog.listenAddr.tcp") (hasKey $extraArgs "syslog.listenAddr.udp")) -}}
+  {{- if and (empty (index $extraArgs "syslog.listenAddr.tcp")) (empty (index $extraArgs "syslog.listenAddr.udp")) -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vl.syslog.args" $app.syslog)) -}}
   {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}

--- a/charts/victoria-logs-single/templates/route.yaml
+++ b/charts/victoria-logs-single/templates/route.yaml
@@ -29,8 +29,11 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $app.http) $httpAddr (empty $httpAddr)))) }}
+          {{- $addrFlag := ($app.extraArgs | default dict).httpListenAddr }}
+          {{- if empty $addrFlag }}
+            {{- $addrFlag = include "vm.addr.primary" $app.http }}
+          {{- end }}
+          port: {{ $route.port | default ($app.service.servicePort | default (include "vm.port.from.flag" (dict "flag" $addrFlag))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.2 -> 0.3.4
 
 ## 0.2.1
 

--- a/charts/victoria-traces-cluster/Chart.lock
+++ b/charts/victoria-traces-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.2
-digest: sha256:9522db9e9daa54b8a8cd0e743f76ed326229f7b7bfb67fcd98b3d914c9f0aacd
-generated: "2026-05-27T14:06:05.730425+03:00"
+  version: 0.3.4
+digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
+generated: "2026-05-30T03:38:42.125148241Z"

--- a/charts/victoria-traces-cluster/Chart.yaml
+++ b/charts/victoria-traces-cluster/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v0.9.0
 description: The VictoriaTraces cluster Helm chart deploys VictoriaTraces cluster database in Kubernetes.
 name: victoria-traces-cluster
-version: 0.2.1
+version: 0.2.2
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-traces-cluster/templates/_helpers.tpl
+++ b/charts/victoria-traces-cluster/templates/_helpers.tpl
@@ -6,15 +6,18 @@
   {{- $ctx := dict "style" "plain" "appKey" "vtstorage" "helm" .helm }}
   {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
   {{- $storage := $Values.vtstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
     {{- $fqdn := include "vm.fqdn" $ctx }}
-    {{- $storageHttpAddr := ($Values.vtstorage.extraArgs | default dict).httpListenAddr -}}
-    {{- $port := include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $Values.vtstorage.http) $storageHttpAddr (empty $storageHttpAddr)) "default" "10491") }}
+    {{- $addrFlag := ($Values.vtstorage.extraArgs | default dict).httpListenAddr -}}
+    {{- if empty $addrFlag -}}
+      {{- $addrFlag = include "vm.addr.primary" $Values.vtstorage.http -}}
+    {{- end -}}
+    {{- $port := include "vm.port.from.flag" (dict "flag" $addrFlag "default" "10491") }}
     {{- range $i := until ($storage.replicaCount | int) -}}
       {{- if not (has (float64 $i) $app.excludeStorageIDs) -}}
         {{- $_ := set $ctx "appIdx" $i }}
@@ -38,7 +41,7 @@
   {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $_ := set $args "auth.config" "/config/auth.yml" -}}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}
@@ -51,15 +54,18 @@
   {{- $ctx := dict "style" "plain" "appKey" "vtstorage" "helm" .helm }}
   {{- $extraArgs := $app.extraArgs | default dict }}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
   {{- $storage := $Values.vtstorage }}
   {{- if and (not $app.suppressStorageFQDNsRender) $storage.enabled $storage.replicaCount }}
     {{- $storageNodes := list }}
     {{- $fqdn := include "vm.fqdn" $ctx }}
-    {{- $storageHttpAddr := ($Values.vtstorage.extraArgs | default dict).httpListenAddr -}}
-    {{- $port := include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $Values.vtstorage.http) $storageHttpAddr (empty $storageHttpAddr)) "default" "10491") }}
+    {{- $addrFlag := ($Values.vtstorage.extraArgs | default dict).httpListenAddr -}}
+    {{- if empty $addrFlag -}}
+      {{- $addrFlag = include "vm.addr.primary" $Values.vtstorage.http -}}
+    {{- end -}}
+    {{- $port := include "vm.port.from.flag" (dict "flag" $addrFlag "default" "10491") }}
     {{- range $i := until ($storage.replicaCount | int) -}}
       {{- $_ := set $ctx "appIdx" $i }}
       {{- $storageNode := include "vm.fqdn" $ctx -}}
@@ -95,7 +101,7 @@
   {{- end -}}
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}

--- a/charts/victoria-traces-cluster/templates/route.yaml
+++ b/charts/victoria-traces-cluster/templates/route.yaml
@@ -28,8 +28,11 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $app.http) $httpAddr (empty $httpAddr)))) }}
+          {{- $addrFlag := ($app.extraArgs | default dict).httpListenAddr }}
+          {{- if empty $addrFlag }}
+            {{- $addrFlag = include "vm.addr.primary" $app.http }}
+          {{- end }}
+          port: {{ $route.port | default ($app.service.servicePort | default (include "vm.port.from.flag" (dict "flag" $addrFlag))) }}
           group: ''
           kind: Service
           weight: 1

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.2 -> 0.3.4
 
 ## 0.1.1
 

--- a/charts/victoria-traces-single/Chart.lock
+++ b/charts/victoria-traces-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.2
-digest: sha256:9522db9e9daa54b8a8cd0e743f76ed326229f7b7bfb67fcd98b3d914c9f0aacd
-generated: "2026-05-27T14:06:13.429957+03:00"
+  version: 0.3.4
+digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
+generated: "2026-05-30T03:38:44.744104419Z"

--- a/charts/victoria-traces-single/Chart.yaml
+++ b/charts/victoria-traces-single/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v0.9.0
 description: The VictoriaTraces single Helm chart deploys VictoriaTraces database in Kubernetes.
 name: victoria-traces-single
-version: 0.1.1
+version: 0.1.2
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-traces-single/templates/_helpers.tpl
+++ b/charts/victoria-traces-single/templates/_helpers.tpl
@@ -21,7 +21,7 @@
   {{- $_ := set $args "storageDataPath" $app.persistentVolume.mountPath -}}
   {{- $args = mergeOverwrite $args (fromYaml (include "vm.license.flag" .)) -}}
   {{- $args = mergeOverwrite $args $extraArgs -}}
-  {{- if not (hasKey $extraArgs "httpListenAddr") -}}
+  {{- if empty $extraArgs.httpListenAddr -}}
     {{- $args = mergeOverwrite $args (fromYaml (include "vm.http.args" $app.http)) -}}
   {{- end -}}
   {{- toYaml (fromYaml (include "vm.args" $args)).args -}}

--- a/charts/victoria-traces-single/templates/route.yaml
+++ b/charts/victoria-traces-single/templates/route.yaml
@@ -29,8 +29,11 @@ spec:
     {{- end }}
     - backendRefs:
         - name: {{ $fullname }}
-          {{- $httpAddr := ($app.extraArgs | default dict).httpListenAddr }}
-          port: {{ $route.port | default (include "vm.port.from.flag" (dict "flag" (ternary (include "vm.addr.primary" $app.http) $httpAddr (empty $httpAddr)))) }}
+          {{- $addrFlag := ($app.extraArgs | default dict).httpListenAddr }}
+          {{- if empty $addrFlag }}
+            {{- $addrFlag = include "vm.addr.primary" $app.http }}
+          {{- end }}
+          port: {{ $route.port | default ($app.service.servicePort | default (include "vm.port.from.flag" (dict "flag" $addrFlag))) }}
           group: ''
           kind: Service
           weight: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Release updated logs and traces Helm charts. Upgrades to `victoria-metrics-common` 0.3.4 and fixes arg/port handling to prevent bad overrides.

- **Dependencies**
  - Update `victoria-metrics-common` to 0.3.4 across logs/traces charts, including locks for `victoria-logs-collector` and `victoria-logs-mcp`.
  - Bump chart versions: `victoria-logs-agent` 0.2.1, `victoria-logs-cluster` 0.2.2, `victoria-logs-multilevel` 0.2.2, `victoria-logs-single` 0.13.2, `victoria-traces-cluster` 0.2.2, `victoria-traces-single` 0.1.2.

- **Bug Fixes**
  - Inject default HTTP/syslog args only when user values are empty, not just missing.
  - Route port now prefers `app.service.servicePort`, then falls back to `httpListenAddr`.
  - Derive storage node ports from the effective HTTP listen address in cluster templates.

<sup>Written for commit 2f88702001b3058e4751cc8b890e240f66bebf25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

