### PR TITLE
charts: add runtimeClassName option to pod specs across all charts

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `runtimeClassName` option to the pod spec
 
 ## 0.2.7
 

--- a/charts/victoria-logs-agent/templates/server.yaml
+++ b/charts/victoria-logs-agent/templates/server.yaml
@@ -29,6 +29,9 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-logs-agent/values.yaml
+++ b/charts/victoria-logs-agent/values.yaml
@@ -207,6 +207,8 @@ affinity: {}
 
 # -- Priority class to be assigned to the pod(s)
 priorityClassName: ""
+# -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+runtimeClassName: ""
 
 serviceMonitor:
   # -- Enable deployment of Service Monitor for server component. This is Prometheus operator object

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `runtimeClassName` option to the pod spec
 
 ## 0.2.7
 

--- a/charts/victoria-logs-cluster/templates/vlinsert-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlinsert-server.yaml
@@ -36,6 +36,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-logs-cluster/templates/vlselect-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlselect-server.yaml
@@ -36,6 +36,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-logs-cluster/templates/vlstorage-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlstorage-server.yaml
@@ -34,6 +34,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-logs-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vmauth-server.yaml
@@ -39,6 +39,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- if or (.Values.serviceAccount).name (.Values.serviceAccount).create }}
       serviceAccountName: {{ tpl ((.Values.serviceAccount).name | default $sa) $ctx }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}

--- a/charts/victoria-logs-cluster/values.yaml
+++ b/charts/victoria-logs-cluster/values.yaml
@@ -74,6 +74,8 @@ vlselect:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vlselect component
   fullnameOverride: ""
   # -- Suppress rendering `--storageNode` FQDNs based on `vlstorage.replicaCount` value. If true suppress rendering `--storageNode`, they can be re-defined in extraArgs
@@ -384,6 +386,8 @@ vlinsert:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vlinsert component
   fullnameOverride: ""
   # -- List of HTTP listen addresses
@@ -710,6 +714,8 @@ vlstorage:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vlstorage component
   fullnameOverride:
 
@@ -1001,6 +1007,8 @@ vmauth:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vmauth component
   fullnameOverride: ""
   # -- List of HTTP listen addresses

--- a/charts/victoria-logs-collector/CHANGELOG.md
+++ b/charts/victoria-logs-collector/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `runtimeClassName` option to the pod spec
 
 ## 0.3.6
 

--- a/charts/victoria-logs-collector/templates/server.yaml
+++ b/charts/victoria-logs-collector/templates/server.yaml
@@ -24,6 +24,9 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       serviceAccountName: {{ include "vm.fullname" $ctx }}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}

--- a/charts/victoria-logs-collector/values.yaml
+++ b/charts/victoria-logs-collector/values.yaml
@@ -208,6 +208,8 @@ affinity: {}
 
 # -- Priority class to be assigned to the Pod(s).
 priorityClassName: ""
+# -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+runtimeClassName: ""
 
 podMonitor:
   # -- Enable PodMonitor

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `runtimeClassName` option to the pod spec
 
 ## 0.2.7
 

--- a/charts/victoria-logs-multilevel/templates/vlselect-server.yaml
+++ b/charts/victoria-logs-multilevel/templates/vlselect-server.yaml
@@ -36,6 +36,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-logs-multilevel/templates/vmauth-server.yaml
+++ b/charts/victoria-logs-multilevel/templates/vmauth-server.yaml
@@ -39,6 +39,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- if or (.Values.serviceAccount).name (.Values.serviceAccount).create }}
       serviceAccountName: {{ tpl ((.Values.serviceAccount).name | default $sa) $ctx }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}

--- a/charts/victoria-logs-multilevel/values.yaml
+++ b/charts/victoria-logs-multilevel/values.yaml
@@ -77,6 +77,8 @@ vlselect:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vlselect component
   fullnameOverride: ""
   # -- List of HTTP listen addresses
@@ -386,6 +388,8 @@ vmauth:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vmauth component
   fullnameOverride: ""
   # -- List of HTTP listen addresses

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `runtimeClassName` option to the pod spec
 
 ## 0.13.8
 

--- a/charts/victoria-logs-single/templates/server.yaml
+++ b/charts/victoria-logs-single/templates/server.yaml
@@ -43,6 +43,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.schedulerName }}
       schedulerName: {{ . }}
       {{- end }}

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -72,6 +72,8 @@ server:
   replicaCount: 1
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of server component
   fullnameOverride: ""
   # -- Data retention period. Possible units character: h(ours), d(ays), w(eeks), y(ears), if no unit character specified - month. The minimum retention period is 24h. See these [docs](https://docs.victoriametrics.com/victorialogs/#retention)

