### PR TITLE
ci: use slim images

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout charts repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213  # v6.1.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
 
       - name: Checkout

--- a/.github/workflows/run-lint.yaml
+++ b/.github/workflows/run-lint.yaml
@@ -24,7 +24,7 @@ permissions: {}
 jobs:
   lint-charts:
     name: Lint Charts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     steps:

--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -32,7 +32,7 @@ permissions: {}
 jobs:
   chart-tests:
     name: Run chart tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,7 +9,7 @@ jobs:
   stale:
     permissions:
       issues: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899  # v10.3.0
         with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch all GitHub Actions workflows to `ubuntu-slim` runners to reduce image size and speed up job startup, improving CI performance.

Updated workflows: docs, labeler, release, lint, testing, stale.

<sup>Written for commit 8431c56e3c7cc629782d2fa4dacd4b64ad1c1ac0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

