### PR TITLE
common: release chart fix bugfixes

### DIFF
--- a/charts/victoria-metrics-common/CHANGELOG.md
+++ b/charts/victoria-metrics-common/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-- TODO
+- added `vm.args.positional` template: builds positional CLI arg lists from a flat list of items with boolean tracking, boolean trailing padding, and all-false key dropping.
+- added `vl.syslog.args` template moved from victoria-logs charts; uses `vm.args.positional` internally.
+- `vm.http.args` refactored to use `vm.args.positional`.
 
 ## 0.3.7
 

--- a/charts/victoria-metrics-common/Chart.yaml
+++ b/charts/victoria-metrics-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: library
 description: VictoriaMetrics Common - contains shared templates for all Victoria Metrics helm charts
 name: victoria-metrics-common
-version: 0.3.7
+version: 0.3.8
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.23.0-0"

--- a/charts/victoria-metrics-common/templates/_service.tpl
+++ b/charts/victoria-metrics-common/templates/_service.tpl
@@ -37,34 +37,33 @@
   {{- $addr -}}
 {{- end -}}
 
-{{- define "vm.http.args" -}}
-  {{- $args := dict }}
-  {{- $hasPrimary := false -}}
-  {{- range $i, $hl := . -}}
-    {{- if not $hl.value -}}
-      {{- fail (printf "`value` is not set for `http` idx %d" $i) -}}
-    {{- end -}}
-    {{- if not $hl.name -}}
-      {{- fail (printf "`name` is not set for `http` idx %d" $i) -}}
-    {{- end -}}
-    {{- if $hl.primary -}}
-      {{- $hasPrimary = true -}}
-    {{- end -}}
-    {{- range $hlKey, $hlValue := (omit $hl "name" "primary") -}}
-      {{- $key := ternary "httpListenAddr" $hlKey (eq $hlKey "value") -}}
-      {{- $param := index $args $key | default list -}}
-      {{- if or $hlValue (kindIs "bool" $hlValue) -}}
-        {{- $gapFill := ternary false "" (kindIs "bool" $hlValue) -}}
+{{- define "vm.args.positional" -}}
+  {{- $args := dict -}}
+  {{- $boolKeys := dict -}}
+  {{- $n := 0 -}}
+  {{- range $i, $item := . -}}
+    {{- $n = add $i 1 -}}
+    {{- range $k, $v := $item -}}
+      {{- if kindIs "bool" $v -}}
+        {{- $_ := set $boolKeys $k true -}}
+      {{- end -}}
+      {{- $param := index $args $k | default list -}}
+      {{- if or $v (kindIs "bool" $v) -}}
+        {{- $gapFill := ternary false "" ((index $boolKeys $k) | default false) -}}
         {{- range until (int (sub $i (len $param))) }}
           {{- $param = append $param $gapFill }}
         {{- end }}
-        {{- $param = append $param $hlValue }}
-        {{- $_ := set $args $key $param -}}
+        {{- $param = append $param $v }}
+        {{- $_ := set $args $k $param -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}
-  {{- if not $hasPrimary -}}
-    {{- fail "at least one item in `http` must have `primary: true`" -}}
+  {{- range $k := keys $boolKeys -}}
+    {{- $v := index $args $k | default list -}}
+    {{- range until (int (sub $n (len $v))) }}
+      {{- $v = append $v false }}
+    {{- end }}
+    {{- $_ := set $args $k $v -}}
   {{- end -}}
   {{- $dropKeys := list -}}
   {{- range $k, $v := $args -}}
@@ -80,6 +79,55 @@
   {{- end -}}
   {{- range $k := $dropKeys -}}
     {{- $_ := unset $args $k -}}
+  {{- end -}}
+  {{- toYaml $args -}}
+{{- end -}}
+
+{{- define "vm.http.args" -}}
+  {{- $hasPrimary := false -}}
+  {{- $items := list -}}
+  {{- range $i, $hl := . -}}
+    {{- if not $hl.value -}}
+      {{- fail (printf "`value` is not set for `http` idx %d" $i) -}}
+    {{- end -}}
+    {{- if not $hl.name -}}
+      {{- fail (printf "`name` is not set for `http` idx %d" $i) -}}
+    {{- end -}}
+    {{- if $hl.primary -}}
+      {{- $hasPrimary = true -}}
+    {{- end -}}
+    {{- $item := omit $hl "name" "primary" -}}
+    {{- $_ := set $item "httpListenAddr" (index $item "value") -}}
+    {{- $item = omit $item "value" -}}
+    {{- $items = append $items $item -}}
+  {{- end -}}
+  {{- if not $hasPrimary -}}
+    {{- fail "at least one item in `http` must have `primary: true`" -}}
+  {{- end -}}
+  {{- include "vm.args.positional" $items -}}
+{{- end -}}
+
+{{- define "vl.syslog.args" -}}
+  {{- $args := dict -}}
+  {{- range $kind, $sls := . -}}
+    {{- $items := list -}}
+    {{- range $i, $sl := $sls -}}
+      {{- if not $sl.value -}}
+        {{- fail (printf "`value` is not set for `syslog.%s` idx %d" $kind $i) -}}
+      {{- end -}}
+      {{- $item := dict -}}
+      {{- range $k, $v := (omit $sl "name") -}}
+        {{- if eq $k "value" -}}
+          {{- $_ := set $item (printf "syslog.listenAddr.%s" $kind) $v -}}
+        {{- else if hasPrefix "tls" $k -}}
+          {{- $_ := set $item (printf "syslog.%s" $k) $v -}}
+        {{- else -}}
+          {{- $_ := set $item (printf "syslog.%s.%s" $k $kind) $v -}}
+        {{- end -}}
+      {{- end -}}
+      {{- $items = append $items $item -}}
+    {{- end -}}
+    {{- $args = mergeOverwrite $args (fromYaml (include "vm.args.positional" $items)) -}}
   {{- end -}}
   {{- toYaml $args -}}
 {{- end -}}

--- a/test-charts/victoria-metrics-common/tests/http_args_test.yaml
+++ b/test-charts/victoria-metrics-common/tests/http_args_test.yaml
@@ -50,6 +50,22 @@ tests:
             - false
             - true
 
+  - it: trailing boolean false padded when later item omits the key
+    set:
+      http:
+        - name: https
+          value: :8443
+          primary: true
+          tls: true
+        - name: http
+          value: :8429
+    asserts:
+      - equal:
+          path: args.tls
+          value:
+            - true
+            - false
+
   - it: multi-item string gap fill uses empty string
     set:
       http:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a general positional args builder and refactor HTTP/syslog arg generation to use it, fixing boolean padding and gap handling. Bumps `victoria-metrics-common` to 0.3.8.

- **New Features**
  - Added `vm.args.positional` to build positional CLI arg lists (tracks boolean keys, pads trailing booleans, drops all-false keys).
  - Introduced `vl.syslog.args` (moved from victoria-logs) using `vm.args.positional`.

- **Bug Fixes**
  - `vm.http.args` now uses `vm.args.positional` to correctly fill gaps and pad trailing boolean values; added test to cover trailing false when a later item omits the key.

<sup>Written for commit 764e6763350da8cdfb28da368f56975fa174dfa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

