### PR TITLE
Fix annotations for victoria-metrics-operator-crds chart

### DIFF
--- a/charts/victoria-metrics-operator-crds/values.yaml
+++ b/charts/victoria-metrics-operator-crds/values.yaml
@@ -1,2 +1,3 @@
 # -- VM operator CRD annotations
-annotations: {}
+crds:
+  annotations: {}


### PR DESCRIPTION
The values file is misleading, the CRDs are actually a subchart so annotations need to specified as `crds.annotations`.

I have not run `helm-docs` as it results in loads of changes, it doesn't seem like it's been run for a while in this repo.