### PR TITLE
release logs and traces charts with new common dependency

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.4 -> 0.3.5
 
 ## 0.2.1
 

--- a/charts/victoria-logs-agent/Chart.lock
+++ b/charts/victoria-logs-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.4
-digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
-generated: "2026-05-30T03:37:43.592800223Z"
+  version: 0.3.5
+digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
+generated: "2026-05-30T07:49:04.25866+03:00"

--- a/charts/victoria-logs-agent/Chart.yaml
+++ b/charts/victoria-logs-agent/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 name: victoria-logs-agent
 description: VictoriaLogs Agent - accepts logs from various protocols and replicates them across multiple VictoriaLogs instances.
-version: 0.2.1
+version: 0.2.2
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.4 -> 0.3.5
 
 ## 0.2.2
 

--- a/charts/victoria-logs-cluster/Chart.lock
+++ b/charts/victoria-logs-cluster/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.52.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.4
-digest: sha256:bedb651b94ba2c0cf8e627612f5d4f60362224f89adf888c181380b42d163989
-generated: "2026-05-30T03:37:46.519347714Z"
+  version: 0.3.5
+digest: sha256:ee4bcf270fa941477b7e6abec893b2157205f48384e5136644133f327be77ca0
+generated: "2026-05-30T07:49:18.587458+03:00"

--- a/charts/victoria-logs-cluster/Chart.yaml
+++ b/charts/victoria-logs-cluster/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs cluster Helm chart deploys VictoriaLogs cluster database in Kubernetes.
 name: victoria-logs-cluster
-version: 0.2.2
+version: 0.2.3
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-collector/Chart.lock
+++ b/charts/victoria-logs-collector/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.4
-digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
-generated: "2026-05-30T03:37:49.552803298Z"
+  version: 0.3.5
+digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
+generated: "2026-05-30T07:49:35.626823+03:00"

--- a/charts/victoria-logs-mcp/Chart.lock
+++ b/charts/victoria-logs-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.4
-digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
-generated: "2026-05-30T03:37:52.170359323Z"
+  version: 0.3.5
+digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
+generated: "2026-05-30T07:49:46.6443+03:00"

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.4 -> 0.3.5
 
 ## 0.2.2
 

--- a/charts/victoria-logs-multilevel/Chart.lock
+++ b/charts/victoria-logs-multilevel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.4
-digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
-generated: "2026-05-30T03:37:55.083483308Z"
+  version: 0.3.5
+digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
+generated: "2026-05-30T07:49:55.629496+03:00"

--- a/charts/victoria-logs-multilevel/Chart.yaml
+++ b/charts/victoria-logs-multilevel/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs multilevel Helm chart deploys global read for multiple storage groups.
 name: victoria-logs-multilevel
-version: 0.2.2
+version: 0.2.3
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.4 -> 0.3.5
 
 ## 0.13.2
 

--- a/charts/victoria-logs-single/Chart.lock
+++ b/charts/victoria-logs-single/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.52.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.4
-digest: sha256:bedb651b94ba2c0cf8e627612f5d4f60362224f89adf888c181380b42d163989
-generated: "2026-05-30T03:37:57.648895712Z"
+  version: 0.3.5
+digest: sha256:ee4bcf270fa941477b7e6abec893b2157205f48384e5136644133f327be77ca0
+generated: "2026-05-30T07:50:03.597519+03:00"

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs single Helm chart deploys VictoriaLogs database in Kubernetes.
 name: victoria-logs-single
-version: 0.13.2
+version: 0.13.3
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.4 -> 0.3.5
 
 ## 0.2.2
 

--- a/charts/victoria-traces-cluster/Chart.lock
+++ b/charts/victoria-traces-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.4
-digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
-generated: "2026-05-30T03:38:42.125148241Z"
+  version: 0.3.5
+digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
+generated: "2026-05-30T07:50:20.080297+03:00"

--- a/charts/victoria-traces-cluster/Chart.yaml
+++ b/charts/victoria-traces-cluster/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v0.9.0
 description: The VictoriaTraces cluster Helm chart deploys VictoriaTraces cluster database in Kubernetes.
 name: victoria-traces-cluster
-version: 0.2.2
+version: 0.2.3
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump common chart version 0.3.4 -> 0.3.5
 
 ## 0.1.2
 

--- a/charts/victoria-traces-single/Chart.lock
+++ b/charts/victoria-traces-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.4
-digest: sha256:1f91fc5cde93d2eb446b1f22838c9eb740afd82d445eac053cffa7ba953d2c24
-generated: "2026-05-30T03:38:44.744104419Z"
+  version: 0.3.5
+digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
+generated: "2026-05-30T07:50:13.146575+03:00"

--- a/charts/victoria-traces-single/Chart.yaml
+++ b/charts/victoria-traces-single/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v0.9.0
 description: The VictoriaTraces single Helm chart deploys VictoriaTraces database in Kubernetes.
 name: victoria-traces-single
-version: 0.1.2
+version: 0.1.3
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update all logs and traces Helm charts to use `victoria-metrics-common` 0.3.5. Bumps affected chart versions and regenerates locks; no breaking changes.

- **Dependencies**
  - Upgrade `victoria-metrics-common` from 0.3.4 to 0.3.5 across all logs and traces charts.
  - Chart version bumps: `victoria-logs-agent` 0.2.2, `victoria-logs-cluster` 0.2.3, `victoria-logs-multilevel` 0.2.3, `victoria-logs-single` 0.13.3, `victoria-traces-cluster` 0.2.3, `victoria-traces-single` 0.1.3.
  - Regenerated Chart.lock files with new digests.

<sup>Written for commit db9250f3aa609c8f722e7be1a920bc9aee3a8313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

