### PR TITLE
common: fixed templates that render http property values

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- TODO
+- fixed rendering failure when an http list entry does not have the `primary` field set.
+- fixed `syslog` args rendering: boolean `false` values (e.g. `tls: false`, `useLocalTimestamp: false`) are now correctly included; absent boolean fields are gap-filled with `false` instead of empty string.
 
 ## 0.2.2
 

--- a/charts/victoria-logs-agent/templates/_helpers.tpl
+++ b/charts/victoria-logs-agent/templates/_helpers.tpl
@@ -9,9 +9,10 @@
         {{- $key := ternary "listenAddr" $slKey (eq $slKey "value") -}}
         {{- $key = ternary (printf "syslog.%s" $key) (printf "syslog.%s.%s" $key $kind) (hasPrefix "tls" $key) -}}
         {{- $param := index $args $key | default list -}}
-        {{- if $slValue -}}
+        {{- if or $slValue (kindIs "bool" $slValue) -}}
+          {{- $gapFill := ternary false "" (kindIs "bool" $slValue) -}}
           {{- range until (int (sub $i (len $param))) }}
-            {{- $param = append $param "" }}
+            {{- $param = append $param $gapFill }}
           {{- end }}
           {{- $param = append $param $slValue }}
           {{- $_ := set $args $key $param -}}

--- a/charts/victoria-logs-agent/templates/service.yaml
+++ b/charts/victoria-logs-agent/templates/service.yaml
@@ -53,7 +53,7 @@ spec:
     {{- range ternary .Values.http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
     - name: {{ .name }}
       {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9429") }}
-      port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+      port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
       protocol: TCP
       targetPort: {{ .name }}
       {{- if and .primary $service.nodePort }}

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+- fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
+- fixed rendering failure when an http list entry does not have the `primary` field set.
+- fixed `syslog` args rendering: boolean `false` values (e.g. `tls: false`, `useLocalTimestamp: false`) are now correctly included; absent boolean fields are gap-filled with `false` instead of empty string.
 
 ## 0.2.3
 

--- a/charts/victoria-logs-cluster/templates/_helpers.tpl
+++ b/charts/victoria-logs-cluster/templates/_helpers.tpl
@@ -9,9 +9,10 @@
         {{- $key := ternary "listenAddr" $slKey (eq $slKey "value") -}}
         {{- $key = ternary (printf "syslog.%s" $key) (printf "syslog.%s.%s" $key $kind) (hasPrefix "tls" $key) -}}
         {{- $param := index $args $key | default list -}}
-        {{- if $slValue -}}
+        {{- if or $slValue (kindIs "bool" $slValue) -}}
+          {{- $gapFill := ternary false "" (kindIs "bool" $slValue) -}}
           {{- range until (int (sub $i (len $param))) }}
-            {{- $param = append $param "" }}
+            {{- $param = append $param $gapFill }}
           {{- end }}
           {{- $param = append $param $slValue }}
           {{- $_ := set $args $key $param -}}
@@ -149,7 +150,7 @@
 {{- range $ports }}
 - name: {{ .name }}
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9471") }}
-  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ .name }}
 {{- end }}
@@ -169,7 +170,7 @@
 {{- range $ports }}
 - name: {{ .name }}
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9481") }}
-  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ .name }}
 {{- end }}
@@ -205,7 +206,7 @@
 {{- range $ports }}
 - name: {{ .name }}
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9491") }}
-  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ .name }}
 {{- end }}
@@ -225,7 +226,7 @@
 {{- range $ports }}
 - name: {{ .name }}
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
-  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ .name }}
 {{- end }}

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- TODO
+- fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
+- fixed rendering failure when an http list entry does not have the `primary` field set.
 
 ## 0.2.3
 

--- a/charts/victoria-logs-multilevel/templates/_helpers.tpl
+++ b/charts/victoria-logs-multilevel/templates/_helpers.tpl
@@ -41,7 +41,7 @@
 {{- range $ports }}
 - name: {{ .name }}
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9471") }}
-  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ .name }}
 {{- end }}
@@ -61,7 +61,7 @@
 {{- range $ports }}
 - name: {{ .name }}
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
-  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ .name }}
 {{- end }}

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+- fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
+- fixed rendering failure when an http list entry does not have the `primary` field set.
+- fixed `syslog` args rendering: boolean `false` values (e.g. `tls: false`, `useLocalTimestamp: false`) are now correctly included; absent boolean fields are gap-filled with `false` instead of empty string.
 
 ## 0.13.3
 
