### PR TITLE
VictoriaTraces: update default version to v0.9.4

### DIFF
--- a/charts/victoria-metrics-k8s-stack/tests/vtcluster_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vtcluster_test.yaml
@@ -48,10 +48,10 @@ tests:
     asserts:
       - equal:
           path: spec.clusterVersion
-          value: v0.9.3
+          value: v0.9.4
       - equal:
           path: metadata.labels["app.kubernetes.io/version"]
-          value: v0.9.3
+          value: v0.9.4
 
   - it: custom clusterVersion in values overrides the pinned default
     set:

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -892,7 +892,7 @@ vtsingle:
     port: "10428"
     image:
       # renovate: image=victoriametrics/victoria-traces
-      tag: v0.9.3
+      tag: v0.9.4
     # -- Data retention period. Possible units character: h(ours), d(ays), w(eeks), y(ears), if no unit character specified - month. The minimum retention period is 24h.
     retentionPeriod: "1"
     replicaCount: 1
@@ -969,7 +969,7 @@ vtcluster:
   # -- Full spec for VTCluster CRD. Allowed values described [here](https://docs.victoriametrics.com/operator/api/#vtclusterspec)
   spec:
     # renovate: image=victoriametrics/victoria-traces
-    clusterVersion: v0.9.3
+    clusterVersion: v0.9.4
     vtstorage:
       replicaCount: 2
       storageDataPath: /vt-data

--- a/charts/victoria-traces-cluster/CHANGELOG.md
+++ b/charts/victoria-traces-cluster/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - added `runtimeClassName` option to the pod spec
 - added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
+- bump version of VictoriaTraces components to [v0.9.4](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.9.4)
 
 ## 0.2.8
 

--- a/charts/victoria-traces-cluster/Chart.yaml
+++ b/charts/victoria-traces-cluster/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 type: application
 # renovate: image=victoriametrics/victoria-traces
-appVersion: v0.9.3
+appVersion: v0.9.4
 description: The VictoriaTraces cluster Helm chart deploys VictoriaTraces cluster database in Kubernetes.
 name: victoria-traces-cluster
-version: 0.2.8
+version: 0.2.9
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4

--- a/charts/victoria-traces-single/CHANGELOG.md
+++ b/charts/victoria-traces-single/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - added `runtimeClassName` option to the pod spec
 - added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
+- bump version of VictoriaTraces components to [v0.9.4](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.9.4)
 
 ## 0.1.9
 

--- a/charts/victoria-traces-single/Chart.yaml
+++ b/charts/victoria-traces-single/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 type: application
 # renovate: image=victoriametrics/victoria-traces
-appVersion: v0.9.3
+appVersion: v0.9.4
 description: The VictoriaTraces single Helm chart deploys VictoriaTraces database in Kubernetes.
 name: victoria-traces-single
-version: 0.1.9
+version: 0.1.10
 sources:
   - https://github.com/VictoriaMetrics/helm-charts
 icon: https://avatars.githubusercontent.com/u/43720803?s=200&v=4


### PR DESCRIPTION
Note that this pull request contains 2 files that I didn't modify during previous release, PTAL:
```
        modified:   charts/victoria-metrics-k8s-stack/tests/vtcluster_test.yaml
        modified:   charts/victoria-metrics-k8s-stack/values.yaml
```