--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- added `runtimeClassName` option to the pod spec
 - bump version of VM components to [v1.146.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.146.0)
 
 ## 0.41.2

--- a/charts/victoria-metrics-agent/templates/server.yaml
+++ b/charts/victoria-metrics-agent/templates/server.yaml
@@ -44,6 +44,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.schedulerName }}
       schedulerName: {{ . }}
       {{- end }}

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -358,6 +358,8 @@ configMap: ""
 
 # -- Priority class to be assigned to the pod(s)
 priorityClassName: ""
+# -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+runtimeClassName: ""
 
 # -- Enable the host network
 hostNetwork: false

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- added `runtimeClassName` option to the pod spec
 - bump version of VM components to [v1.146.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.146.0)
 - add `nodePort` support for `Service` resources
 

--- a/charts/victoria-metrics-alert/templates/alert-server.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-server.yaml
@@ -112,6 +112,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-metrics-alert/templates/alertmanager-server.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-server.yaml
@@ -119,6 +119,9 @@ spec:
       {{- if $app.priorityClassName }}
       priorityClassName: {{ $app.priorityClassName | quote }}
       {{- end }}
+      {{- if $app.runtimeClassName }}
+      runtimeClassName: {{ $app.runtimeClassName | quote }}
+      {{- end }}
       {{- with $app.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -334,6 +334,8 @@ server:
 
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
 
   # -- Node tolerations for server scheduling to nodes with taints. Details are [here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
   tolerations: []
@@ -444,6 +446,8 @@ alertmanager:
   nodeSelector: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Resource object. Details are [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   resources: {}
   # -- Node tolerations for server scheduling to nodes with taints. Details are [here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- added `runtimeClassName` option to the pod spec
 - bump version of VM components to [v1.146.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.146.0)
 
 ## 0.34.1

--- a/charts/victoria-metrics-auth/templates/server.yaml
+++ b/charts/victoria-metrics-auth/templates/server.yaml
@@ -36,6 +36,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.schedulerName }}
       schedulerName: {{ . }}
       {{- end }}

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -20,6 +20,8 @@ replicaCount: 1
 
 # -- Name of Priority Class
 priorityClassName: ""
+# -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+runtimeClassName: ""
 
 image:
   # -- Image registry

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- added `runtimeClassName` option to the pod spec
 - bump version of VM components to [v1.146.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.146.0)
 - added extraVolumeMounts to vmbackupmanager sidecar container and vmbackupmanager init restore container
 

--- a/charts/victoria-metrics-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmauth-server.yaml
@@ -37,6 +37,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- if or (.Values.serviceAccount).name (.Values.serviceAccount).create }}
       serviceAccountName: {{ tpl ((.Values.serviceAccount).name | default $sa) $ctx }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}

--- a/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
@@ -37,6 +37,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmselect-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-server.yaml
@@ -44,6 +44,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.schedulerName }}
       schedulerName: {{ . }}
       {{- end }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
@@ -34,6 +34,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.schedulerName }}
       schedulerName: {{ . }}
       {{- end }}

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -84,6 +84,8 @@ vmselect:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vmselect component
   fullnameOverride: ""
   # -- Suppress rendering `--storageNode` FQDNs based on `vmstorage.replicaCount` value. If true suppress rendering `--storageNodes`, they can be re-defined in extraArgs
@@ -464,6 +466,8 @@ vminsert:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vminsert component
   fullnameOverride: ""
   # -- HTTP listen address configuration. See https://docs.victoriametrics.com/helm/victoria-metrics-cluster/#http-listen-address for details.
@@ -810,6 +814,8 @@ vmauth:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vmauth component
   fullnameOverride: ""
   # -- HTTP listen address configuration. See https://docs.victoriametrics.com/helm/victoria-metrics-cluster/#http-listen-address for details.
@@ -1118,6 +1124,8 @@ vmstorage:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vmstorage component
   fullnameOverride:
 

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- added `runtimeClassName` option to the pod spec
 - add `nodePort` support for `Service` resources
 
 ## 0.65.1

--- a/charts/victoria-metrics-operator/templates/server.yaml
+++ b/charts/victoria-metrics-operator/templates/server.yaml
@@ -165,6 +165,9 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.lifecycle }}
       lifecycle: {{ toYaml . | nindent 8 }}

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -316,6 +316,8 @@ strategy:
 
 # -- Name of Priority Class
 priorityClassName: ""
