### PR TITLE
charts: update vm apps to v1.145.0

### DIFF
--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Update note 1**: `.Values.extraArgs.httpListenAddr` was replaced by `.Values.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-agent/#http-listen-address) for details.
 
+- bump version of VM components to [v1.145.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.145.0)
 - `serviceMonitor` port now defaults to the primary `http` list item name; added explicit `port` field to override it without using `targetPort`.
 - fixed HTTPRoute backend `port` field being rendered on the same line as `name` due to incorrect whitespace trimming in the route template.
 

--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 name: victoria-metrics-agent
 description: VictoriaMetrics Agent - collects metrics from various sources and stores them to VictoriaMetrics
-version: 0.40.0
+version: 0.41.0
 # renovate: image=victoriametrics/vmagent
-appVersion: v1.144.0
+appVersion: v1.145.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Update note 1**: `.Values.server.extraArgs.httpListenAddr` was replaced by `.Values.server.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-alert/#http-listen-address) for details.
 
+- bump version of VM components to [v1.145.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.145.0)
 - added `.Values.server.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Has higher priority than `extraArgs`.
 - add ability to override container command.
 

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 name: victoria-metrics-alert
 description: VictoriaMetrics Alert - executes a list of given MetricsQL expressions (rules) and sends alerts to Alert Manager.
-version: 0.41.0
+version: 0.42.0
 # renovate: image=victoriametrics/vmalert
-appVersion: v1.144.0
+appVersion: v1.145.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Update note 1**: `.Values.extraArgs.httpListenAddr` was replaced by `.Values.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-auth/#http-listen-address) for details.
 
+- bump version of VM components to [v1.145.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.145.0)
 - `serviceMonitor` port now defaults to the primary `http` list item name; added explicit `port` field to override it without using `targetPort`.
 - fixed HTTPRoute backend `port` field being rendered on the same line as `name` due to incorrect whitespace trimming in the route template.
 

--- a/charts/victoria-metrics-auth/Chart.yaml
+++ b/charts/victoria-metrics-auth/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Auth - is a simple auth proxy and router for VictoriaMetrics.
 name: victoria-metrics-auth
-version: 0.33.0
+version: 0.34.0
 # renovate: image=victoriametrics/vmauth
-appVersion: v1.144.0
+appVersion: v1.145.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Update note 1**: `.Values.{vminsert,vmselect,vmstorage,vmauth}.extraArgs.httpListenAddr` was replaced by `.Values.{vminsert,vmselect,vmstorage,vmauth}.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-cluster/#http-listen-address) for details.
 
+- bump version of VM components to [v1.145.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.145.0)
 - `serviceMonitor` port for each component now defaults to the primary `http` list item name; added explicit `port` field to override it without using `targetPort`.
 - fixed HTTPRoute backend `port` field being rendered on the same line as `name` due to incorrect whitespace trimming in the route template.
 

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.43.0
+version: 0.44.0
 # renovate: image=victoriametrics/vmselect
-appVersion: v1.144.0
+appVersion: v1.145.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.145.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.145.0)
 
 ## 0.38.0
 

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: victoria-metrics-distributed
 description: A Helm chart for Running VMCluster on Multiple Availability Zones
 type: application
-version: 0.38.0
+version: 0.39.0
 deprecated: true
 # renovate: image=victoriametrics/victoria-metrics
-appVersion: v1.144.0
+appVersion: v1.145.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.25.0-0"

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Update note 1**: `.Values.extraArgs.httpListenAddr` was replaced by `.Values.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-gateway/#http-listen-address) for details.
 
+- bump version of VM components to [v1.145.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.145.0)
 - added `.Values.http` list of objects, where each item configures an HTTP listen address with optional TLS settings. Items are used for Pod ports, command line arguments and Service port generation. Has higher priority than `extraArgs`.
 - add ability to override container command.
 

--- a/charts/victoria-metrics-gateway/Chart.yaml
+++ b/charts/victoria-metrics-gateway/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Gateway - Auth & Rate-Limitting proxy for Victoria Metrics
 name: victoria-metrics-gateway
-version: 0.31.0
+version: 0.32.0
 # renovate: image=victoriametrics/vmgateway
-appVersion: v1.144.0
+appVersion: v1.145.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VM components to [v1.145.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.145.0)
 
 ## 0.81.0
 

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: victoria-metrics-k8s-stack
 description: Kubernetes monitoring on VictoriaMetrics stack. Includes VictoriaMetrics Operator, Grafana dashboards, ServiceScrapes and VMRules
 type: application
-version: 0.81.0
+version: 0.82.0
 # renovate: image=victoriametrics/victoria-metrics
-appVersion: v1.144.0
+appVersion: v1.145.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Update note 1**: `.Values.server.extraArgs.httpListenAddr` was replaced by `.Values.server.http` list for HTTP listen address configuration. See [HTTP listen address](https://docs.victoriametrics.com/helm/victoria-metrics-single/#http-listen-address) for details.
 
+- bump version of VM components to [v1.145.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.145.0)
 - `serviceMonitor` port now defaults to the primary `http` list item name; added explicit `port` field to override it without using `targetPort`.
 - fixed HTTPRoute backend `port` field being rendered on the same line as `name` due to incorrect whitespace trimming in the route template.
 

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Single version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-single
-version: 0.39.0
+version: 0.40.0
 # renovate: image=victoriametrics/victoria-metrics
-appVersion: v1.144.0
+appVersion: v1.145.0
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 kubeVersion: ">=1.25.0-0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update all VictoriaMetrics Helm charts to v1.145.0 to pull in the latest upstream fixes and improvements. Also bumps chart versions and updates CHANGELOGs.

- **Dependencies**
  - Set `appVersion: v1.145.0` for `victoria-metrics-agent`, `victoria-metrics-alert`, `victoria-metrics-auth`, `victoria-metrics-cluster`, `victoria-metrics-distributed`, `victoria-metrics-gateway`, `victoria-metrics-k8s-stack`, and `victoria-metrics-single`; incremented chart versions accordingly.

<sup>Written for commit 7ea94a1585907c14a133b37210b7b5cf2203a7ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

