### PR TITLE
fix: make sync job a helm pre hook

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - use explicit semver tag for sync job
+- make syncJob a helm hook
 
 ## 0.85.0
 

--- a/charts/victoria-metrics-k8s-stack/templates/sync-job/job.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/sync-job/job.yaml
@@ -3,15 +3,16 @@
 {{- $fullname := include "vm.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- $job := .Values.syncJob }}
-
-{{- $configHash := include (print $.Template.BasePath "/sync-job/config.yaml") . | sha256sum | trunc 8 }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $fullname }}-sync-job-{{ $configHash }}
+  name: {{ $fullname }}-sync-job
   namespace: {{ $ns }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   ttlSecondsAfterFinished: {{ $job.ttlSecondsAfterFinished }}
   backoffLimit: {{ $job.backoffLimit }}


### PR DESCRIPTION
The current implementation is a simple batch job with the config map hash in the name. This causes GitOps systems like argo-cd to always show an OutOfSync error. By making the Job a helm hook this is avoided