### PR TITLE
release logs and traces charts

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - fixed rendering failure when an http list entry does not have the `primary` field set.
 - fixed `syslog` args rendering: boolean `false` values (e.g. `tls: false`, `useLocalTimestamp: false`) are now correctly included; absent boolean fields are gap-filled with `false` instead of empty string.
+- bump common chart version 0.3.5 -> 0.3.7
 
 ## 0.2.2
 

--- a/charts/victoria-logs-agent/Chart.lock
+++ b/charts/victoria-logs-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.5
-digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
-generated: "2026-05-30T07:49:04.25866+03:00"
+  version: 0.3.7
+digest: sha256:89cae8c480a951112c74926a79c0b51865bd5887117568762977b193e260d657
+generated: "2026-06-01T12:24:40.328887192Z"

--- a/charts/victoria-logs-agent/Chart.yaml
+++ b/charts/victoria-logs-agent/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 name: victoria-logs-agent
 description: VictoriaLogs Agent - accepts logs from various protocols and replicates them across multiple VictoriaLogs instances.
-version: 0.2.2
+version: 0.2.3
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-agent/templates/_helpers.tpl
+++ b/charts/victoria-logs-agent/templates/_helpers.tpl
@@ -20,6 +20,21 @@
       {{- end -}}
     {{- end -}}
   {{- end -}}
+  {{- $dropKeys := list -}}
+  {{- range $k, $v := $args -}}
+    {{- $hasValue := false -}}
+    {{- range $v -}}
+      {{- if . -}}
+        {{- $hasValue = true -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if not $hasValue -}}
+      {{- $dropKeys = append $dropKeys $k -}}
+    {{- end -}}
+  {{- end -}}
+  {{- range $k := $dropKeys -}}
+    {{- $_ := unset $args $k -}}
+  {{- end -}}
   {{- toYaml $args -}}
 {{- end -}}
 

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
 - fixed rendering failure when an http list entry does not have the `primary` field set.
 - fixed `syslog` args rendering: boolean `false` values (e.g. `tls: false`, `useLocalTimestamp: false`) are now correctly included; absent boolean fields are gap-filled with `false` instead of empty string.
+- bump common chart version 0.3.5 -> 0.3.7
 
 ## 0.2.3
 

--- a/charts/victoria-logs-cluster/Chart.lock
+++ b/charts/victoria-logs-cluster/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.52.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.5
-digest: sha256:ee4bcf270fa941477b7e6abec893b2157205f48384e5136644133f327be77ca0
-generated: "2026-05-30T07:49:18.587458+03:00"
+  version: 0.3.7
+digest: sha256:42a961a7f10a09ddf6de899622d74f44b569dfe154e63f10e2758e97f8a7412a
+generated: "2026-06-01T12:24:43.510610834Z"

--- a/charts/victoria-logs-cluster/Chart.yaml
+++ b/charts/victoria-logs-cluster/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs cluster Helm chart deploys VictoriaLogs cluster database in Kubernetes.
 name: victoria-logs-cluster
-version: 0.2.3
+version: 0.2.4
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-cluster/templates/_helpers.tpl
+++ b/charts/victoria-logs-cluster/templates/_helpers.tpl
@@ -20,6 +20,21 @@
       {{- end -}}
     {{- end -}}
   {{- end -}}
+  {{- $dropKeys := list -}}
+  {{- range $k, $v := $args -}}
+    {{- $hasValue := false -}}
+    {{- range $v -}}
+      {{- if . -}}
+        {{- $hasValue = true -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if not $hasValue -}}
+      {{- $dropKeys = append $dropKeys $k -}}
+    {{- end -}}
+  {{- end -}}
+  {{- range $k := $dropKeys -}}
+    {{- $_ := unset $args $k -}}
+  {{- end -}}
   {{- toYaml $args -}}
 {{- end -}}
 

--- a/charts/victoria-logs-collector/Chart.lock
+++ b/charts/victoria-logs-collector/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.5
-digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
-generated: "2026-05-30T07:49:35.626823+03:00"
+  version: 0.3.7
+digest: sha256:89cae8c480a951112c74926a79c0b51865bd5887117568762977b193e260d657
+generated: "2026-06-01T12:24:46.709908279Z"

--- a/charts/victoria-logs-mcp/Chart.lock
+++ b/charts/victoria-logs-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.5
-digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
-generated: "2026-05-30T07:49:46.6443+03:00"
+  version: 0.3.7
+digest: sha256:89cae8c480a951112c74926a79c0b51865bd5887117568762977b193e260d657
+generated: "2026-06-01T12:24:51.384321655Z"

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
 - fixed rendering failure when an http list entry does not have the `primary` field set.
+- bump common chart version 0.3.5 -> 0.3.7
 
 ## 0.2.3
 

--- a/charts/victoria-logs-multilevel/Chart.lock
+++ b/charts/victoria-logs-multilevel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.5
-digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
-generated: "2026-05-30T07:49:55.629496+03:00"
+  version: 0.3.7
+digest: sha256:89cae8c480a951112c74926a79c0b51865bd5887117568762977b193e260d657
+generated: "2026-06-01T12:24:54.869480057Z"