@@ -54,7 +56,9 @@
 
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v1.50.0](https://img.shields.io/badge/v1.50.0-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fvictorialogs%2Fchangelog%2F%23v1500)
 
-- TODO
+- fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
+- fixed rendering failure when an http list entry does not have the `primary` field set.
+- fixed `syslog` args rendering: boolean `false` values (e.g. `tls: false`, `useLocalTimestamp: false`) are now correctly included; absent boolean fields are gap-filled with `false` instead of empty string.
 
 ## 0.12.3
 
@@ -413,7 +417,9 @@
 
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v1.18.0](https://img.shields.io/badge/v1.18.0-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fvictorialogs%2Fchangelog%2F%23v1180)
 
-- TODO
+- fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
+- fixed rendering failure when an http list entry does not have the `primary` field set.
+- fixed `syslog` args rendering: boolean `false` values (e.g. `tls: false`, `useLocalTimestamp: false`) are now correctly included; absent boolean fields are gap-filled with `false` instead of empty string.
 
 ## 0.9.4
 

--- a/charts/victoria-logs-single/templates/_helpers.tpl
+++ b/charts/victoria-logs-single/templates/_helpers.tpl
@@ -10,9 +10,10 @@
         {{- $key := ternary "listenAddr" $slKey (eq $slKey "value") -}}
         {{- $key = ternary (printf "syslog.%s" $key) (printf "syslog.%s.%s" $key $kind) (hasPrefix "tls" $key) -}}
         {{- $param := index $args $key | default list -}}
-        {{- if $slValue -}}
+        {{- if or $slValue (kindIs "bool" $slValue) -}}
+          {{- $gapFill := ternary false "" (kindIs "bool" $slValue) -}}
           {{- range until (int (sub $i (len $param))) }}
-            {{- $param = append $param "" }}
+            {{- $param = append $param $gapFill }}
           {{- end }}
           {{- $param = append $param $slValue }}
           {{- $_ := set $args $key $param -}}

--- a/charts/victoria-logs-single/templates/service.yaml
+++ b/charts/victoria-logs-single/templates/service.yaml
@@ -59,7 +59,7 @@ spec:
     {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
     - name: {{ .name }}
       {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9428") }}
-      port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+      port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
       protocol: TCP
       targetPort: {{ .name }}
       {{- if and .primary $service.nodePort }}

--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next release
 
-- TODO
+- `vm.probe` and `vm.url` now detect TLS from the primary http list item's `tls` field when `httpListenAddr` is not set in `extraArgs`; `extraArgs.tls` is used as fallback in all other cases.
+- `vm.http.args` now correctly includes boolean `false` values (e.g. `tls: false`, `mtls: false`); absent boolean fields at earlier indices are gap-filled with `false` instead of empty string.
 
 ## 0.3.5
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: VictoriaMetrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.3.5
+version: 0.3.6
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_service.tpl
+++ b/charts/victoria-metrics-common/templates/_service.tpl
@@ -53,9 +53,10 @@
     {{- range $hlKey, $hlValue := (omit $hl "name" "primary") -}}
       {{- $key := ternary "httpListenAddr" $hlKey (eq $hlKey "value") -}}
       {{- $param := index $args $key | default list -}}
-      {{- if $hlValue -}}
+      {{- if or $hlValue (kindIs "bool" $hlValue) -}}
+        {{- $gapFill := ternary false "" (kindIs "bool" $hlValue) -}}
         {{- range until (int (sub $i (len $param))) }}
-          {{- $param = append $param "" }}
+          {{- $param = append $param $gapFill }}
         {{- end }}
         {{- $param = append $param $hlValue }}
         {{- $_ := set $args $key $param -}}

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- TODO
+- fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
+- fixed rendering failure when an http list entry does not have the `primary` field set.
 
 ## 0.2.4
 
@@ -59,7 +60,8 @@
 
 ![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v0.8.2](https://img.shields.io/badge/v0.8.2-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fvictoriatraces%2Fchangelog%2F%23v082)
 
-- TODO
+- fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
+- fixed rendering failure when an http list entry does not have the `primary` field set.
 
 ## 0.1.1
 

--- a/charts/victoria-traces-cluster/templates/_helpers.tpl
+++ b/charts/victoria-traces-cluster/templates/_helpers.tpl
@@ -115,7 +115,7 @@
 {{- range $ports }}
 - name: {{ .name }}
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10471") }}
-  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ .name }}
 {{- end }}
@@ -135,7 +135,7 @@
 {{- range $ports }}
 - name: {{ .name }}
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10481") }}
-  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ .name }}
 {{- end }}
@@ -161,7 +161,7 @@
 {{- range $ports }}
 - name: {{ .name }}
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10491") }}
-  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ .name }}
 {{- end }}
