### PR TITLE
Update template.tmpl in order to avoid mistaken installations (adding a forgotten flag)

### DIFF
--- a/hack/docs/template.tmpl
+++ b/hack/docs/template.tmpl
@@ -104,13 +104,13 @@ Test the installation with command:
   - For HTTPS repository
 
     ```console
-    helm install {{ $release }} vm/{{ template "chart.name" . }} -f values.yaml -n NAMESPACE --debug
+    helm install {{ $release }} vm/{{ template "chart.name" . }} -f values.yaml -n NAMESPACE --debug --dry-run
     ```
 
   - For OCI repository
 
     ```console
-    helm install {{ $release }} oci://ghcr.io/victoriametrics/helm-charts/{{ template "chart.name" . }} -f values.yaml -n NAMESPACE --debug
+    helm install {{ $release }} oci://ghcr.io/victoriametrics/helm-charts/{{ template "chart.name" . }} -f values.yaml -n NAMESPACE --debug --dry-run
     ```
 
 Install chart with command:


### PR DESCRIPTION
It was supposed to be there, yet it wasn't there. The dry run option is necessary in order to perform a test install without installing. I faced this blindly luckily in a Minikube. But imagine this in a production machine...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--dry-run` to Helm “Test the installation” commands in `hack/docs/template.tmpl` for both HTTPS and OCI examples to prevent accidental deployments. This lets users safely validate charts before running a real install.

<sup>Written for commit e0af2147090bba2c967335398d5b655f478e262b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/3006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

