### PR TITLE
Updates to vmsingle and vmcluster charts related to vmbackupmanager

### DIFF
--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 - added extraVolumeMounts to vmbackupmanager sidecar container and vmbackupmanager init restore container
 
+## 0.44.2
+
+**Release date:** 16 Jun 2026
+
+![Helm: v3](https://img.shields.io/badge/Helm-v3.14%2B-informational?color=informational&logo=helm&link=https%3A%2F%2Fgithub.com%2Fhelm%2Fhelm%2Freleases%2Ftag%2Fv3.14.0) ![AppVersion: v1.145.0](https://img.shields.io/badge/v1.145.0-success?logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fhelm%2Fvictoria-metrics-cluster%2Fchangelog%2F%23v11450)
+
+- add `nodePort` support for `Service` resources
+
 ## 0.44.1
 
 **Release date:** 13 Jun 2026

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added extraVolumeMounts to vmbackupmanager sidecar container and vmbackupmanager init restore container
 
 ## 0.44.1
 

--- a/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
@@ -76,6 +76,9 @@ spec:
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
             {{- end }}
+            {{- with $app.vmbackupmanager.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         {{- end }}
         {{- end }}
       {{- with ($app.imagePullSecrets | default .Values.global.imagePullSecrets) }}
@@ -219,6 +222,9 @@ spec:
               {{- with .readOnly }}
               readOnly: {{ . }}
               {{- end }}
+            {{- end }}
+            {{- with $app.vmbackupmanager.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- include "vm.license.mount" . | nindent 12 }}
         {{- end }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -1454,9 +1454,8 @@ vmstorage:
       #  subPath: ""
       #  readOnly: true
 
-    #  Extra Volume Mounts for the container
-    extraVolumeMounts:
-      []
+    # --  Extra Volume Mounts for the container
+    extraVolumeMounts: []
       # - name: example
       #   mountPath: /example
   serviceMonitor:

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -1453,6 +1453,12 @@ vmstorage:
       #  mountPath: /etc/credentials
       #  subPath: ""
       #  readOnly: true
+
+    #  Extra Volume Mounts for the container
+    extraVolumeMounts:
+      []
+      # - name: example
+      #   mountPath: /example
   serviceMonitor:
     # -- Enable deployment of Service Monitor for vmstorage component. This is Prometheus operator object
     enabled: false

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next release
 
-- TODO
+- fixed security context issue with vmbackupmanager init recovery container
+- fixed incorrect mount name for persistent storage volume in vmbackupmanager init recovery container
+- added extraVolumeMounts to vmbackupmanager init recovery container
 
 ## 0.40.1
 

--- a/charts/victoria-metrics-single/templates/server.yaml
+++ b/charts/victoria-metrics-single/templates/server.yaml
@@ -84,7 +84,7 @@ spec:
         - name: manager-http
           containerPort: 8300
         volumeMounts:
-        - name: server-volume
+        - name: {{ $storageName }}
           mountPath: {{ $pvc.mountPath }}
           subPath: {{ $pvc.subPath }}
         {{- range $manager.extraSecretMounts }}

--- a/charts/victoria-metrics-single/templates/server.yaml
+++ b/charts/victoria-metrics-single/templates/server.yaml
@@ -65,8 +65,8 @@ spec:
         {{- $_ := set $ctx "appKey" (list "server" "vmbackupmanager") }}
         image: {{ include "vm.image" $ctx }}
         imagePullPolicy: {{ $app.image.pullPolicy }}
-        {{- with $app.podSecurityContext }}
-        securityContext:  {{ toYaml . | nindent 10 }}
+        {{- if $app.securityContext.enabled }}
+        securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.securityContext "helm" .) | nindent 10 }}
         {{- end }}
         args: {{ include "vmbackupmanager.restore.args" $ctx | nindent 12 }}
         {{- with $manager.resources }}
@@ -84,13 +84,16 @@ spec:
         - name: manager-http
           containerPort: 8300
         volumeMounts:
-        - name: vmstorage-volume
+        - name: server-volume
           mountPath: {{ $pvc.mountPath }}
           subPath: {{ $pvc.subPath }}
         {{- range $manager.extraSecretMounts }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
           subPath: {{ .subPath }}
+        {{- end }}
+        {{- with $manager.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- end }}


### PR DESCRIPTION
during onboarding found that it would be useful to be able to mount an extra volume in tje vmbackupmanager sidecar for local filesystem backups.  This was easily done and straight forward.

This chnange would allow a customer to be able to setup a shared pvc in k8's that all vmstorage nodes could use as a backup location.  This shared pvc could use nfs to seperate the backups from the storage environment.

Once i looked at the vmsingle chart, i found that the extraVolumeMount existed in the vmbackupmanager sidecar container however it was not setup in the vmbackupmanager restore container that is created when restore on start is enabled.  

During testing found that the init restore container failed to start due to a misconfigured security context and misnamed storage volume. 

This is in draft so i can have a few folks have a look first.