### PR TITLE
add useLegacyNaming flag to switch between legacy (current chart naming) and operator naming

### DIFF
--- a/charts/victoria-logs-agent/values.yaml
+++ b/charts/victoria-logs-agent/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vlagent-<release>).
+useLegacyNaming: true
+
 # Important helm-chart settings below, modify them with your own settings
 
 # -- Maximum disk usage per remoteWrite URL. When exceeded, old logs will be deleted.

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added network policy configuration support. See [#2977](https://github.com/VictoriaMetrics/helm-charts/issues/2977)
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v0.2.8
 

--- a/charts/victoria-logs-cluster/_index.md.gotmpl
+++ b/charts/victoria-logs-cluster/_index.md.gotmpl
@@ -181,6 +181,17 @@ vlinsert:
 
 {{ include "chart.uninstallSection" . }}
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vlinsert-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-logs-cluster/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-logs-cluster/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,64 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+tests:
+  - it: vlinsert useLegacyNaming false uses operator-style name
+    templates:
+      - vlinsert-server.yaml
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vlinsert-RELEASE-NAME
+
+  - it: vlinsert useLegacyNaming true preserves legacy naming
+    templates:
+      - vlinsert-server.yaml
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-logs-cluster-vlinsert
+
+  - it: vlselect useLegacyNaming false uses operator-style name
+    templates:
+      - vlselect-server.yaml
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vlselect-RELEASE-NAME
+
+  - it: vlselect useLegacyNaming true preserves legacy naming
+    templates:
+      - vlselect-server.yaml
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-logs-cluster-vlselect
+
+  - it: vlstorage useLegacyNaming false uses operator-style name
+    templates:
+      - vlstorage-server.yaml
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vlstorage-RELEASE-NAME
+
+  - it: vlstorage useLegacyNaming true preserves legacy naming
+    templates:
+      - vlstorage-server.yaml
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-logs-cluster-vlstorage

--- a/charts/victoria-logs-cluster/values.yaml
+++ b/charts/victoria-logs-cluster/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoriaLogs cluster chart.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vlinsert-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []

--- a/charts/victoria-logs-collector/values.yaml
+++ b/charts/victoria-logs-collector/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vlsingle-<release>).
+useLegacyNaming: true
+
 # Important helm-chart settings below, modify them with your own settings.
 
 image:

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added network policy configuration support. See [#2977](https://github.com/VictoriaMetrics/helm-charts/issues/2977)
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v0.2.8
 

--- a/charts/victoria-logs-multilevel/_index.md.gotmpl
+++ b/charts/victoria-logs-multilevel/_index.md.gotmpl
@@ -124,6 +124,17 @@ vmauth:
 
 {{ include "chart.helmDocs" . }}
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vlselect-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-logs-multilevel/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-logs-multilevel/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,52 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+tests:
+  - it: vlselect useLegacyNaming false uses operator-style name
+    templates:
+      - vlselect-server.yaml
+    set:
+      useLegacyNaming: false
+      storageNodes:
+        - vlstorage:9491
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vlselect-RELEASE-NAME
+
+  - it: vlselect useLegacyNaming true preserves legacy naming
+    templates:
+      - vlselect-server.yaml
+    set:
+      useLegacyNaming: true
+      storageNodes:
+        - vlstorage:9491
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-logs-multilevel-vlselect
+
+  - it: vmauth useLegacyNaming false uses operator-style name
+    templates:
+      - vmauth-server.yaml
+    set:
+      useLegacyNaming: false
+      storageNodes:
+        - vlstorage:9491
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmauth-RELEASE-NAME
+
+  - it: vmauth useLegacyNaming true preserves legacy naming
+    templates:
+      - vmauth-server.yaml
+    set:
+      useLegacyNaming: true
+      storageNodes:
+        - vlstorage:9491
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-logs-multilevel-vmauth

--- a/charts/victoria-logs-multilevel/values.yaml
+++ b/charts/victoria-logs-multilevel/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoriaLogs cluster chart.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vlselect-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added network policy configuration support. See [#2977](https://github.com/VictoriaMetrics/helm-charts/issues/2977)
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v0.13.9
 

--- a/charts/victoria-logs-single/_index.md.gotmpl
+++ b/charts/victoria-logs-single/_index.md.gotmpl
@@ -177,6 +177,17 @@ server:
 
 {{ include "chart.uninstallSection" . }}
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vlsingle-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-logs-single/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-logs-single/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,22 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - service.yaml
+tests:
+  - it: useLegacyNaming false uses operator-style name
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vlsingle-RELEASE-NAME
+
+  - it: useLegacyNaming true preserves legacy naming
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-logs-single-server

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoria-logs.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vlsingle-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []

--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v0.45.0
 

--- a/charts/victoria-metrics-agent/_index.md.gotmpl
+++ b/charts/victoria-metrics-agent/_index.md.gotmpl
@@ -249,6 +249,17 @@ http:
     tlsKeyFile: /path/to/tls.key
 ```
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vmagent-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-agent/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-agent/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,26 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - monitor.yaml
+tests:
+  - it: useLegacyNaming false uses operator-style name
+    set:
+      useLegacyNaming: false
+      serviceMonitor:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmagent-RELEASE-NAME
+
+  - it: useLegacyNaming true preserves legacy naming
+    set:
+      useLegacyNaming: true
+      serviceMonitor:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-agent

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoria-metrics-agent.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vmagent-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - bump version of VM components to [v1.147.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.147.0)
 - added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v0.43.0
 

--- a/charts/victoria-metrics-alert/_index.md.gotmpl
+++ b/charts/victoria-metrics-alert/_index.md.gotmpl
@@ -65,6 +65,17 @@ server:
       tlsKeyFile: /path/to/tls.key
 ```
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vmalert-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-alert/tests/alert-useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-alert/tests/alert-useLegacyNaming_test.yaml
@@ -1,0 +1,22 @@
+suite: useLegacyNaming tests (alert)
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - alert-service.yaml
+tests:
+  - it: useLegacyNaming false uses operator-style name
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmalert-RELEASE-NAME
+
+  - it: useLegacyNaming true preserves legacy naming
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-alert-server

--- a/charts/victoria-metrics-alert/tests/alertmanager-useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-alert/tests/alertmanager-useLegacyNaming_test.yaml
@@ -1,0 +1,26 @@
+suite: useLegacyNaming tests (alertmanager)
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - alertmanager-service.yaml
+tests:
+  - it: useLegacyNaming false uses operator-style name
+    set:
+      useLegacyNaming: false
+      alertmanager:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmalertmanager-RELEASE-NAME
+
+  - it: useLegacyNaming true preserves legacy naming
+    set:
+      useLegacyNaming: true
+      alertmanager:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-alert-alertmanager

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoria-metrics-alert.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vmalert-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []

--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- TODO
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v1.12.15
 

--- a/charts/victoria-metrics-anomaly/_index.md.gotmpl
+++ b/charts/victoria-metrics-anomaly/_index.md.gotmpl
@@ -26,6 +26,17 @@ This chart will do the following:
 
 {{ include "chart.uninstallSection" . }}
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vmanomaly-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-anomaly/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-anomaly/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,26 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - service.yaml
+tests:
+  - it: useLegacyNaming false uses operator-style name
+    set:
+      useLegacyNaming: false
+      service:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmanomaly-RELEASE-NAME
+
+  - it: useLegacyNaming true preserves legacy naming
+    set:
+      useLegacyNaming: true
+      service:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-anomaly

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoria-metrics-anomaly.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vmanomaly-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 - bump version of VM components to [v1.147.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.147.0)
 - added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v0.35.0
 

--- a/charts/victoria-metrics-auth/_index.md.gotmpl
+++ b/charts/victoria-metrics-auth/_index.md.gotmpl
@@ -56,6 +56,17 @@ http:
     tlsKeyFile: /path/to/tls.key
 ```
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vmauth-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-auth/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-auth/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,22 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - service.yaml
+tests:
+  - it: useLegacyNaming false uses operator-style name
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmauth-RELEASE-NAME
+
+  - it: useLegacyNaming true preserves legacy naming
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-auth

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoria-metrics-auth.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vmauth-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v0.48.0
 

--- a/charts/victoria-metrics-cluster/_index.md.gotmpl
+++ b/charts/victoria-metrics-cluster/_index.md.gotmpl
@@ -62,6 +62,17 @@ vminsert:
       tlsKeyFile: /path/to/tls.key
 ```
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vminsert-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-cluster/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-cluster/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,64 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+tests:
+  - it: vminsert useLegacyNaming false uses operator-style name
+    templates:
+      - vminsert-server.yaml
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vminsert-RELEASE-NAME
+
+  - it: vminsert useLegacyNaming true preserves legacy naming
+    templates:
+      - vminsert-server.yaml
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-cluster-vminsert
+
+  - it: vmselect useLegacyNaming false uses operator-style name
+    templates:
+      - vmselect-server.yaml
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmselect-RELEASE-NAME
+
+  - it: vmselect useLegacyNaming true preserves legacy naming
+    templates:
+      - vmselect-server.yaml
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-cluster-vmselect
+
+  - it: vmstorage useLegacyNaming false uses operator-style name
+    templates:
+      - vmstorage-server.yaml
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmstorage-RELEASE-NAME
+
+  - it: vmstorage useLegacyNaming true preserves legacy naming
+    templates:
+      - vmstorage-server.yaml
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-cluster-vmstorage

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoria-metrics.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vminsert-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - bump version of VM components to [v1.147.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.147.0)
 - added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v0.33.0
 

--- a/charts/victoria-metrics-gateway/_index.md.gotmpl
+++ b/charts/victoria-metrics-gateway/_index.md.gotmpl
@@ -122,6 +122,17 @@ http:
     tlsKeyFile: /path/to/tls.key
 ```
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vmgateway-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-gateway/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-gateway/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,26 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - service.yaml
+tests:
+  - it: useLegacyNaming false uses operator-style name
+    set:
+      useLegacyNaming: false
+      service:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmgateway-RELEASE-NAME
+
+  - it: useLegacyNaming true preserves legacy naming
+    set:
+      useLegacyNaming: true
+      service:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-gateway

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoria-metrics-gateway.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vmgateway-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -28,6 +28,7 @@
 - bump version of VM components to [v1.147.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.147.0)
 - added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 - added `global.compatibility.openshift.automountServiceSigningCA` (default `auto`) to automount the OpenShift service signing CA (`openshift-service-ca.crt`) into the pod; CA available at `/etc/ssl/certs/openshift-service-ca/service-ca.crt`
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v0.41.0
 

--- a/charts/victoria-metrics-single/_index.md.gotmpl
+++ b/charts/victoria-metrics-single/_index.md.gotmpl
@@ -63,6 +63,17 @@ server:
       tlsKeyFile: /path/to/tls.key
 ```
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vmsingle-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-metrics-single/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-single/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,22 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - service.yaml
+tests:
+  - it: useLegacyNaming false uses operator-style name
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmsingle-RELEASE-NAME
+
+  - it: useLegacyNaming true preserves legacy naming
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-victoria-metrics-single-server

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoria-metrics.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vmsingle-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added network policy configuration support. See [#2977](https://github.com/VictoriaMetrics/helm-charts/issues/2977)
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v0.2.9
 

--- a/charts/victoria-traces-cluster/_index.md.gotmpl
+++ b/charts/victoria-traces-cluster/_index.md.gotmpl
@@ -140,6 +140,17 @@ vtstorage:
 
 {{ include "chart.uninstallSection" . }}
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vtinsert-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-traces-cluster/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-traces-cluster/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,64 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+tests:
+  - it: vtinsert useLegacyNaming false uses operator-style name
+    templates:
+      - vtinsert-server.yaml
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vtinsert-RELEASE-NAME
+
+  - it: vtinsert useLegacyNaming true preserves legacy naming
+    templates:
+      - vtinsert-server.yaml
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-vt-cluster-vtinsert
+
+  - it: vtselect useLegacyNaming false uses operator-style name
+    templates:
+      - vtselect-server.yaml
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vtselect-RELEASE-NAME
+
+  - it: vtselect useLegacyNaming true preserves legacy naming
+    templates:
+      - vtselect-server.yaml
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-vt-cluster-vtselect
+
+  - it: vtstorage useLegacyNaming false uses operator-style name
+    templates:
+      - vtstorage-server.yaml
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vtstorage-RELEASE-NAME
+
+  - it: vtstorage useLegacyNaming true preserves legacy naming
+    templates:
+      - vtstorage-server.yaml
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-vt-cluster-vtstorage

--- a/charts/victoria-traces-cluster/values.yaml
+++ b/charts/victoria-traces-cluster/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoriaTraces cluster chart.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vtinsert-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added network policy configuration support. See [#2977](https://github.com/VictoriaMetrics/helm-charts/issues/2977)
+- added `useLegacyNaming` option. When set to `false`, resource names use the operator-style convention (`<type>-<release>`) instead of the default release-name based naming.
 
 ## v0.1.10
 

--- a/charts/victoria-traces-single/_index.md.gotmpl
+++ b/charts/victoria-traces-single/_index.md.gotmpl
@@ -92,6 +92,17 @@ server:
 
 {{ include "chart.uninstallSection" . }}
 
+## Resource Naming
+
+By default, this chart uses release-name based resource naming for historical reasons and
+backwards compatibility with existing deployments.
+
+> [!WARNING]
+> For new deployments, it is recommended to set `useLegacyNaming: false` to use operator-style
+> names (e.g. `vtsingle-<release>`). This aligns resource names with the
+> [VictoriaMetrics operator](https://docs.victoriametrics.com/operator/) convention and
+> simplifies future migration to operator-managed resources.
+
 ## Parameters
 
 The following tables lists the configurable parameters of the chart and their default values.

--- a/charts/victoria-traces-single/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-traces-single/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,22 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - service.yaml
+tests:
+  - it: useLegacyNaming false uses operator-style name
+    set:
+      useLegacyNaming: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vtsingle-RELEASE-NAME
+
+  - it: useLegacyNaming true preserves legacy naming
+    set:
+      useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-vt-single-server

--- a/charts/victoria-traces-single/values.yaml
+++ b/charts/victoria-traces-single/values.yaml
@@ -1,6 +1,13 @@
 # Default values for victoria-traces.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# -- Use legacy naming convention (release-name based). When false, resource names
+# -- use the same convention as the operator (type-prefixed, e.g. vtsingle-<release>).
+# -- The default (`true`) exists for historical reasons and backwards compatibility with existing deployments.
+# -- For new deployments, setting this to `false` is recommended to match VictoriaMetrics operator naming
+# -- and simplify future migration to operator-managed resources.
+useLegacyNaming: true
 global:
   # -- Image pull secrets, that can be shared across multiple helm charts
   imagePullSecrets: []


### PR DESCRIPTION
added `useLegacyNaming` flag (default: true), which allows to define naming convention for plain k8s resources, that are managed by helm charts that do not contain operator. It allows for new users to have resources with naming convention, which is compatible with operator (`useLegacyNaming: false`)