### PR TITLE
support Service nodePort

### DIFF
--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add `nodePort` support for `Service` resources
 
 ## 0.2.6
 

--- a/charts/victoria-logs-cluster/templates/_helpers.tpl
+++ b/charts/victoria-logs-cluster/templates/_helpers.tpl
@@ -127,6 +127,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -147,6 +150,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- $syslogTCPAddr := index $extraArgs "syslog.listenAddr.tcp" -}}
 {{- $tcpPorts := ternary .syslog.tcp (list (dict "name" "syslog-tcp" "value" $syslogTCPAddr)) (empty $syslogTCPAddr) }}
@@ -183,6 +189,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -203,6 +212,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}

--- a/charts/victoria-logs-cluster/templates/service.yaml
+++ b/charts/victoria-logs-cluster/templates/service.yaml
@@ -54,9 +54,6 @@ spec:
   {{- $portsTpl := printf "%s.ports" $name }}
   {{- with include $portsTpl $app }}
   ports: {{ . | nindent 4 }}
-  {{- if and (eq $type "NodePort") $service.nodePort }}
-  nodePort: {{ $service.nodePort }}
-  {{- end }}
   {{- end }}
   selector: {{ include "vm.selectorLabels" $ctx | nindent 4 }}
 {{- end }}

--- a/charts/victoria-logs-cluster/tests/service_test.yaml
+++ b/charts/victoria-logs-cluster/tests/service_test.yaml
@@ -52,3 +52,33 @@ tests:
             extraServiceLabelName: storageExtraServiceLabelValue
     asserts:
       - matchSnapshot: {}
+  - it: should render nodePort for vlselect service
+    set:
+      vlselect:
+        service:
+          type: NodePort
+          nodePort: 30471
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+        documentIndex: 1
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30471
+        documentIndex: 1
+  - it: should render nodePort for vlinsert service
+    set:
+      vlinsert:
+        service:
+          type: NodePort
+          nodePort: 30481
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+        documentIndex: 0
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30481
+        documentIndex: 0

--- a/charts/victoria-logs-mcp/CHANGELOG.md
+++ b/charts/victoria-logs-mcp/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Update node 1**: due to change in label name pods will be restarted.
 
 - added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
+- add `nodePort` support for `Service` resources
 
 ## 0.1.0
 

--- a/charts/victoria-logs-mcp/templates/service.yaml
+++ b/charts/victoria-logs-mcp/templates/service.yaml
@@ -14,4 +14,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector: {{ include "vm.selectorLabels" $ctx | nindent 4 }}

--- a/charts/victoria-logs-mcp/tests/service_test.yaml
+++ b/charts/victoria-logs-mcp/tests/service_test.yaml
@@ -1,0 +1,22 @@
+suite: service templates test
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - service.yaml
+tests:
+  - it: service should match snapshot
+    asserts:
+      - matchSnapshot: {}
+  - it: should render nodePort for service
+    set:
+      service:
+        type: NodePort
+        nodePort: 30808
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30808

--- a/charts/victoria-logs-mcp/values.yaml
+++ b/charts/victoria-logs-mcp/values.yaml
@@ -73,6 +73,8 @@ service:
   type: ClusterIP
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 8080
+  # -- Service node port
+  nodePort: ""
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add `nodePort` support for `Service` resources
 
 ## 0.2.6
 

--- a/charts/victoria-logs-multilevel/templates/_helpers.tpl
+++ b/charts/victoria-logs-multilevel/templates/_helpers.tpl
@@ -44,6 +44,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -64,6 +67,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}

--- a/charts/victoria-logs-multilevel/tests/service_test.yaml
+++ b/charts/victoria-logs-multilevel/tests/service_test.yaml
@@ -52,3 +52,36 @@ tests:
             extraServiceLabelName: storageExtraServiceLabelValue
     asserts:
       - matchSnapshot: {}
+  - it: should render nodePort for vlselect service
+    set:
+      vlselect:
+        service:
+          type: NodePort
+          nodePort: 30471
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+        documentIndex: 0
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30471
+        documentIndex: 0
+  - it: should render nodePort for vmauth service
+    set:
+      vmauth:
+        enabled: true
+        image:
+          tag: v1.116.0
+        service:
+          type: NodePort
+          nodePort: 30427
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+        documentIndex: 1
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30427
+        documentIndex: 1

--- a/charts/victoria-logs-multilevel/values.yaml
+++ b/charts/victoria-logs-multilevel/values.yaml
@@ -269,6 +269,8 @@ vlselect:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: ""
+    # -- Service node port
+    nodePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -575,6 +577,8 @@ vmauth:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: ""
+    # -- Service node port
+    nodePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add `nodePort` support for `Service` resources
 
 ## 0.42.1
 

--- a/charts/victoria-metrics-alert/templates/alertmanager-service.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-service.yaml
@@ -51,6 +51,9 @@ spec:
       port: {{ $service.servicePort }}
       targetPort: web
       protocol: TCP
