### PR TITLE
sync-job: add possibility of overriding dns configuration and policy

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- sync-job now supports overriding the dnsConfig and dnsPolicy
 
 ## 0.85.6
 

--- a/charts/victoria-metrics-k8s-stack/templates/sync-job/job.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/sync-job/job.yaml
@@ -28,6 +28,13 @@ spec:
       {{- with $job.podSecurityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $job.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if $job.dnsPolicy }}
+      dnsPolicy: {{ $job.dnsPolicy }}
+      {{- end }}
       containers:
         - name: sync-job
           image: "{{ $job.image.repository }}:{{ $job.image.tag }}"

--- a/charts/victoria-metrics-k8s-stack/templates/sync-job/job.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/sync-job/job.yaml
@@ -32,8 +32,8 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if $job.dnsPolicy }}
-      dnsPolicy: {{ $job.dnsPolicy }}
+      {{- with $job.dnsPolicy }}
+      dnsPolicy: {{ . }}
       {{- end }}
       containers:
         - name: sync-job

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -190,6 +190,10 @@ syncJob:
   containerSecurityContext: {}
   # -- Affinity for sync-job Pod scheduling
   affinity: {}
+  # -- Custom dns config for the sync job Pod.
+  dnsConfig: {}
+  # -- Alternative DNS policy for the sync job Pod
+  dnsPolicy: ""
 
 # -- Create default rules for monitoring the cluster
 defaultRules:


### PR DESCRIPTION
As the title says. 

More or less I am facing a couple of connectivity issues when trying to retrieve the yaml files and setting up the dns policy would resolve the problems