@@ -181,7 +181,7 @@
 {{- range $ports }}
 - name: {{ .name }}
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
-  port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+  port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   targetPort: {{ .name }}
   protocol: TCP
 {{- end }}

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- TODO
+- fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
+- fixed rendering failure when an http list entry does not have the `primary` field set.
 
 ## 0.1.4
 

--- a/charts/victoria-traces-single/templates/service.yaml
+++ b/charts/victoria-traces-single/templates/service.yaml
@@ -58,7 +58,7 @@ spec:
     {{- range ternary $app.http (list (dict "name" "http" "value" $httpAddr "primary" true)) (empty $httpAddr) }}
     - name: {{ .name }}
       {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10428") }}
-      port: {{ ternary ($service.servicePort | default $port) $port (and .primary (not (empty $service.servicePort))) }}
+      port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
       protocol: TCP
       targetPort: {{ .name }}
       {{- if and .primary $service.nodePort }}

--- a/test-charts/victoria-metrics-common/templates/http_args.yaml
+++ b/test-charts/victoria-metrics-common/templates/http_args.yaml
@@ -1,0 +1,2 @@
+{{- $http := .Values.http | default list -}}
+args: {{ include "vm.http.args" $http | fromYaml | toYaml | nindent 2 }}

--- a/test-charts/victoria-metrics-common/tests/http_args_test.yaml
+++ b/test-charts/victoria-metrics-common/tests/http_args_test.yaml
@@ -1,0 +1,114 @@
+suite: http.args templates
+templates:
+  - http_args.yaml
+tests:
+  - it: single item produces httpListenAddr
+    set:
+      http:
+        - name: http
+          value: :8429
+          primary: true
+    asserts:
+      - equal:
+          path: args.httpListenAddr
+          value:
+            - :8429
+
+  - it: boolean false is included not skipped
+    set:
+      http:
+        - name: http
+          value: :8429
+          primary: true
+          tls: false
+          mtls: false
+    asserts:
+      - equal:
+          path: args.tls
+          value:
+            - false
+      - equal:
+          path: args.mtls
+          value:
+            - false
+
+  - it: multi-item boolean gap fill uses false not empty string
+    set:
+      http:
+        - name: http
+          value: :8429
+          primary: true
+          tls: false
+        - name: https
+          value: :8443
+          tls: true
+    asserts:
+      - equal:
+          path: args.httpListenAddr
+          value:
+            - :8429
+            - :8443
+      - equal:
+          path: args.tls
+          value:
+            - false
+            - true
+
+  - it: multi-item string gap fill uses empty string
+    set:
+      http:
+        - name: http
+          value: :8429
+          primary: true
+        - name: https
+          value: :8443
+          tlsCertFile: /path/cert.crt
+    asserts:
+      - equal:
+          path: args.httpListenAddr
+          value:
+            - :8429
+            - :8443
+      - equal:
+          path: args.tlsCertFile
+          value:
+            - ""
+            - /path/cert.crt
+
+  - it: empty string fields are omitted
+    set:
+      http:
+        - name: http
+          value: :8429
+          primary: true
+          tlsCertFile: ""
+    asserts:
+      - notExists:
+          path: args.tlsCertFile
+
+  - it: fails when no item has primary true
+    set:
+      http:
+        - name: http
+          value: :8429
+    asserts:
+      - failedTemplate:
+          errorMessage: "at least one item in `http` must have `primary: true`"
+
+  - it: fails when item has no value
+    set:
+      http:
+        - name: http
+          primary: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "`value` is not set for `http` idx 0"
+
+  - it: fails when item has no name
+    set:
+      http:
+        - value: :8429
+          primary: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "`name` is not set for `http` idx 0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Helm templates to render HTTP args and Service ports correctly across logs and traces charts. Booleans are now handled properly, `primary` defaults are safe, and `HTTPRoute` backends render valid YAML.

- **Bug Fixes**
  - `vm.http.args`: include `false` for `tls`/`mtls`; gap-fill booleans with `false` and strings with empty string; omit empty-string fields.
  - Syslog args: include `false` values and gap-fill booleans with `false` for logs charts.
  - Service ports: use `(.primary | default false)` when picking `servicePort` to avoid failures if `primary` is missing.
  - `HTTPRoute` backends: write `name` and `port` as separate keys to fix YAML rendering.
  - `vm.probe`/`vm.url`: auto-detect TLS from the primary HTTP item when `httpListenAddr` isn’t set; fallback to `extraArgs.tls`.
  - Added tests for `vm.http.args` covering boolean handling, gap-fill, and validation.

- **Dependencies**
  - Bump `victoria-metrics-common` to `0.3.6`.

<sup>Written for commit 068f157e929743bddf71d5a3d19ce735775a8704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

