### PR TITLE
support global.extraLabels and global.extraAnnotations in all charts

### DIFF
--- a/charts/victoria-logs-agent/CHANGELOG.md
+++ b/charts/victoria-logs-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.2.8
 

--- a/charts/victoria-logs-agent/Chart.lock
+++ b/charts/victoria-logs-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:56:43.822304803Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:44:40.505058389Z"

--- a/charts/victoria-logs-agent/Chart.lock
+++ b/charts/victoria-logs-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:44:40.505058389Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:41:31.654497184Z"

--- a/charts/victoria-logs-agent/templates/server.yaml
+++ b/charts/victoria-logs-agent/templates/server.yaml
@@ -8,9 +8,11 @@ metadata:
   {{- $_ := set $ctx "extraLabels" .Values.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
-  {{- with .Values.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" .Values.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
 spec:
   selector:
     matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 6 }}
@@ -24,7 +26,11 @@ spec:
       {{- $_ := set $ctx "extraLabels" .Values.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
-      annotations: {{ toYaml .Values.podAnnotations | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" .Values.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
+      {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}

--- a/charts/victoria-logs-agent/values.yaml
+++ b/charts/victoria-logs-agent/values.yaml
@@ -153,6 +153,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, used for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 # -- Extra labels for Pods only
 podLabels: {}

--- a/charts/victoria-logs-cluster/CHANGELOG.md
+++ b/charts/victoria-logs-cluster/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added `runtimeClassName` option to the pod spec
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.2.7
 

--- a/charts/victoria-logs-cluster/Chart.lock
+++ b/charts/victoria-logs-cluster/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.56.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:1a920e4564e72b25a52092429bcea3483aa161c89ae37c4c55c75abb7b6519aa
-generated: "2026-07-01T06:44:43.499173948Z"
+  version: 0.3.15
+digest: sha256:6f9e7a2af007b005697fc15df4e4b083ffb09112f72e45113e399d6b8dd0ed4b
+generated: "2026-07-02T11:41:34.894102772Z"

--- a/charts/victoria-logs-cluster/Chart.lock
+++ b/charts/victoria-logs-cluster/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.56.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:608fe5810a024809817aac7499071250cfd3e0b6711fa6a3c653193f22cc6dfc
-generated: "2026-06-13T04:56:46.752088657Z"
+  version: 0.3.13
+digest: sha256:1a920e4564e72b25a52092429bcea3483aa161c89ae37c4c55c75abb7b6519aa
+generated: "2026-07-01T06:44:43.499173948Z"

--- a/charts/victoria-logs-cluster/templates/vlinsert-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlinsert-server.yaml
@@ -8,9 +8,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -27,9 +29,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
     spec:

--- a/charts/victoria-logs-cluster/templates/vlselect-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlselect-server.yaml
@@ -8,9 +8,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -27,9 +29,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
     spec:

--- a/charts/victoria-logs-cluster/templates/vlstorage-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlstorage-server.yaml
@@ -9,9 +9,11 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -25,9 +27,11 @@ spec:
   podManagementPolicy: {{ $app.podManagementPolicy }}
   template:
     metadata:
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
     spec:

--- a/charts/victoria-logs-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vmauth-server.yaml
@@ -8,9 +8,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -32,6 +34,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/vmauth-config.yaml") . | sha256sum }}
+        {{- with ((.Values.global).extraAnnotations) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}

--- a/charts/victoria-logs-cluster/values.yaml
+++ b/charts/victoria-logs-cluster/values.yaml
@@ -14,6 +14,10 @@ global:
   # -- k8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
   cluster:
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 # -- Print information after deployment
 printNotes: true

--- a/charts/victoria-logs-collector/CHANGELOG.md
+++ b/charts/victoria-logs-collector/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added `runtimeClassName` option to the pod spec
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.3.6
 

--- a/charts/victoria-logs-collector/Chart.lock
+++ b/charts/victoria-logs-collector/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:44:46.904076546Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:41:38.344309954Z"

--- a/charts/victoria-logs-collector/Chart.lock
+++ b/charts/victoria-logs-collector/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:56:49.850710527Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:44:46.904076546Z"

--- a/charts/victoria-logs-collector/templates/server.yaml
+++ b/charts/victoria-logs-collector/templates/server.yaml
@@ -17,9 +17,11 @@ spec:
       {{- $_ := set $ctx "extraLabels" .Values.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
-      {{- with .Values.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" .Values.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}

--- a/charts/victoria-logs-collector/values.yaml
+++ b/charts/victoria-logs-collector/values.yaml
@@ -138,6 +138,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, used for building storage Pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/).
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 # -- Service account is needed to enrich logs with Pod metadata using Kubernetes API.
 serviceAccount:

--- a/charts/victoria-logs-mcp/CHANGELOG.md
+++ b/charts/victoria-logs-mcp/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added `app.kubernetes.io/component` with value from custom `app` label. See [#2785](https://github.com/VictoriaMetrics/helm-charts/issues/2785).
 - add `nodePort` support for `Service` resources
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.1.0
 

--- a/charts/victoria-logs-mcp/Chart.lock
+++ b/charts/victoria-logs-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:44:50.297554091Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:41:41.422731599Z"

--- a/charts/victoria-logs-mcp/Chart.lock
+++ b/charts/victoria-logs-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:56:52.686788774Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:44:50.297554091Z"

--- a/charts/victoria-logs-mcp/templates/deployment.yaml
+++ b/charts/victoria-logs-mcp/templates/deployment.yaml
@@ -17,9 +17,11 @@ spec:
     matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" .Values.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       labels:
         {{- include "vm.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/charts/victoria-logs-multilevel/CHANGELOG.md
+++ b/charts/victoria-logs-multilevel/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added `runtimeClassName` option to the pod spec
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.2.7
 

--- a/charts/victoria-logs-multilevel/Chart.lock
+++ b/charts/victoria-logs-multilevel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:56:55.470496646Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:44:53.080607587Z"

--- a/charts/victoria-logs-multilevel/Chart.lock
+++ b/charts/victoria-logs-multilevel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:44:53.080607587Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:41:44.366353168Z"

--- a/charts/victoria-logs-multilevel/templates/vlselect-server.yaml
+++ b/charts/victoria-logs-multilevel/templates/vlselect-server.yaml
@@ -8,9 +8,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -27,9 +29,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
     spec:

--- a/charts/victoria-logs-multilevel/templates/vmauth-server.yaml
+++ b/charts/victoria-logs-multilevel/templates/vmauth-server.yaml
@@ -8,9 +8,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -32,6 +34,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/vmauth-config.yaml") . | sha256sum }}
+        {{- with ((.Values.global).extraAnnotations) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}

--- a/charts/victoria-logs-multilevel/values.yaml
+++ b/charts/victoria-logs-multilevel/values.yaml
@@ -14,6 +14,10 @@ global:
   # -- k8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
   cluster:
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 # -- Print information after deployment
 printNotes: true

--- a/charts/victoria-logs-single/CHANGELOG.md
+++ b/charts/victoria-logs-single/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added `runtimeClassName` option to the pod spec
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.13.8
 

--- a/charts/victoria-logs-single/Chart.lock
+++ b/charts/victoria-logs-single/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.56.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:608fe5810a024809817aac7499071250cfd3e0b6711fa6a3c653193f22cc6dfc
-generated: "2026-06-13T04:56:58.088676724Z"
+  version: 0.3.13
+digest: sha256:1a920e4564e72b25a52092429bcea3483aa161c89ae37c4c55c75abb7b6519aa
+generated: "2026-07-01T06:44:56.195620482Z"

--- a/charts/victoria-logs-single/Chart.lock
+++ b/charts/victoria-logs-single/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.56.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:1a920e4564e72b25a52092429bcea3483aa161c89ae37c4c55c75abb7b6519aa
-generated: "2026-07-01T06:44:56.195620482Z"
+  version: 0.3.15
+digest: sha256:6f9e7a2af007b005697fc15df4e4b083ffb09112f72e45113e399d6b8dd0ed4b
+generated: "2026-07-02T11:41:47.611121176Z"

--- a/charts/victoria-logs-single/templates/server.yaml
+++ b/charts/victoria-logs-single/templates/server.yaml
@@ -18,9 +18,11 @@ metadata:
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
 spec:
   {{- with $modeOpts.spec }}
   {{- toYaml . | nindent 2 }}
@@ -36,9 +38,11 @@ spec:
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}

--- a/charts/victoria-logs-single/values.yaml
+++ b/charts/victoria-logs-single/values.yaml
@@ -14,6 +14,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 # -- Override chart name
 nameOverride: ""

--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
+- added `global.compatibility.openshift.automountServiceSigningCA` (default `auto`) to automount the OpenShift service signing CA (`openshift-service-ca.crt`) into the pod; CA available at `/etc/ssl/certs/openshift-service-ca/service-ca.crt`
 
 ## 0.42.0
 

--- a/charts/victoria-metrics-agent/CHANGELOG.md
+++ b/charts/victoria-metrics-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.42.0
 

--- a/charts/victoria-metrics-agent/Chart.lock
+++ b/charts/victoria-metrics-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:57:01.366659157Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:44:59.27328871Z"

--- a/charts/victoria-metrics-agent/Chart.lock
+++ b/charts/victoria-metrics-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:44:59.27328871Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:41:51.221637154Z"

--- a/charts/victoria-metrics-agent/templates/server.yaml
+++ b/charts/victoria-metrics-agent/templates/server.yaml
@@ -165,6 +165,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- include "vm.license.mount" . | nindent 12 }}
+            {{- include "vm.openshift.serviceCA.volumeMount" . | nindent 12 }}
         {{- with $app.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -222,6 +223,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- include "vm.license.volume" . | nindent 8 }}
+        {{- include "vm.openshift.serviceCA.volume" . | nindent 8 }}
   {{- if and (eq $mode "statefulSet") $pvc.enabled (not $pvc.existingClaim) }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/charts/victoria-metrics-agent/templates/server.yaml
+++ b/charts/victoria-metrics-agent/templates/server.yaml
@@ -15,9 +15,11 @@ metadata:
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
-  {{- with .Values.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" .Values.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
 spec:
   {{- with $modeOpts.spec }}
   {{- toYaml . | nindent 2 }}
@@ -38,8 +40,9 @@ spec:
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
-      {{- $annotations := merge (dict "checksum/config" (include (print .Template.BasePath "/configmap.yaml") . | sha256sum)) (deepCopy $app.podAnnotations) }}
-      annotations: {{ toYaml $annotations | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" (merge (dict "checksum/config" (include (print .Template.BasePath "/configmap.yaml") . | sha256sum)) (deepCopy $app.podAnnotations)) }}
+      annotations: {{ include "vm.annotations" $ctx | nindent 8 }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}

--- a/charts/victoria-metrics-agent/tests/server_test.yaml
+++ b/charts/victoria-metrics-agent/tests/server_test.yaml
@@ -53,3 +53,39 @@ tests:
             - /custom/bin/vmagent
         template: server.yaml
         documentIndex: 0
+  - it: should apply global.extraLabels to resource metadata and pod template
+    set:
+      remoteWrite:
+        - url: http://vm-insert:8480/insert/0/prometheus
+      global:
+        extraLabels:
+          team: platform
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+        template: server.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+        template: server.yaml
+        documentIndex: 0
+  - it: should apply global.extraAnnotations to resource metadata and pod template
+    set:
+      remoteWrite:
+        - url: http://vm-insert:8480/insert/0/prometheus
+      global:
+        extraAnnotations:
+          owner: platform-team
+    asserts:
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: server.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.template.metadata.annotations.owner
+          value: platform-team
+        template: server.yaml
+        documentIndex: 0

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -14,6 +14,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 # -- Replica count     
 replicaCount: 1

--- a/charts/victoria-metrics-agent/values.yaml
+++ b/charts/victoria-metrics-agent/values.yaml
@@ -11,6 +11,8 @@ global:
   compatibility:
     openshift:
       adaptSecurityContext: "auto"
+      # -- Automount OpenShift service signing CA into the pod
+      automountServiceSigningCA: "auto"
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.

--- a/charts/victoria-metrics-alert/CHANGELOG.md
+++ b/charts/victoria-metrics-alert/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.43.0
 

--- a/charts/victoria-metrics-alert/Chart.lock
+++ b/charts/victoria-metrics-alert/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:57:04.365743764Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:45:02.139903415Z"

--- a/charts/victoria-metrics-alert/Chart.lock
+++ b/charts/victoria-metrics-alert/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:45:02.139903415Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:41:54.244646956Z"

--- a/charts/victoria-metrics-alert/templates/alert-server.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-server.yaml
@@ -17,9 +17,11 @@ metadata:
   name: {{ $fullname }}
   namespace: {{ $ns }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
 spec:
   minReadySeconds: {{ $app.minReadySeconds }}
   replicas: {{ $app.replicaCount }}
@@ -35,7 +37,9 @@ spec:
       {{- $_ := unset $ctx "extraLabels" }}
       {{- $annotations := dict "checksum/config" (include (print .Template.BasePath "/alert-configmap.yaml") . | sha256sum) }}
       {{- $annotations = merge $annotations $app.podAnnotations }}
-      annotations: {{ toYaml $annotations | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $annotations }}
+      annotations: {{ include "vm.annotations" $ctx | nindent 8 }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- if or (.Values.serviceAccount).name (.Values.serviceAccount).create }}
       serviceAccountName: {{ tpl ((.Values.serviceAccount).name | default $sa) $ctx }}

--- a/charts/victoria-metrics-alert/templates/alertmanager-server.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-server.yaml
@@ -32,9 +32,9 @@ spec:
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
-      {{- $annotations := dict "checksum/config" (include (print .Template.BasePath "/alertmanager-configmap.yaml") . | sha256sum) }}
-      {{- $annotations = merge $annotations (deepCopy $app.podAnnotations) }}
-      annotations: {{ toYaml $annotations | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" (merge (dict "checksum/config" (include (print .Template.BasePath "/alertmanager-configmap.yaml") . | sha256sum)) (deepCopy $app.podAnnotations)) }}
+      annotations: {{ include "vm.annotations" $ctx | nindent 8 }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- if or (.Values.serviceAccount).name (.Values.serviceAccount).create }}
       serviceAccountName: {{ tpl ((.Values.serviceAccount).name | default $sa) $ctx }}

--- a/charts/victoria-metrics-alert/tests/__snapshot__/alert-service_test.yaml.snap
+++ b/charts/victoria-metrics-alert/tests/__snapshot__/alert-service_test.yaml.snap
@@ -1,0 +1,26 @@
+alert service should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: server
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-alert
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: victoria-metrics-alert-0.1.1
+      name: RELEASE-NAME-victoria-metrics-alert-server
+      namespace: NAMESPACE
+    spec:
+      clusterIP: None
+      ports:
+        - name: http
+          port: 8880
+          protocol: TCP
+          targetPort: http
+      selector:
+        app: server
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: victoria-metrics-alert
+      type: ClusterIP

--- a/charts/victoria-metrics-alert/tests/__snapshot__/alertmanager-service_test.yaml.snap
+++ b/charts/victoria-metrics-alert/tests/__snapshot__/alertmanager-service_test.yaml.snap
@@ -1,0 +1,25 @@
+alertmanager service should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-alert
+        app.kubernetes.io/version: v0.33.0
+        helm.sh/chart: victoria-metrics-alert-0.1.1
+      name: RELEASE-NAME-victoria-metrics-alert-alertmanager
+      namespace: NAMESPACE
+    spec:
+      ports:
+        - name: web
+          port: 9093
+          protocol: TCP
+          targetPort: web
+      selector:
+        app: alertmanager
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: victoria-metrics-alert
+      type: ClusterIP

--- a/charts/victoria-metrics-alert/values.yaml
+++ b/charts/victoria-metrics-alert/values.yaml
@@ -14,6 +14,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 serviceAccount:
   # -- Specifies whether a service account should be created

--- a/charts/victoria-metrics-anomaly/CHANGELOG.md
+++ b/charts/victoria-metrics-anomaly/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 1.12.14
 

--- a/charts/victoria-metrics-anomaly/Chart.lock
+++ b/charts/victoria-metrics-anomaly/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:57:06.96238236Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:45:05.012982392Z"

--- a/charts/victoria-metrics-anomaly/Chart.lock
+++ b/charts/victoria-metrics-anomaly/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:45:05.012982392Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:41:57.437871677Z"

--- a/charts/victoria-metrics-anomaly/templates/server.yaml
+++ b/charts/victoria-metrics-anomaly/templates/server.yaml
@@ -41,7 +41,11 @@ spec:
       {{- if semverCompare "<1.25.0" $tag }}
       {{- $_ := set $annotations "checksum/config" (include (print .Template.BasePath "/configmap.yaml") . | sha256sum) }}
       {{- end }}
-      annotations: {{ toYaml $annotations | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $annotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
+      {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" .Values.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}

--- a/charts/victoria-metrics-anomaly/values.yaml
+++ b/charts/victoria-metrics-anomaly/values.yaml
@@ -14,6 +14,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 image:
   # -- Victoria Metrics anomaly Docker registry

--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.35.0
 

--- a/charts/victoria-metrics-auth/Chart.lock
+++ b/charts/victoria-metrics-auth/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:45:07.978139199Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:42:00.544614738Z"

--- a/charts/victoria-metrics-auth/Chart.lock
+++ b/charts/victoria-metrics-auth/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:57:09.509633864Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:45:07.978139199Z"

--- a/charts/victoria-metrics-auth/templates/server.yaml
+++ b/charts/victoria-metrics-auth/templates/server.yaml
@@ -13,9 +13,11 @@ metadata:
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
 spec:
   {{- with $modeOpts.spec }}
   {{- toYaml . | nindent 2 }}
@@ -30,8 +32,9 @@ spec:
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
-      {{- $annotations := merge (dict "checksum/config" (include (print .Template.BasePath "/secret.yaml") . | sha256sum)) $app.podAnnotations }}
-      annotations: {{ toYaml $annotations | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" (merge (dict "checksum/config" (include (print .Template.BasePath "/secret.yaml") . | sha256sum)) $app.podAnnotations) }}
+      annotations: {{ include "vm.annotations" $ctx | nindent 8 }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -14,6 +14,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
       
 # -- Number of replicas of vmauth
 replicaCount: 1

--- a/charts/victoria-metrics-cluster/CHANGELOG.md
+++ b/charts/victoria-metrics-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.45.0
 

--- a/charts/victoria-metrics-cluster/Chart.lock
+++ b/charts/victoria-metrics-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:45:10.945258051Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:42:03.497694835Z"

--- a/charts/victoria-metrics-cluster/Chart.lock
+++ b/charts/victoria-metrics-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:57:12.4581192Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:45:10.945258051Z"

--- a/charts/victoria-metrics-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmauth-server.yaml
@@ -8,9 +8,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -27,9 +29,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}

--- a/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
@@ -9,9 +9,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -28,9 +30,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
     spec:

--- a/charts/victoria-metrics-cluster/templates/vmselect-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-server.yaml
@@ -17,9 +17,11 @@ metadata:
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
 spec:
   {{- with $modeOpts.spec }}
   {{- toYaml . | nindent 2 }}
@@ -37,9 +39,11 @@ spec:
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
@@ -9,9 +9,11 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -25,9 +27,11 @@ spec:
   podManagementPolicy: {{ $app.podManagementPolicy }}
   template:
     metadata:
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
     spec:

--- a/charts/victoria-metrics-cluster/tests/vminsert_test.yaml
+++ b/charts/victoria-metrics-cluster/tests/vminsert_test.yaml
@@ -29,3 +29,27 @@ tests:
           path: spec.template.spec.containers[0].command
           value:
             - /custom/bin/vminsert
+  - it: should apply global.extraLabels to resource metadata and pod template
+    set:
+      global:
+        extraLabels:
+          team: platform
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+  - it: should apply global.extraAnnotations to resource metadata and pod template
+    set:
+      global:
+        extraAnnotations:
+          owner: platform-team
+    asserts:
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+      - equal:
+          path: spec.template.metadata.annotations.owner
+          value: platform-team

--- a/charts/victoria-metrics-cluster/values.yaml
+++ b/charts/victoria-metrics-cluster/values.yaml
@@ -17,6 +17,10 @@ global:
   # -- k8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
   cluster:
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 # -- Print information after deployment
 printNotes: true

--- a/charts/victoria-metrics-distributed/CHANGELOG.md
+++ b/charts/victoria-metrics-distributed/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.40.0
 

--- a/charts/victoria-metrics-distributed/Chart.lock
+++ b/charts/victoria-metrics-distributed/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
+  version: 0.3.13
 - name: victoria-metrics-k8s-stack
   repository: oci://ghcr.io/victoriametrics/helm-charts
   version: 0.72.6
-digest: sha256:0974d676dbb2b63976ae6bdce7091cca2c9509a8e6db00d734507d3119d5cbb7
-generated: "2026-06-13T04:57:18.306988126Z"
+digest: sha256:223eb7f2379d64f7e390211095a1b18b8403b0e9a6d00596c96f83137aa8e579
+generated: "2026-07-01T06:45:16.295523431Z"

--- a/charts/victoria-metrics-distributed/Chart.lock
+++ b/charts/victoria-metrics-distributed/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
+  version: 0.3.15
 - name: victoria-metrics-k8s-stack
   repository: oci://ghcr.io/victoriametrics/helm-charts
   version: 0.72.6
-digest: sha256:223eb7f2379d64f7e390211095a1b18b8403b0e9a6d00596c96f83137aa8e579
-generated: "2026-07-01T06:45:16.295523431Z"
+digest: sha256:89166e7351805be3e9a2c151416ace9b47eca42fe70283454e95b08e0a5c2165
+generated: "2026-07-02T11:42:09.616069143Z"

--- a/charts/victoria-metrics-distributed/values.yaml
+++ b/charts/victoria-metrics-distributed/values.yaml
@@ -9,6 +9,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 common:
   vmauth:

--- a/charts/victoria-metrics-gateway/CHANGELOG.md
+++ b/charts/victoria-metrics-gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.33.0
 

--- a/charts/victoria-metrics-gateway/Chart.lock
+++ b/charts/victoria-metrics-gateway/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:45:19.926514262Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:42:13.878068518Z"

--- a/charts/victoria-metrics-gateway/Chart.lock
+++ b/charts/victoria-metrics-gateway/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:57:21.95722959Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:45:19.926514262Z"

--- a/charts/victoria-metrics-gateway/templates/server.yaml
+++ b/charts/victoria-metrics-gateway/templates/server.yaml
@@ -35,9 +35,11 @@ metadata:
   {{- $_ := set $ctx "extraLabels" .Values.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
-  {{- with .Values.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" .Values.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -47,8 +49,9 @@ spec:
       {{- $_ := set $ctx "extraLabels" .Values.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
-      {{- $annotations := merge (dict "checksum/config" (include (print .Template.BasePath "/configmap.yaml") . | sha256sum)) .Values.podAnnotations }}
-      annotations: {{ toYaml $annotations | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" (merge (dict "checksum/config" (include (print .Template.BasePath "/configmap.yaml") . | sha256sum)) .Values.podAnnotations) }}
+      annotations: {{ include "vm.annotations" $ctx | nindent 8 }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- if or (.Values.serviceAccount).name (.Values.serviceAccount).create }}
       serviceAccountName: {{ tpl ((.Values.serviceAccount).name | default $fullname) $ctx }}

--- a/charts/victoria-metrics-gateway/values.yaml
+++ b/charts/victoria-metrics-gateway/values.yaml
@@ -14,6 +14,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 # -- Number of replicas of vmgateway
 replicaCount: 1

--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.85.9
 

--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.10
+  version: 0.3.13
 - name: victoria-metrics-operator
   repository: oci://ghcr.io/victoriametrics/helm-charts
   version: 0.65.1
@@ -14,5 +14,5 @@ dependencies:
 - name: grafana
   repository: oci://ghcr.io/grafana-community/helm-charts
   version: 12.3.3
-digest: sha256:e85b81fcd0fd16119829683f22d85c00c75d3575ee56be1c0f949565d8695b89
-generated: "2026-06-19T09:21:01.378829+03:00"
+digest: sha256:a66a30691dd0b08715e8da1b601c6d685c7706c779b73fd1e9db29d6485c22cf
+generated: "2026-07-01T06:45:25.698535932Z"

--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
+  version: 0.3.15
 - name: victoria-metrics-operator
   repository: oci://ghcr.io/victoriametrics/helm-charts
   version: 0.65.1
@@ -14,5 +14,5 @@ dependencies:
 - name: grafana
   repository: oci://ghcr.io/grafana-community/helm-charts
   version: 12.3.3
-digest: sha256:a66a30691dd0b08715e8da1b601c6d685c7706c779b73fd1e9db29d6485c22cf
-generated: "2026-07-01T06:45:25.698535932Z"
+digest: sha256:617d5c5be6f5b32d166e00e512d79643d3ef48e6bf8c0112143d67d026d75d4d
+generated: "2026-07-02T11:42:20.08089408Z"

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -10,6 +10,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 # -- Override chart name
 nameOverride: ""

--- a/charts/victoria-metrics-mcp/CHANGELOG.md
+++ b/charts/victoria-metrics-mcp/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - add ability to override container command.
 - add `nodePort` support for `Service` resources
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.3.0
 

--- a/charts/victoria-metrics-mcp/Chart.lock
+++ b/charts/victoria-metrics-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:45:30.734220206Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:42:24.756554986Z"

--- a/charts/victoria-metrics-mcp/Chart.lock
+++ b/charts/victoria-metrics-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:57:32.810737374Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:45:30.734220206Z"

--- a/charts/victoria-metrics-mcp/templates/deployment.yaml
+++ b/charts/victoria-metrics-mcp/templates/deployment.yaml
@@ -18,9 +18,11 @@ spec:
     matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" .Values.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       labels:
         {{- include "vm.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/charts/victoria-metrics-operator-crds/CHANGELOG.md
+++ b/charts/victoria-metrics-operator-crds/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `global.extraAnnotations` support for upgrade job pod template
 
 ## 0.12.0
 

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added `runtimeClassName` option to the pod spec
 - add `nodePort` support for `Service` resources
 - added `global.extraLabels` and `global.extraAnnotations`; automatically injects `VM_COMMON_LABELS` and `VM_COMMON_ANNOTATIONS` env vars into the operator so they propagate to CRs
+- removed deprecated `VM_ENABLEDPROMETHEUSCONVERTER_*` env vars; `operator.disable_prometheus_converter: true` now uses `--controller.disableReconcileFor` CLI arg, merging with any user-provided values in `extraArgs` and deduplicating
 
 ## 0.65.1
 

--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - added `runtimeClassName` option to the pod spec
 - add `nodePort` support for `Service` resources
+- added `global.extraLabels` and `global.extraAnnotations`; automatically injects `VM_COMMON_LABELS` and `VM_COMMON_ANNOTATIONS` env vars into the operator so they propagate to CRs
 
 ## 0.65.1
 

--- a/charts/victoria-metrics-operator/Chart.lock
+++ b/charts/victoria-metrics-operator/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
+  version: 0.3.15
 - name: crds
   repository: ""
   version: 0.0.*
-digest: sha256:465b1f26e238fb4ed4130a6d5503912c16b32c4164dbe222af7c60135425d2ba
-generated: "2026-07-01T06:45:35.371437482Z"
+digest: sha256:c311f27ec4bd554cdfb7914593c9d507bae7b59661394ba8a637a8a1ffe68a51
+generated: "2026-07-02T11:42:32.861937155Z"

--- a/charts/victoria-metrics-operator/Chart.lock
+++ b/charts/victoria-metrics-operator/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
+  version: 0.3.13
 - name: crds
   repository: ""
   version: 0.0.*
-digest: sha256:e6ba80db516fb1e6ea47df87dbc1e4a877133fd70608b3b767ba51e34325f639
-generated: "2026-06-13T04:57:37.165413511Z"
+digest: sha256:465b1f26e238fb4ed4130a6d5503912c16b32c4164dbe222af7c60135425d2ba
+generated: "2026-07-01T06:45:35.371437482Z"

--- a/charts/victoria-metrics-operator/charts/crds/templates/job.yaml
+++ b/charts/victoria-metrics-operator/charts/crds/templates/job.yaml
@@ -19,6 +19,9 @@ metadata:
     {{- with $app.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- with ((.Values.global).extraAnnotations) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- $extraLabels := $app.labels | default dict }}
   {{- $_ := set $ctx "extraLabels" $app.labels }}
   {{- $_ := set $extraLabels "app.kubernetes.io/component" "upgrade-crds" }}
@@ -32,9 +35,11 @@ spec:
       {{- with $app.podLabels }}
       labels: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- with (.Values.imagePullSecrets | default (.Values.global).imagePullSecrets) }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}

--- a/charts/victoria-metrics-operator/templates/server.yaml
+++ b/charts/victoria-metrics-operator/templates/server.yaml
@@ -14,9 +14,11 @@ metadata:
   {{- $_ := set $ctx "extraLabels" .Values.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
-  {{- with .Values.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" .Values.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -26,9 +28,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with .Values.annotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" .Values.annotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" .Values.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
@@ -80,6 +84,14 @@ spec:
             - name: VM_CONTAINERREGISTRY
               value: {{ quote . }}
             {{- end -}}
+            {{- with ((.Values.global).extraLabels) }}
+            - name: VM_COMMON_LABELS
+              value: {{ include "vm.keyValue" . | quote }}
+            {{- end }}
+            {{- with ((.Values.global).extraAnnotations) }}
+            - name: VM_COMMON_ANNOTATIONS
+              value: {{ include "vm.keyValue" . | quote }}
+            {{- end }}
             {{- if not (empty (.Values.configReloader).image) }}
             - name: VM_CONFIG_RELOADER_IMAGE
               {{- $_ := set $ctx "appKey" (list "configReloader") }}

--- a/charts/victoria-metrics-operator/templates/server.yaml
+++ b/charts/victoria-metrics-operator/templates/server.yaml
@@ -98,20 +98,7 @@ spec:
               value: {{ include "vm.image" $ctx }}
               {{- $_ := unset $ctx "appKey" }}
             {{- end }}
-            {{- if .Values.operator.disable_prometheus_converter }}
-            - name: VM_ENABLEDPROMETHEUSCONVERTER_PODMONITOR
-              value: "false"
-            - name: VM_ENABLEDPROMETHEUSCONVERTER_SERVICESCRAPE
-              value: "false"
-            - name: VM_ENABLEDPROMETHEUSCONVERTER_PROMETHEUSRULE
-              value: "false"
-            - name: VM_ENABLEDPROMETHEUSCONVERTER_PROBE
-              value: "false"
-            - name: VM_ENABLEDPROMETHEUSCONVERTER_ALERTMANAGERCONFIG
-              value: "false"
-            - name: VM_ENABLEDPROMETHEUSCONVERTER_SCRAPECONFIG
-              value: "false"
-            {{- else if .Values.operator.prometheus_converter_add_argocd_ignore_annotations }}
+            {{- if .Values.operator.prometheus_converter_add_argocd_ignore_annotations }}
             - name: VM_PROMETHEUSCONVERTERADDARGOCDIGNOREANNOTATIONS
               value: "true"
             {{- end }}
@@ -120,6 +107,18 @@ spec:
           {{- with .Values.command }}
           command: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- $extraArgs := deepCopy .Values.extraArgs }}
+          {{- $existing := index $extraArgs "controller.disableReconcileFor" }}
+          {{- $disableFor := ternary (splitList "," (toString $existing)) ($existing | default list) (kindIs "string" $existing) }}
+          {{- if .Values.operator.disable_prometheus_converter }}
+          {{- $disableFor = concat $disableFor (list "PodMonitor" "ServiceMonitor" "PrometheusRule" "Probe" "AlertmanagerConfig" "ScrapeConfig") }}
+          {{- end }}
+          {{- $disableFor = $disableFor | compact | uniq }}
+          {{- if $disableFor }}
+          {{- $_ := set $extraArgs "controller.disableReconcileFor" ($disableFor | join ",") }}
+          {{- else }}
+          {{- $_ := unset $extraArgs "controller.disableReconcileFor" }}
+          {{- end }}
           args:
             - --zap-log-level={{ .Values.logLevel }}
             - --leader-elect
@@ -127,7 +126,7 @@ spec:
             {{- if .Values.admissionWebhooks.enabled }}
             - --webhook.enable=true
             {{- end }}
-            {{- range $key, $value := .Values.extraArgs }}
+            {{- range $key, $value := $extraArgs }}
             {{- if kindIs "slice" $value }}
             {{- range $v := $value }}
             - --{{ $key }}={{ $v }}

--- a/charts/victoria-metrics-operator/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/victoria-metrics-operator/tests/__snapshot__/service_test.yaml.snap
@@ -1,0 +1,26 @@
+service should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: victoria-metrics-operator-0.1.1
+      name: RELEASE-NAME-victoria-metrics-operator
+      namespace: NAMESPACE
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: http
+        - name: webhook
+          port: 9443
+          targetPort: webhook
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: victoria-metrics-operator
+      type: ClusterIP

--- a/charts/victoria-metrics-operator/tests/server_test.yaml
+++ b/charts/victoria-metrics-operator/tests/server_test.yaml
@@ -67,3 +67,29 @@ tests:
       - equal:
           path: spec.template.metadata.annotations.owner
           value: platform-team
+  - it: should add controller.disableReconcileFor arg when disable_prometheus_converter is true
+    set:
+      operator:
+        disable_prometheus_converter: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --controller.disableReconcileFor=PodMonitor,ServiceMonitor,PrometheusRule,Probe,AlertmanagerConfig,ScrapeConfig
+          any: true
+  - it: should merge disable_prometheus_converter with user-provided controller.disableReconcileFor
+    set:
+      operator:
+        disable_prometheus_converter: true
+      extraArgs:
+        controller.disableReconcileFor: "VMCluster,PodMonitor"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --controller.disableReconcileFor=VMCluster,PodMonitor,ServiceMonitor,PrometheusRule,Probe,AlertmanagerConfig,ScrapeConfig
+          any: true
+  - it: should not add controller.disableReconcileFor arg when disable_prometheus_converter is false and extraArgs has no override
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --controller.disableReconcileFor=PodMonitor,ServiceMonitor,PrometheusRule,Probe,AlertmanagerConfig,ScrapeConfig
+          any: true

--- a/charts/victoria-metrics-operator/tests/server_test.yaml
+++ b/charts/victoria-metrics-operator/tests/server_test.yaml
@@ -1,0 +1,69 @@
+suite: server templates test
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - server.yaml
+tests:
+  - it: should inject VM_COMMON_LABELS env var when global.extraLabels is set
+    set:
+      global:
+        extraLabels:
+          team: platform
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VM_COMMON_LABELS
+            value: "team=platform"
+          any: true
+  - it: should inject VM_COMMON_ANNOTATIONS env var when global.extraAnnotations is set
+    set:
+      global:
+        extraAnnotations:
+          owner: platform-team
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VM_COMMON_ANNOTATIONS
+            value: "owner=platform-team"
+          any: true
+  - it: should not inject VM_COMMON_LABELS when global.extraLabels is empty
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VM_COMMON_LABELS
+          any: true
+  - it: should not inject VM_COMMON_ANNOTATIONS when global.extraAnnotations is empty
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VM_COMMON_ANNOTATIONS
+          any: true
+  - it: should apply global.extraLabels to resource metadata and pod template
+    set:
+      global:
+        extraLabels:
+          team: platform
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+  - it: should apply global.extraAnnotations to resource metadata and pod template
+    set:
+      global:
+        extraAnnotations:
+          owner: platform-team
+    asserts:
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+      - equal:
+          path: spec.template.metadata.annotations.owner
+          value: platform-team

--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -11,6 +11,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 # Default values for victoria-metrics.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
+- added `global.compatibility.openshift.automountServiceSigningCA` (default `auto`) to automount the OpenShift service signing CA (`openshift-service-ca.crt`) into the pod; CA available at `/etc/ssl/certs/openshift-service-ca/service-ca.crt`
 
 ## 0.41.0
 

--- a/charts/victoria-metrics-single/CHANGELOG.md
+++ b/charts/victoria-metrics-single/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.41.0
 

--- a/charts/victoria-metrics-single/Chart.lock
+++ b/charts/victoria-metrics-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:57:39.692514729Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:45:38.276133104Z"

--- a/charts/victoria-metrics-single/Chart.lock
+++ b/charts/victoria-metrics-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:45:38.276133104Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:42:36.35437803Z"

--- a/charts/victoria-metrics-single/templates/server.yaml
+++ b/charts/victoria-metrics-single/templates/server.yaml
@@ -219,6 +219,7 @@ spec:
               {{- end }}
             {{- end }}
             {{- include "vm.license.mount" . | nindent 12 }}
+            {{- include "vm.openshift.serviceCA.volumeMount" . | nindent 12 }}
             {{- with $app.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -259,6 +260,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- include "vm.license.mount" . | nindent 12 }}
+            {{- include "vm.openshift.serviceCA.volumeMount" . | nindent 12 }}
         {{- end }}
         {{- with $app.extraContainers }}
         {{- toYaml . | nindent 8 }}
@@ -307,6 +309,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- include "vm.license.volume" . | nindent 8 }}
+        {{- include "vm.openshift.serviceCA.volume" . | nindent 8 }}
   {{- if and (eq $mode "statefulSet") $pvc.enabled (not $pvc.existingClaim) }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/charts/victoria-metrics-single/templates/server.yaml
+++ b/charts/victoria-metrics-single/templates/server.yaml
@@ -15,9 +15,11 @@ metadata:
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
 spec:
   {{- with $modeOpts.spec }}
   {{- toYaml . | nindent 2 }}
@@ -33,9 +35,11 @@ spec:
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}

--- a/charts/victoria-metrics-single/tests/server_test.yaml
+++ b/charts/victoria-metrics-single/tests/server_test.yaml
@@ -52,3 +52,57 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.runtimeClassName
+  - it: should apply global.extraLabels to resource metadata and pod template
+    set:
+      global:
+        extraLabels:
+          team: platform
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+  - it: should apply global.extraAnnotations to resource metadata and pod template
+    set:
+      global:
+        extraAnnotations:
+          owner: platform-team
+    asserts:
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+      - equal:
+          path: spec.template.metadata.annotations.owner
+          value: platform-team
+  - it: should merge global.extraLabels with component extraLabels
+    set:
+      global:
+        extraLabels:
+          global-label: global-value
+      server:
+        extraLabels:
+          component-label: component-value
+    asserts:
+      - equal:
+          path: metadata.labels.global-label
+          value: global-value
+      - equal:
+          path: metadata.labels.component-label
+          value: component-value
+  - it: should merge global.extraAnnotations with component annotations
+    set:
+      global:
+        extraAnnotations:
+          global-annotation: global-value
+      server:
+        annotations:
+          component-annotation: component-value
+    asserts:
+      - equal:
+          path: metadata.annotations.global-annotation
+          value: global-value
+      - equal:
+          path: metadata.annotations.component-annotation
+          value: component-value

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -14,6 +14,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 rbac:
   # -- Enables Role/RoleBinding creation

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -11,6 +11,8 @@ global:
   compatibility:
     openshift:
       adaptSecurityContext: "auto"
+      # -- Automount OpenShift service signing CA into the pod
+      automountServiceSigningCA: "auto"
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added `runtimeClassName` option to the pod spec
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.2.8
 

--- a/charts/victoria-traces-cluster/Chart.lock
+++ b/charts/victoria-traces-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:57:42.40878151Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:45:41.213902295Z"

--- a/charts/victoria-traces-cluster/Chart.lock
+++ b/charts/victoria-traces-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:45:41.213902295Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:42:39.660625645Z"

--- a/charts/victoria-traces-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vmauth-server.yaml
@@ -8,9 +8,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -27,9 +29,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}

--- a/charts/victoria-traces-cluster/templates/vtinsert-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtinsert-server.yaml
@@ -8,9 +8,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -27,9 +29,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
     spec:

--- a/charts/victoria-traces-cluster/templates/vtselect-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtselect-server.yaml
@@ -8,9 +8,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -27,9 +29,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
     spec:

--- a/charts/victoria-traces-cluster/templates/vtstorage-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtstorage-server.yaml
@@ -9,9 +9,11 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
@@ -25,9 +27,11 @@ spec:
   podManagementPolicy: {{ $app.podManagementPolicy }}
   template:
     metadata:
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
     spec:

--- a/charts/victoria-traces-cluster/values.yaml
+++ b/charts/victoria-traces-cluster/values.yaml
@@ -14,6 +14,10 @@ global:
   # -- k8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
   cluster:
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 # -- Print information after deployment
 printNotes: true

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - added `runtimeClassName` option to the pod spec
+- added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
 
 ## 0.1.9
 

--- a/charts/victoria-traces-single/Chart.lock
+++ b/charts/victoria-traces-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.9
-digest: sha256:b6e17eccffc03a752967f3d5af039cdce0456c4d09e553a3a0ec93c56b72f4b6
-generated: "2026-06-13T04:57:45.210427525Z"
+  version: 0.3.13
+digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
+generated: "2026-07-01T06:45:44.00585595Z"

--- a/charts/victoria-traces-single/Chart.lock
+++ b/charts/victoria-traces-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.13
-digest: sha256:f10480b9ad4e72c6f1f96772dd1832c2bfaec9cb70798b46d0c4f930eac71521
-generated: "2026-07-01T06:45:44.00585595Z"
+  version: 0.3.15
+digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
+generated: "2026-07-02T11:42:43.488383901Z"

--- a/charts/victoria-traces-single/templates/server.yaml
+++ b/charts/victoria-traces-single/templates/server.yaml
@@ -18,9 +18,11 @@ metadata:
   {{- $_ := set $ctx "extraLabels" $app.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
   {{- $_ := unset $ctx "extraLabels" }}
-  {{- with $app.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- $_ := set $ctx "extraAnnotations" $app.annotations }}
+  {{- with (include "vm.annotations" $ctx) }}
+  annotations: {{ . | nindent 4 }}
   {{- end }}
+  {{- $_ := unset $ctx "extraAnnotations" }}
 spec:
   {{- with $modeOpts.spec }}
   {{- toYaml . | nindent 2 }}
@@ -36,9 +38,11 @@ spec:
       {{- $_ := set $ctx "extraLabels" $app.podLabels }}
       labels: {{ include "vm.podLabels" $ctx | nindent 8 }}
       {{- $_ := unset $ctx "extraLabels" }}
-      {{- with $app.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      {{- $_ := set $ctx "extraAnnotations" $app.podAnnotations }}
+      {{- with (include "vm.annotations" $ctx) }}
+      annotations: {{ . | nindent 8 }}
       {{- end }}
+      {{- $_ := unset $ctx "extraAnnotations" }}
     spec:
       {{- with $app.priorityClassName }}
       priorityClassName: {{ . }}

--- a/charts/victoria-traces-single/values.yaml
+++ b/charts/victoria-traces-single/values.yaml
@@ -14,6 +14,10 @@ global:
   cluster:
     # -- K8s cluster domain suffix, uses for building storage pods' FQDN. Details are [here](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
     dnsDomain: cluster.local.
+  # -- Labels added to all resources
+  extraLabels: {}
+  # -- Annotations added to all resources
+  extraAnnotations: {}
 
 # -- Override chart name
 nameOverride: vt-single


### PR DESCRIPTION
- updated common chart to use global.extraLabels and global.extraAnnotations in all charts
- use global.extraLabels and global.extraAnnotations for VM_COMMON_LABELS and VM_COMMON_ANNOTATIONS operator variables generation

related issue #3053
fixes #2891