### PR TITLE
.github: add explicit persist-credentials for checkout action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           path: __vm-helm-charts
+          persist-credentials: false
 
       - name: Checkout docs repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -36,6 +37,7 @@ jobs:
           repository: VictoriaMetrics/vmdocs
           ref: main
           token: ${{ secrets.VM_BOT_GH_TOKEN }}
+          persist-credentials: true  # required by the "Push to vmdocs" step below
           path: __vm-docs
 
       - name: Import GPG key
@@ -93,6 +95,7 @@ jobs:
         with:
           ref: gh-pages
           path: __vm-helm-charts
+          persist-credentials: true  # required by the "Synchronize docs" step below
 
       - name: Synchronize docs
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.VM_BOT_GH_TOKEN }}
+          persist-credentials: true  # required by the "Automatic update changelogs and readme" step below
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd  # v7.0.0

--- a/.github/workflows/run-lint.yaml
+++ b/.github/workflows/run-lint.yaml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install helm
         uses: yokawasa/action-setup-kube-tools@9d39563c24d4a419d1a8289c34d6da5a6171252c  # v0.13.5

--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0


### PR DESCRIPTION
Add explicit `persist-credentials` as it's `true` by default.

More Info: https://github.com/actions/checkout/issues/485

cc: @arkid15r
