### PR TITLE
dependency: update VictoriaTraces version to v0.9.3

### DIFF
--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - add `nodePort` support for `Service` resources
+- bump version of VictoriaTraces components to [v0.9.3](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.9.3)
 
 ## 0.2.7
 

--- a/charts/victoria-traces-cluster/Chart.yaml
+++ b/charts/victoria-traces-cluster/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 type: application
 # renovate: image=victoriametrics/victoria-traces
-appVersion: v0.9.2
+appVersion: v0.9.3
 description: The VictoriaTraces cluster Helm chart deploys VictoriaTraces cluster database in Kubernetes.
 name: victoria-traces-cluster
-version: 0.2.7
+version: 0.2.8
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- bump version of VictoriaTraces components to [v0.9.3](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.9.3)
 
 ## 0.1.8
 

--- a/charts/victoria-traces-single/Chart.yaml
+++ b/charts/victoria-traces-single/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 type: application
 # renovate: image=victoriametrics/victoria-traces
-appVersion: v0.9.2
+appVersion: v0.9.3
 description: The VictoriaTraces single Helm chart deploys VictoriaTraces database in Kubernetes.
 name: victoria-traces-single
-version: 0.1.8
+version: 0.1.9
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4


### PR DESCRIPTION
dependency: update VictoriaTraces version to v0.9.3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump VictoriaTraces to v0.9.3 in the Helm charts. Aligns `victoria-traces-cluster` and `victoria-traces-single` with the latest release to pick up upstream fixes and improvements.

- **Dependencies**
  - Set appVersion to v0.9.3 for both charts (image `victoriametrics/victoria-traces:v0.9.3`).
  - Bump chart versions: `victoria-traces-cluster` to 0.2.8, `victoria-traces-single` to 0.1.9.
  - Update CHANGELOG entries to note the version bump.

<sup>Written for commit fbbe973eedc64940de1ec1d3a2f0fd03e6234986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/helm-charts/pull/3007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

