### PR TITLE
release common chart

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-- TODO
+- `vm.http.args` absent boolean fields at earlier indices are now gap-filled with `false` instead of empty string; keys where all values are falsy are dropped entirely to avoid passing disabled-feature flags (e.g. `--mtls=false` for enterprise-only features).
 
 ## 0.3.6
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: VictoriaMetrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.3.6
+version: 0.3.7
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_service.tpl
+++ b/charts/victoria-metrics-common/templates/_service.tpl
@@ -66,6 +66,21 @@
   {{- if not $hasPrimary -}}
     {{- fail "at least one item in `http` must have `primary: true`" -}}
   {{- end -}}
+  {{- $dropKeys := list -}}
+  {{- range $k, $v := $args -}}
+    {{- $hasValue := false -}}
+    {{- range $v -}}
+      {{- if . -}}
+        {{- $hasValue = true -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if not $hasValue -}}
+      {{- $dropKeys = append $dropKeys $k -}}
+    {{- end -}}
+  {{- end -}}
+  {{- range $k := $dropKeys -}}
+    {{- $_ := unset $args $k -}}
+  {{- end -}}
   {{- toYaml $args -}}
 {{- end -}}
 

--- a/test-charts/victoria-metrics-common/tests/http_args_test.yaml
+++ b/test-charts/victoria-metrics-common/tests/http_args_test.yaml
@@ -14,7 +14,7 @@ tests:
           value:
             - :8429
 
-  - it: boolean false is included not skipped
+  - it: all-false boolean key is dropped entirely
     set:
       http:
         - name: http
@@ -23,14 +23,10 @@ tests:
           tls: false
           mtls: false
     asserts:
-      - equal:
+      - notExists:
           path: args.tls
-          value:
-            - false
-      - equal:
+      - notExists:
           path: args.mtls
-          value:
-            - false
 
   - it: multi-item boolean gap fill uses false not empty string
     set:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalize `vm.http.args` in the common Helm chart: fill missing boolean positions with false and drop keys where all values are false to avoid emitting disabled flags like `--mtls=false`. Release `victoria-metrics-common` 0.3.7 and update tests to reflect the new behavior.

<sup>Written for commit 4f26cd0047484becfa75968f22942317275865f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

