### PR TITLE
common: vm.url and vm.probe detect TLS from primary http list item, when httpListenAddr is not set

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- `vm.probe` switches from `httpGet` to `tcpSocket` when TLS is enabled on the primary HTTP listener.
 
 ## 0.3.4
 
@@ -11,7 +11,7 @@
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0)
 
 - `vm.http.args` now requires each item to have not empty `name` property.
-- `vm.probe` switches from `httpGet` to `tcpSocket` when TLS is enabled on the primary HTTP listener.
+- `vm.probe` and `vm.url` now detect TLS from the primary http list item's `tls` field when `httpListenAddr` is not set in `extraArgs`; `extraArgs.tls` is used as a fallback in all other cases.
 - fixed nil panic in `vm.probe` when `app.probe` is not set.
 - removed unused `vm.sa.name` template.
 - removed `vm.service` template; its style dispatch is now inlined into `vm.fqdn`.

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: VictoriaMetrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.3.4
+version: 0.3.5
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_pod.tpl
+++ b/charts/victoria-metrics-common/templates/_pod.tpl
@@ -48,13 +48,14 @@ Render probe
     {{- end -}}
   {{- end -}}
   {{- $isSecure := false -}}
-  {{- if (.app).http -}}
+  {{- if and (.app).http (empty ((.app).extraArgs | default dict).httpListenAddr) -}}
     {{- range (.app).http -}}
       {{- if and .primary .tls -}}
         {{- $isSecure = true -}}
       {{- end -}}
     {{- end -}}
-  {{- else -}}
+  {{- end -}}
+  {{- if not $isSecure -}}
     {{- with ((.app).extraArgs).tls -}}
       {{- $isSecure = eq (toString .) "true" -}}
     {{- end -}}

--- a/charts/victoria-metrics-common/templates/_service.tpl
+++ b/charts/victoria-metrics-common/templates/_service.tpl
@@ -84,13 +84,14 @@
       {{- $ctx = ternary (dict) (index $ctx $ak | default dict) (empty $ctx) -}}
     {{- end -}}
     {{- $spec := $values | default $ctx -}}
-    {{- if $spec.http -}}
+    {{- if and $spec.http (empty ($spec.extraArgs).httpListenAddr) -}}
       {{- range $spec.http -}}
         {{- if and .primary .tls -}}
           {{- $isSecure = true -}}
         {{- end -}}
       {{- end -}}
-    {{- else -}}
+    {{- end -}}
+    {{- if not $isSecure -}}
       {{- with ($spec.extraArgs).tls -}}
         {{- $isSecure = eq (toString .) "true" -}}
       {{- end -}}

--- a/test-charts/victoria-metrics-common/tests/probe_test.yaml
+++ b/test-charts/victoria-metrics-common/tests/probe_test.yaml
@@ -71,10 +71,49 @@ tests:
             tcpSocket:
               port: https
 
+  - it: httpGet probe falls back to extraArgs.tls when http section has no tls
+    set:
+      app:
+        http:
+          - name: http
+            value: :8429
+            primary: true
+        extraArgs:
+          tls: "true"
+        probe:
+          readiness:
+            httpGet: {}
+    asserts:
+      - equal:
+          path: probe.readiness
+          value:
+            tcpSocket:
+              port: http
+
   - it: httpGet probe falls back to extraArgs.tls when no http section
     set:
       app:
         extraArgs:
+          tls: "true"
+        probe:
+          readiness:
+            httpGet: {}
+    asserts:
+      - equal:
+          path: probe.readiness
+          value:
+            tcpSocket:
+              port: http
+
+  - it: httpGet probe uses extraArgs.tls when httpListenAddr overrides http section
+    set:
+      app:
+        http:
+          - name: http
+            value: :8429
+            primary: true
+        extraArgs:
+          httpListenAddr: :9000
           tls: "true"
         probe:
           readiness:

--- a/test-charts/victoria-metrics-common/tests/service_test.yaml
+++ b/test-charts/victoria-metrics-common/tests/service_test.yaml
@@ -130,6 +130,22 @@ tests:
       - equal:
           path: vm.url
           value: https://RELEASE-NAME-victoria-metrics-common-server.NAMESPACE.svc:8443
+  - it: with http section and no tls falls back to extraArgs.tls
+    set:
+      ctx:
+        style: plain
+        appKey: server
+      server:
+        http:
+          - name: http
+            value: :8429
+            primary: true
+        extraArgs:
+          tls: "true"
+    asserts:
+      - equal:
+          path: vm.url
+          value: https://RELEASE-NAME-victoria-metrics-common-server.NAMESPACE.svc:8429
   - it: with no http section falls back to extraArgs.tls for https scheme
     set:
       ctx:
@@ -142,3 +158,37 @@ tests:
       - equal:
           path: vm.url
           value: https://RELEASE-NAME-victoria-metrics-common-server.NAMESPACE.svc:443
+  - it: with httpListenAddr set http item tls is ignored without extraArgs.tls
+    set:
+      ctx:
+        style: plain
+        appKey: server
+      server:
+        http:
+          - name: https
+            value: :8443
+            primary: true
+            tls: true
+        extraArgs:
+          httpListenAddr: :9000
+    asserts:
+      - equal:
+          path: vm.url
+          value: http://RELEASE-NAME-victoria-metrics-common-server.NAMESPACE.svc:8443
+  - it: with httpListenAddr and extraArgs.tls both set uses https
+    set:
+      ctx:
+        style: plain
+        appKey: server
+      server:
+        http:
+          - name: http
+            value: :8429
+            primary: true
+        extraArgs:
+          httpListenAddr: :9000
+          tls: "true"
+    asserts:
+      - equal:
+          path: vm.url
+          value: https://RELEASE-NAME-victoria-metrics-common-server.NAMESPACE.svc:8429


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix TLS detection for `vm.url` and `vm.probe` to read the primary HTTP item's tls when `extraArgs.httpListenAddr` is not set, otherwise fall back to `extraArgs.tls`. This ensures correct http/https scheme selection and probe type.

- **Bug Fixes**
  - Detect TLS from the primary `http` item when `extraArgs.httpListenAddr` is unset; otherwise use `extraArgs.tls`.
  - Align probe logic to the same rule and switch `httpGet` to `tcpSocket` under TLS.
  - Add tests for service URL and probes; bump chart to 0.3.5 and update changelog.

<sup>Written for commit 1f3cce1d531388d3c794af2bc2c32f5fccdc3373. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

