### PR TITLE
fix: use stable labels on volumeClaimTemplates on victoria-logs-agent

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added `runtimeClassName` option to the pod spec
+- do not merge .Values.persistentVolume.extraLabels with default chart labels. See [#2460](https://github.com/VictoriaMetrics/helm-charts/issues/2460).
 
 ## 0.2.7
 

--- a/charts/victoria-logs-agent/templates/server.yaml
+++ b/charts/victoria-logs-agent/templates/server.yaml
@@ -117,11 +117,11 @@ spec:
       kind: PersistentVolumeClaim
       metadata:
         name: vl-agent-data
-        {{- $_ := set $ctx "extraLabels" $pvc.extraLabels }}
-        labels: {{ include "vm.labels" $ctx | nindent 10 }}
-        {{- $_ := unset $ctx "extraLabels" }}
         {{- with $pvc.annotations  }}
         annotations: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $pvc.extraLabels }}
+        labels: {{ toYaml . | nindent 10 }}
         {{- end }}
       spec:
         {{- with $pvc.accessModes }}


### PR DESCRIPTION
volumeClaimTemplates metadata is immutable after StatefulSet creation. Applying vm.labels there included app.kubernetes.io/version and helm.sh/chart, which change on every chart/app version bump and caused helm upgrade to fail when persistentVolume.enabled is true.

Fixes: https://github.com/VictoriaMetrics/helm-charts/issues/3035