+# -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+runtimeClassName: ""
 
 # -- Array of tolerations object. Spec is [here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
 tolerations: []

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed security context issue with vmbackupmanager init recovery container
 - fixed incorrect mount name for persistent storage volume in vmbackupmanager init recovery container
 - added extraVolumeMounts to vmbackupmanager init recovery container
+- added `runtimeClassName` option to the pod spec
 
 ## 0.40.1
 

--- a/charts/victoria-metrics-single/templates/server.yaml
+++ b/charts/victoria-metrics-single/templates/server.yaml
@@ -40,6 +40,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.schedulerName }}
       schedulerName: {{ . }}
       {{- end }}

--- a/charts/victoria-metrics-single/tests/server_test.yaml
+++ b/charts/victoria-metrics-single/tests/server_test.yaml
@@ -40,3 +40,15 @@ tests:
           path: spec.template.spec.containers[0].command
           value:
             - /custom/bin/victoriametrics
+  - it: should render runtimeClassName
+    set:
+      server:
+        runtimeClassName: gvisor
+    asserts:
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: gvisor
+  - it: should not render runtimeClassName by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.runtimeClassName

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -89,6 +89,8 @@ server:
   replicaCount: 1
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of server component
   fullnameOverride:
   # -- Data retention period. Possible units character: h(ours), d(ays), w(eeks), y(ears), if no unit character specified - month. The minimum retention period is 24h. See these [docs](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention)

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `runtimeClassName` option to the pod spec
 
 ## 0.2.8
 

--- a/charts/victoria-traces-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vmauth-server.yaml
@@ -37,6 +37,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- if or (.Values.serviceAccount).name (.Values.serviceAccount).create }}
       serviceAccountName: {{ tpl ((.Values.serviceAccount).name | default $sa) $ctx }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}

--- a/charts/victoria-traces-cluster/templates/vtinsert-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtinsert-server.yaml
@@ -36,6 +36,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-traces-cluster/templates/vtselect-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtselect-server.yaml
@@ -36,6 +36,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-traces-cluster/templates/vtstorage-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtstorage-server.yaml
@@ -34,6 +34,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/victoria-traces-cluster/values.yaml
+++ b/charts/victoria-traces-cluster/values.yaml
@@ -74,6 +74,8 @@ vtselect:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vtselect component
   fullnameOverride: ""
   # -- Suppress rendering `--storageNode` FQDNs based on `vtstorage.replicaCount` value. If true suppress rendering `--storageNode`, they can be re-defined in extraArgs
@@ -385,6 +387,8 @@ vtinsert:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vtinsert component
   fullnameOverride: ""
   # -- List of HTTP listen addresses
@@ -693,6 +697,8 @@ vtstorage:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vtstorage component
   fullnameOverride:
 
@@ -986,6 +992,8 @@ vmauth:
   lifecycle: {}
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of vmauth component
   fullnameOverride: ""
   # -- List of HTTP listen addresses

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `runtimeClassName` option to the pod spec
 
 ## 0.1.9
 

--- a/charts/victoria-traces-single/templates/server.yaml
+++ b/charts/victoria-traces-single/templates/server.yaml
@@ -43,6 +43,9 @@ spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with $app.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with $app.schedulerName }}
       schedulerName: {{ . }}
       {{- end }}

--- a/charts/victoria-traces-single/values.yaml
+++ b/charts/victoria-traces-single/values.yaml
@@ -72,6 +72,8 @@ server:
   replicaCount: 1
   # -- Name of Priority Class
   priorityClassName: ""
+  # -- Name of the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) used to run the pod, e.g. "gvisor"
+  runtimeClassName: ""
   # -- Overrides the full name of server component
   fullnameOverride: ""
   # -- Data retention period. Possible units character: h(ours), d(ays), w(eeks), y(ears), if no unit character specified - month. The minimum retention period is 24h. See these [docs](https://docs.victoriametrics.com/victoriatraces/#retention)


### PR DESCRIPTION
Adds an optional `server.runtimeClassName` value to the victoria-metrics-single chart, mirroring the existing `priorityClassName` / `schedulerName` pod-spec fields. This lets users run the pod under a specific RuntimeClass (e.g. gvisor, kata) for sandboxed/isolated runtimes.

The field is opt-in and defaults to `""`, so the default render is byte-identical to before.

Validation (local):
- helm unittest: 7 passed (added "should render runtimeClassName" + "should not render by default"; 4 existing snapshots unchanged)
- helm lint -f lint/simple.yaml: 0 failed
- helm template default render: byte-identical to master
- helm template --set server.runtimeClassName=gvisor: field renders under pod spec