+      {{- if $service.nodePort }}
+      nodePort: {{ $service.nodePort }}
+      {{- end }}
   selector: {{ include "vm.selectorLabels" $ctx | nindent 4 }}
 {{- end }}
 {{- if and (eq $mode "statefulSet") (gt (int $app.replicaCount) 1) }}

--- a/charts/victoria-metrics-alert/tests/alert-service_test.yaml
+++ b/charts/victoria-metrics-alert/tests/alert-service_test.yaml
@@ -1,0 +1,23 @@
+suite: alert service templates test
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - alert-service.yaml
+tests:
+  - it: alert service should match snapshot
+    asserts:
+      - matchSnapshot: {}
+  - it: should render nodePort for alert service
+    set:
+      server:
+        service:
+          type: NodePort
+          nodePort: 30880
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30880

--- a/charts/victoria-metrics-alert/tests/alertmanager-service_test.yaml
+++ b/charts/victoria-metrics-alert/tests/alertmanager-service_test.yaml
@@ -1,0 +1,27 @@
+suite: alertmanager service templates test
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - alertmanager-service.yaml
+tests:
+  - it: alertmanager service should match snapshot
+    set:
+      alertmanager:
+        enabled: true
+    asserts:
+      - matchSnapshot: {}
+  - it: should render nodePort for alertmanager service
+    set:
+      alertmanager:
+        enabled: true
+        service:
+          type: NodePort
+          nodePort: 30093
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30093

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -224,7 +224,8 @@ server:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: ""
-    # nodePort: 30000
+    # -- Service node port
+    nodePort: ""
     # -- Service type
     type: ClusterIP
     # -- Service external traffic policy. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -530,7 +531,8 @@ alertmanager:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: 9093
-    # nodePort: 30000
+    # -- Service node port
+    nodePort: ""
     # -- Service type
     type: ClusterIP
     # -- Service external traffic policy. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add `nodePort` support for `Service` resources
 
 ## 0.44.1
 

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: VictoriaMetrics Cluster version - high-performance, cost-effective and scalable TSDB, long-term remote storage for Prometheus
 name: victoria-metrics-cluster
-version: 0.44.1
+version: 0.44.2
 # renovate: image=victoriametrics/vmselect
 appVersion: v1.145.0
 sources:

--- a/charts/victoria-metrics-cluster/templates/_helpers.tpl
+++ b/charts/victoria-metrics-cluster/templates/_helpers.tpl
@@ -179,6 +179,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -204,6 +207,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -266,6 +272,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
   protocol: TCP
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 - port: {{ $service.vmselectPort }}
   targetPort: vmselect
@@ -293,6 +302,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
   protocol: TCP
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}

--- a/charts/victoria-metrics-cluster/tests/service_test.yaml
+++ b/charts/victoria-metrics-cluster/tests/service_test.yaml
@@ -48,3 +48,48 @@ tests:
             extraServiceLabelName: storageExtraServiceLabelValue
     asserts:
       - matchSnapshot: {}
+  - it: should render nodePort for vmselect service
+    set:
+      vmselect:
+        service:
+          type: NodePort
+          nodePort: 30481
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+        documentIndex: 1
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30481
+        documentIndex: 1
+  - it: should render nodePort for vminsert service
+    set:
+      vminsert:
+        service:
+          type: NodePort
+          nodePort: 30480
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+        documentIndex: 0
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30480
+        documentIndex: 0
+  - it: should render nodePort for vmstorage service
+    set:
+      vmstorage:
+        service:
+          type: NodePort
+          nodePort: 30482
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+        documentIndex: 2
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30482
+        documentIndex: 2

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -284,6 +284,8 @@ vmselect:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: ""
+    # -- Service node port
+    nodePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -658,6 +660,8 @@ vminsert:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: ""
+    # -- Service node port
+    nodePort: ""
     # -- Service type
     type: ClusterIP
     # -- Enable UDP port. used if you have `spec.opentsdbListenAddr` specified
@@ -993,6 +997,8 @@ vmauth:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: ""
+    # -- Service node port
+    nodePort: ""
     # -- Service type
     type: ClusterIP
     # -- Enable UDP port. used if you have `spec.opentsdbListenAddr` specified
@@ -1309,6 +1315,8 @@ vmstorage:
     labels: {}
     # -- Service port
     servicePort: ""
+    # -- Service node port
+    nodePort: ""
     # -- Port for accepting connections from vminsert
     vminsertPort: 8400
     # -- Port for accepting connections from vmselect

--- a/charts/victoria-metrics-mcp/CHANGELOG.md
+++ b/charts/victoria-metrics-mcp/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - add ability to override container command.
+- add `nodePort` support for `Service` resources
 
 ## 0.3.0
 

--- a/charts/victoria-metrics-mcp/templates/service.yaml
+++ b/charts/victoria-metrics-mcp/templates/service.yaml
@@ -14,4 +14,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector: {{ include "vm.selectorLabels" $ctx | nindent 4 }}

--- a/charts/victoria-metrics-mcp/tests/service_test.yaml
+++ b/charts/victoria-metrics-mcp/tests/service_test.yaml
@@ -1,0 +1,22 @@
+suite: service templates test
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - service.yaml
+tests:
+  - it: service should match snapshot
+    asserts:
+      - matchSnapshot: {}
+  - it: should render nodePort for service
+    set:
+      service:
+        type: NodePort
+        nodePort: 30808
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30808