--- a/charts/victoria-logs-multilevel/Chart.yaml
+++ b/charts/victoria-logs-multilevel/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs multilevel Helm chart deploys global read for multiple storage groups.
 name: victoria-logs-multilevel
-version: 0.2.3
+version: 0.2.4
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
 - fixed rendering failure when an http list entry does not have the `primary` field set.
 - fixed `syslog` args rendering: boolean `false` values (e.g. `tls: false`, `useLocalTimestamp: false`) are now correctly included; absent boolean fields are gap-filled with `false` instead of empty string.
+- bump common chart version 0.3.5 -> 0.3.7
 
 ## 0.13.3
 

--- a/charts/victoria-logs-single/Chart.lock
+++ b/charts/victoria-logs-single/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.52.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.5
-digest: sha256:ee4bcf270fa941477b7e6abec893b2157205f48384e5136644133f327be77ca0
-generated: "2026-05-30T07:50:03.597519+03:00"
+  version: 0.3.7
+digest: sha256:42a961a7f10a09ddf6de899622d74f44b569dfe154e63f10e2758e97f8a7412a
+generated: "2026-06-01T12:24:58.518366027Z"

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v1.50.0
 description: The VictoriaLogs single Helm chart deploys VictoriaLogs database in Kubernetes.
 name: victoria-logs-single
-version: 0.13.3
+version: 0.13.4
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-logs-single/templates/_helpers.tpl
+++ b/charts/victoria-logs-single/templates/_helpers.tpl
@@ -21,6 +21,21 @@
       {{- end -}}
     {{- end -}}
   {{- end -}}
+  {{- $dropKeys := list -}}
+  {{- range $k, $v := $args -}}
+    {{- $hasValue := false -}}
+    {{- range $v -}}
+      {{- if . -}}
+        {{- $hasValue = true -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if not $hasValue -}}
+      {{- $dropKeys = append $dropKeys $k -}}
+    {{- end -}}
+  {{- end -}}
+  {{- range $k := $dropKeys -}}
+    {{- $_ := unset $args $k -}}
+  {{- end -}}
   {{- toYaml $args -}}
 {{- end -}}
 

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
 - fixed rendering failure when an http list entry does not have the `primary` field set.
+- bump common chart version 0.3.5 -> 0.3.7
 
 ## 0.2.4
 

--- a/charts/victoria-traces-cluster/Chart.lock
+++ b/charts/victoria-traces-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.5
-digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
-generated: "2026-05-30T07:50:20.080297+03:00"
+  version: 0.3.7
+digest: sha256:89cae8c480a951112c74926a79c0b51865bd5887117568762977b193e260d657
+generated: "2026-06-01T12:25:51.638340962Z"

--- a/charts/victoria-traces-cluster/Chart.yaml
+++ b/charts/victoria-traces-cluster/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v0.9.2
 description: The VictoriaTraces cluster Helm chart deploys VictoriaTraces cluster database in Kubernetes.
 name: victoria-traces-cluster
-version: 0.2.4
+version: 0.2.5
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - fixed `HTTPRoute` backend template rendering where the `port` field was incorrectly joined onto the same line as `name`.
 - fixed rendering failure when an http list entry does not have the `primary` field set.
+- bump common chart version 0.3.5 -> 0.3.7
 
 ## 0.1.4
 

--- a/charts/victoria-traces-single/Chart.lock
+++ b/charts/victoria-traces-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.5
-digest: sha256:1a4c528881de128fc3fb6d01f57370da6454a07a5bddd6bc04423e1347c3a31e
-generated: "2026-05-30T07:50:13.146575+03:00"
+  version: 0.3.7
+digest: sha256:89cae8c480a951112c74926a79c0b51865bd5887117568762977b193e260d657
+generated: "2026-06-01T12:25:54.798115023Z"

--- a/charts/victoria-traces-single/Chart.yaml
+++ b/charts/victoria-traces-single/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 appVersion: v0.9.2
 description: The VictoriaTraces single Helm chart deploys VictoriaTraces database in Kubernetes.
 name: victoria-traces-single
-version: 0.1.4
+version: 0.1.5
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Release updated Helm charts for VictoriaLogs and VictoriaTraces, bumping `victoria-metrics-common` to 0.3.7. Fixes HTTPRoute backend rendering and hardens args handling (include boolean false, default absent booleans to false, drop empty keys).

- **Bug Fixes**
  - HTTPRoute backend: port no longer joined to name.
  - Avoid render error when an http list entry lacks `primary`.
  - Args rendering: include boolean false, default absent booleans to false, drop empty keys.

- **Dependencies**
  - Bumped `victoria-metrics-common` 0.3.5 → 0.3.7 across: `victoria-logs-agent` 0.2.3, `victoria-logs-single` 0.13.4, `victoria-logs-cluster` 0.2.4, `victoria-logs-multilevel` 0.2.4, `victoria-traces-single` 0.1.5, `victoria-traces-cluster` 0.2.5; updated locks for `victoria-logs-collector` and `victoria-logs-mcp`.

<sup>Written for commit c1c0d1e1bfe5ad41c192575cf76e12814c2ae8e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

