### PR TITLE
victoria-logs-collector: added fileCollector section support

### DIFF
--- a/charts/victoria-logs-collector/CHANGELOG.md
+++ b/charts/victoria-logs-collector/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add `fileCollector` list to support multiple file-based log collection configurations (glob patterns paired with extra fields). Each list entry maps to a set of positional `-fileCollector.*` flags, enabling configurations that were previously impossible with the `extraArgs` dict. See [#2990](https://github.com/VictoriaMetrics/helm-charts/issues/2990).
 
 ## 0.3.4
 

--- a/charts/victoria-logs-collector/Chart.yaml
+++ b/charts/victoria-logs-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-logs-collector
 description: VictoriaLogs Collector - collects logs from Kubernetes containers and stores them to VictoriaLogs
-version: 0.3.4
+version: 0.3.5
 # renovate: image=victoriametrics/vlagent
 appVersion: v1.50.0
 sources:

--- a/charts/victoria-logs-collector/templates/_helpers.tpl
+++ b/charts/victoria-logs-collector/templates/_helpers.tpl
@@ -82,8 +82,7 @@
     {{- end }}
   {{- end }}
 
-  {{- $requiredParams := list "url" }}
-
+  {{- $rwItems := list }}
   {{- range $i, $oldRw := $Values.remoteWrite }}
     {{- $rw := fromYaml (tpl (toYaml (deepCopy $oldRw)) $) }}
     {{- $_ := set $ "rw" $rw }}
@@ -93,37 +92,40 @@
     {{- $_ := unset $rw "extraFields" }}
     {{- $_ := unset $rw "ignoreFields" }}
     {{- $rw = mergeOverwrite $rw (fromYaml (include "victoria-logs-collector.tls" $)) }}
-    {{- $_ := unset $rw "tls"}}
-
-    {{- range $rwKey, $rwValue := $rw }}
-      {{- if has $rwKey $requiredParams }}
-        {{- if empty $rw }}
-          {{- fail (printf "remoteWrite[%d].%s parameter is not set" $i $rwKey) }}
-        {{- end }}
-      {{- end }}
-
-      {{- $key := printf "remoteWrite.%s" $rwKey }}
-      {{- $param := index $args $key | default list}}
-      {{- range until (int (sub $i (len $param))) }}
-        {{- $param = append $param "" }}
-      {{- end }}
-      {{- $value := $rwValue }}
-      {{- if eq $rwKey "url" }}
-        {{- $url := urlParse $rwValue }}
-        {{- $isEmptyPath := empty (trimPrefix "/" $url.path) }}
-        {{- $isNativeFormat := or (empty $rw.format) (eq $rw.format "native") }}
-        {{- $_ = set $url "path" (ternary "/insert/native" $url.path (and $isEmptyPath $isNativeFormat)) }}
-        {{- $value = urlJoin $url }}
-      {{- else if eq $rwKey "headers" }}
-        {{- $headers := list }}
-        {{- range $hk, $hv := $rwValue }}
-          {{- $headers = append $headers (printf "%s:%s" $hk $hv) }}
-        {{- end }}
-        {{- $value = quote (join "^^" $headers) }}
-      {{- end }}
-      {{- $param = append $param $value }}
-      {{- $_ := set $args $key $param }}
+    {{- $_ := unset $rw "tls" }}
+    {{- if empty $rw.url }}
+      {{- fail (printf "remoteWrite[%d].url parameter is not set" $i) }}
     {{- end }}
+    {{- $url := urlParse $rw.url }}
+    {{- $isEmptyPath := empty (trimPrefix "/" $url.path) }}
+    {{- $isNativeFormat := or (empty $rw.format) (eq $rw.format "native") }}
+    {{- $_ := set $url "path" (ternary "/insert/native" $url.path (and $isEmptyPath $isNativeFormat)) }}
+    {{- $_ := set $rw "url" (urlJoin $url) }}
+    {{- $headers := list }}
+    {{- range $hk, $hv := $rw.headers }}
+      {{- $headers = append $headers (printf "%s:%s" $hk $hv) }}
+    {{- end }}
+    {{- $_ := set $rw "headers" (quote (join "^^" $headers)) }}
+    {{- $prefixed := dict }}
+    {{- range $k, $v := $rw }}
+      {{- $_ := set $prefixed (printf "remoteWrite.%s" $k) $v }}
+    {{- end }}
+    {{- $rwItems = append $rwItems $prefixed }}
   {{- end }}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.args.positional" $rwItems)) }}
+
+  {{- $fcItems := list }}
+  {{- range $i, $fc := ($Values.fileCollector | default list) }}
+    {{- if empty $fc.glob }}
+      {{- fail (printf "fileCollector[%d].glob parameter is not set" $i) }}
+    {{- end }}
+    {{- $prefixed := dict }}
+    {{- range $k, $v := $fc }}
+      {{- $_ := set $prefixed (printf "fileCollector.%s" $k) $v }}
+    {{- end }}
+    {{- $fcItems = append $fcItems $prefixed }}
+  {{- end }}
+  {{- $args = mergeOverwrite $args (fromYaml (include "vm.args.positional" $fcItems)) }}
+
   {{- toYaml (mergeOverwrite $args $Values.extraArgs) -}}
 {{- end }}

--- a/charts/victoria-logs-collector/tests/collector_test.yaml
+++ b/charts/victoria-logs-collector/tests/collector_test.yaml
@@ -36,3 +36,71 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--remoteWrite.url=http://RELEASE-NAME-vlogs:9428/insert/native"
         template: server.yaml
+
+  - it: single fileCollector entry produces correct args
+    set:
+      remoteWrite:
+        - url: http://victoria-logs:9428
+      fileCollector:
+        - glob: /var/log/app/*.log
+          extraFields: '{"app":"myapp"}'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: '--fileCollector.glob=/var/log/app/*.log'
+        template: server.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: '--fileCollector.extraFields={"app":"myapp"}'
+        template: server.yaml
+
+  - it: multiple fileCollector entries produce repeated positional args
+    set:
+      remoteWrite:
+        - url: http://victoria-logs:9428
+      fileCollector:
+        - glob: /var/log/app/*.log
+          extraFields: '{"app":"myapp"}'
+        - glob: /var/log/nginx/*.log
+          extraFields: '{"app":"nginx"}'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: '--fileCollector.glob=/var/log/app/*.log'
+        template: server.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: '--fileCollector.glob=/var/log/nginx/*.log'
+        template: server.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: '--fileCollector.extraFields={"app":"myapp"}'
+        template: server.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: '--fileCollector.extraFields={"app":"nginx"}'
+        template: server.yaml
+
+  - it: fileCollector gap-fills excludeGlob when only some entries have it
+    set:
+      remoteWrite:
+        - url: http://victoria-logs:9428
+      fileCollector:
+        - glob: /var/log/*/*.log
+          excludeGlob: /var/log/nginx/*
+          extraFields: '{"app":"other"}'
+        - glob: /var/log/nginx/*.log
+          extraFields: '{"app":"nginx"}'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: '--fileCollector.excludeGlob=/var/log/nginx/*'
+        template: server.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: '--fileCollector.glob=/var/log/*/*.log'
+        template: server.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: '--fileCollector.glob=/var/log/nginx/*.log'
+        template: server.yaml

--- a/charts/victoria-logs-collector/values.yaml
+++ b/charts/victoria-logs-collector/values.yaml
@@ -227,6 +227,17 @@ podMonitor:
   # -- Metric relabeling rules
   metricRelabelings: []
 
+# -- List of file-based log collection configurations.
+# Each entry maps directly to a set of positional `-fileCollector.*` flags, preserving
+# the order needed for multiple glob patterns to pair correctly with their extra fields.
+# See https://docs.victoriametrics.com/victorialogs/vlagent/#multiple-glob-patterns-and-ordering
+fileCollector: []
+  # - glob: /var/log/*/*.log
+  #   excludeGlob: /var/log/nginx/*
+  #   extraFields: '{"app":"other"}'
+  # - glob: /var/log/nginx/*.log
+  #   extraFields: '{"app":"nginx"}'
+
 # -- vlagent extra command line arguments.
 extraArgs:
   envflag.enable: true

--- a/charts/victoria-metrics-alert/templates/_helpers.tpl
+++ b/charts/victoria-metrics-alert/templates/_helpers.tpl
@@ -78,33 +78,33 @@
 {{- define "vmalert.subargs" }}
   {{- $args := .args }}
   {{- range $k, $vs := (omit . "args") }}
+    {{- $items := list }}
     {{- range $i, $v := $vs }}
-      {{- with $v }}
-        {{- if not .url -}}
-          {{- fail (printf "`url` is not set for `%s` idx %d" $k $i) -}}
-        {{- end -}}
-        {{- range $vKey, $vValue := . -}}
+      {{- $prefixed := dict }}
+      {{- if $v }}
+        {{- if not $v.url }}
+          {{- fail (printf "`url` is not set for `%s` idx %d" $k $i) }}
+        {{- end }}
+        {{- range $vKey, $vValue := $v }}
           {{- if $vValue }}
-            {{- $key := printf "%s.%s" $k $vKey -}}
-            {{- $param := index $args $key | default list -}}
-            {{- range until (int (sub $i (len $param))) }}
-              {{- $param = append $param "" }}
-            {{- end }}
+            {{- $serialized := $vValue }}
             {{- if kindIs "map" $vValue }}
               {{- $values := list }}
               {{- range $mk, $mvs := $vValue }}
                 {{- $mv := ternary (join "," $mvs | quote) $mvs (kindIs "slice" $mvs) }}
                 {{- $values = append $values (printf "%s:%s" $mk $mv) }}
               {{- end }}
-              {{- $param = append $param (join "^^" $values | squote) }}
-            {{- else -}}
-              {{- $param = append $param $vValue }}
+              {{- $serialized = join "^^" $values | squote }}
             {{- end }}
-            {{- $_ := set $args $key $param -}}
+            {{- $_ := set $prefixed (printf "%s.%s" $k $vKey) $serialized }}
           {{- end }}
-        {{- end -}}
-      {{- end -}}
-    {{- end -}}
+        {{- end }}
+      {{- end }}
+      {{- $items = append $items $prefixed }}
+    {{- end }}
+    {{- range $rk, $rv := (fromYaml (include "vm.args.positional" $items)) }}
+      {{- $_ := set $args $rk $rv }}
+    {{- end }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/helm-charts/issues/2990

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `fileCollector` list to the `victoria-logs-collector` chart to support multiple file-based inputs with ordered positional flags. Also refactors arg generation for `remoteWrite` and `vmalert` for consistent, safer behavior.

- **New Features**
  - Added `fileCollector` array; each entry maps to `-fileCollector.*` flags (`glob`, `excludeGlob`, `extraFields`) with order preserved, gap-filling for missing keys, and validation for required `glob`.
  - Added tests for single/multiple entries and mixed keys; bumped chart to 0.3.5 and updated changelog.

- **Refactors**
  - Switched to `vm.args.positional` for `remoteWrite` and `vmalert` to handle repeated flags and keep ordering; serialize map values as `key:value` joined by `^^`.
  - `remoteWrite.url` is now required; defaults `/insert/native` when path is empty and format is native; headers serialized as `key:value` pairs.

<sup>Written for commit 166ebdb1dfe19ece4f77e68c4bf33e15b94c7603. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/2991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