--- a/charts/victoria-metrics-mcp/values.yaml
+++ b/charts/victoria-metrics-mcp/values.yaml
@@ -79,6 +79,8 @@ service:
   type: ClusterIP
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 8080
+  # -- Service node port
+  nodePort: ""
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add `nodePort` support for `Service` resources
 
 ## 0.65.1
 

--- a/charts/victoria-metrics-operator/templates/service.yaml
+++ b/charts/victoria-metrics-operator/templates/service.yaml
@@ -47,6 +47,9 @@ spec:
       port: {{ $service.servicePort }}
       targetPort: http
       protocol: TCP
+      {{- if $service.nodePort }}
+      nodePort: {{ $service.nodePort }}
+      {{- end }}
     - name: webhook
       port: {{ $service.webhookPort }}
       targetPort: webhook

--- a/charts/victoria-metrics-operator/tests/service_test.yaml
+++ b/charts/victoria-metrics-operator/tests/service_test.yaml
@@ -1,0 +1,22 @@
+suite: service templates test
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - service.yaml
+tests:
+  - it: service should match snapshot
+    asserts:
+      - matchSnapshot: {}
+  - it: should render nodePort for service
+    set:
+      service:
+        type: NodePort
+        nodePort: 30080
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30080

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -272,6 +272,8 @@ service:
   ipFamilies: []
   # -- Service port
   servicePort: 8080
+  # -- Service node port
+  nodePort: ""
   # -- Service webhook port
   webhookPort: 9443
 

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- add `nodePort` support for `Service` resources
 
 ## 0.2.7
 

--- a/charts/victoria-traces-cluster/templates/_helpers.tpl
+++ b/charts/victoria-traces-cluster/templates/_helpers.tpl
@@ -118,6 +118,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -138,6 +141,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- with .extraArgs.otlpGRPCListenAddr }}
 - name: otlpgrpc-tcp
@@ -164,6 +170,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   protocol: TCP
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}
@@ -184,6 +193,9 @@
   port: {{ ternary ($service.servicePort | default $port) $port (and (.primary | default false) (not (empty $service.servicePort))) }}
   targetPort: {{ ternary $service.targetPort .name (and (.primary | default false) (not (empty $service.targetPort))) }}
   protocol: TCP
+  {{- if and (.primary | default false) $service.nodePort }}
+  nodePort: {{ $service.nodePort }}
+  {{- end }}
 {{- end }}
 {{- range $service.extraPorts }}
 - name: {{ .name }}

--- a/charts/victoria-traces-cluster/tests/service_test.yaml
+++ b/charts/victoria-traces-cluster/tests/service_test.yaml
@@ -52,3 +52,33 @@ tests:
             extraServiceLabelName: storageExtraServiceLabelValue
     asserts:
       - matchSnapshot: {}
+  - it: should render nodePort for vtselect service
+    set:
+      vtselect:
+        service:
+          type: NodePort
+          nodePort: 30471
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+        documentIndex: 1
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30471
+        documentIndex: 1
+  - it: should render nodePort for vtinsert service
+    set:
+      vtinsert:
+        service:
+          type: NodePort
+          nodePort: 30481
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+        documentIndex: 0
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30481
+        documentIndex: 0

--- a/charts/victoria-traces-cluster/values.yaml
+++ b/charts/victoria-traces-cluster/values.yaml
@@ -269,6 +269,8 @@ vtselect:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: ""
+    # -- Service node port
+    nodePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -580,6 +582,8 @@ vtinsert:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: ""
+    # -- Service node port
+    nodePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -859,6 +863,8 @@ vtstorage:
     labels: {}
     # -- Service port
     servicePort: ""
+    # -- Service node port
+    nodePort: ""
     # -- Extra service ports
     extraPorts: []
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details
@@ -1171,6 +1177,8 @@ vmauth:
     loadBalancerSourceRanges: []
     # -- Service port
     servicePort: ""
+    # -- Service node port
+    nodePort: ""
     # -- Service type
     type: ClusterIP
     # -- Health check node port for a service. Check [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for details


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/helm-charts/issues/3000

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Service nodePort support across VictoriaMetrics charts so you can pin specific node ports when service.type is NodePort. Defaults stay the same; nothing changes unless you set nodePort.

- **New Features**
  - Set `ports[].nodePort` on the primary port when `service.type: NodePort` and `service.nodePort` is provided.
  - Added `service.nodePort` values (default "") across logs, metrics, traces, alert (server and alertmanager), operator, and MCP Services; updated CHANGELOGs and bumped `victoria-metrics-cluster` to 0.44.2.
  - Added tests to verify nodePort rendering for each affected chart.

- **Migration**
  - No breaking changes.
  - To use: set `service.type: NodePort` and `service.nodePort` to the desired port in values for the component’s Service.

<sup>Written for commit 18f376b215cb1bbc05a87e860e7e0ff360c24304. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/3001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

