### PR TITLE
logs and traces: override service target port

### DIFF
--- a/charts/victoria-logs-agent/templates/service.yaml
+++ b/charts/victoria-logs-agent/templates/service.yaml
@@ -55,7 +55,7 @@ spec:
       {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9429") }}
       port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
       protocol: TCP
-      targetPort: {{ .name }}
+      targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
       {{- if and .primary $service.nodePort }}
       nodePort: {{ $service.nodePort }}
       {{- end }}

--- a/charts/victoria-logs-cluster/templates/_helpers.tpl
+++ b/charts/victoria-logs-cluster/templates/_helpers.tpl
@@ -126,7 +126,7 @@
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9471") }}
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ .name }}
+  targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -146,7 +146,7 @@
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9481") }}
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ .name }}
+  targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
 {{- end }}
 {{- $syslogTCPAddr := index $extraArgs "syslog.listenAddr.tcp" -}}
 {{- $tcpPorts := ternary .syslog.tcp (list (dict "name" "syslog-tcp" "value" $syslogTCPAddr)) (empty $syslogTCPAddr) }}
@@ -182,7 +182,7 @@
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9491") }}
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ .name }}
+  targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -202,7 +202,7 @@
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ .name }}
+  targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}

--- a/charts/victoria-logs-multilevel/templates/_helpers.tpl
+++ b/charts/victoria-logs-multilevel/templates/_helpers.tpl
@@ -43,7 +43,7 @@
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9471") }}
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ .name }}
+  targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -63,7 +63,7 @@
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ .name }}
+  targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}

--- a/charts/victoria-logs-single/templates/service.yaml
+++ b/charts/victoria-logs-single/templates/service.yaml
@@ -61,7 +61,7 @@ spec:
       {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "9428") }}
       port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
       protocol: TCP
-      targetPort: {{ .name }}
+      targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
       {{- if and .primary $service.nodePort }}
       nodePort: {{ $service.nodePort }}
       {{- end }}

--- a/charts/victoria-traces-cluster/templates/_helpers.tpl
+++ b/charts/victoria-traces-cluster/templates/_helpers.tpl
@@ -117,7 +117,7 @@
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10471") }}
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ .name }}
+  targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -137,7 +137,7 @@
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10481") }}
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ .name }}
+  targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
 {{- end }}
 {{- with .extraArgs.otlpGRPCListenAddr }}
 - name: otlpgrpc-tcp
@@ -163,7 +163,7 @@
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10491") }}
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
-  targetPort: {{ .name }}
+  targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -182,7 +182,7 @@
 - name: {{ .name }}
   {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "8427") }}
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
-  targetPort: {{ .name }}
+  targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
   protocol: TCP
 {{- end }}
 {{- range $service.extraPorts }}

--- a/charts/victoria-traces-single/templates/service.yaml
+++ b/charts/victoria-traces-single/templates/service.yaml
@@ -60,7 +60,7 @@ spec:
       {{- $port := include "vm.port.from.flag" (dict "flag" .value "default" "10428") }}
       port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
       protocol: TCP
-      targetPort: {{ .name }}
+      targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
       {{- if and .primary $service.nodePort }}
       nodePort: {{ $service.nodePort }}
       {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support to override Kubernetes Service targetPort in `victoria-logs-*` and `victoria-traces-*` charts. Set `service.targetPort` to map Service ports to a specific container port; defaults remain unchanged.

- New Features
  - Primary Services now honor `.Values.service.targetPort`; if unset, they use the named port as before. Applies to `victoria-logs-agent`, `victoria-logs-single`, `victoria-logs-cluster`, `victoria-logs-multilevel`, `victoria-traces-single`, and `victoria-traces-cluster`.

<sup>Written for commit a20d08319fd040ed696aa4e2d1ec432909930a01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

