### PR TITLE
update chart to remove targetPort from values and set container port name to always be http

### DIFF
--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - fix VMPodMonitor relabelling configuration rendering. See [#2917](https://github.com/VictoriaMetrics/helm-charts/issues/2917).
 - add ability to override container command.
-- hard code container port name to http and port number to 8490 to match helm chart service definition.
+- removed potential confusion around targetPort in values by setting the containers port name always to be http and removing targetPort from values.yaml
 
 ## 1.12.12
 

--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - fix VMPodMonitor relabelling configuration rendering. See [#2917](https://github.com/VictoriaMetrics/helm-charts/issues/2917).
 - add ability to override container command.
+- hard code container port name to http and port number to 8490 to match helm chart service definition.
 
 ## 1.12.12
 

--- a/charts/victoria-metrics-anomaly/templates/server.yaml
+++ b/charts/victoria-metrics-anomaly/templates/server.yaml
@@ -56,17 +56,9 @@ spec:
         - name: model
           image: {{ include "vm.image" $ctx }}
           workingDir: {{ .Values.containerWorkingDir }}
-          {{- if or (((.Values.config).monitoring).pull).enabled ((.Values.config).server).port }}
           ports:
-            {{- with (((.Values.config).monitoring).pull).port }}
-            - containerPort: {{ . }}
-              name: metrics
-            {{- end }}
-            {{- with ((.Values.config).server).port }}
-            - containerPort: {{ . }}
+            - containerPort: 8490
               name: http
-            {{- end }}
-          {{- end }}
           {{- with .Values.command }}
           command: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-metrics-anomaly/templates/server.yaml
+++ b/charts/victoria-metrics-anomaly/templates/server.yaml
@@ -57,8 +57,10 @@ spec:
           image: {{ include "vm.image" $ctx }}
           workingDir: {{ .Values.containerWorkingDir }}
           ports:
-            - containerPort: 8490
+            {{- with ((.Values.config).server).port | default 8490  }}
+            - containerPort: {{ . }}
               name: http
+            {{- end }}
           {{- with .Values.command }}
           command: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/victoria-metrics-anomaly/templates/service.yaml
+++ b/charts/victoria-metrics-anomaly/templates/service.yaml
@@ -61,7 +61,7 @@ spec:
     - name: http
       port: {{ $service.servicePort }}
       protocol: TCP
-      targetPort: {{ $service.targetPort }}
+      targetPort: http
       {{- with $service.nodePort }}
       nodePort: {{ . }}
       {{- end }}

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -300,7 +300,6 @@ service:
   loadBalancerSourceRanges: []
   # -- Service port
   servicePort: 8490
-  # -- Target port
   # -- Node port
   # nodePort: 30000
   # -- Service type

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -301,7 +301,6 @@ service:
   # -- Service port
   servicePort: 8490
   # -- Target port
-  targetPort: http
   # -- Node port
   # nodePort: 30000
   # -- Service type


### PR DESCRIPTION
vmanomaly no longer needs the "monitoring" or "server" setting in the config to enable listening on port 8490.   Originally one would need to set either one or the other for the containerPort to be created  in server.yaml.  As the container listens by default it is no longer necessary to create this config, and also harmonize the expected targetport name in the service definition of the values file. 

If a user were to add a monitoring config, instead of a servier / port config, and keep the default targetport name of http the container port name would be set to "metrics" and the service would be targetting a port named "http"

This update resolves this by setting the service to always use targetport http and the pod's container port is always named http.  The targetport value in the values file has also been remvoved.  The service port and node port values still remain.

