### PR TITLE
feat(victoria-metrics-single): add serviceMonitor path parameter

### DIFF
--- a/charts/victoria-metrics-single/templates/monitor.yaml
+++ b/charts/victoria-metrics-single/templates/monitor.yaml
@@ -30,6 +30,16 @@ spec:
     matchLabels: {{ include "vm.commonLabels" $ctx | nindent 6 }} 
   endpoints:
     -
+      {{- with $serviceMonitor.path }}
+      path: {{ . }}
+      {{- else }}
+      {{- $prefix := trimSuffix "/" (trimPrefix "/" (dig "extraArgs" "http.pathPrefix" "" .Values.server)) }}
+      {{- if $prefix }}
+      path: {{ printf "/%s/metrics" $prefix }}
+      {{- else }}
+      path: /metrics
+      {{- end }}
+      {{- end }}
       {{- with $serviceMonitor.targetPort }}
       targetPort: {{ . }}
       {{- else }}

--- a/charts/victoria-metrics-single/values.yaml
+++ b/charts/victoria-metrics-single/values.yaml
@@ -466,6 +466,8 @@ server:
     extraLabels: {}
     # -- Service Monitor annotations
     annotations: {}
+    # -- Service Monitor path
+    path: ""
     # -- Basic auth params for Service Monitor
     basicAuth: {}
     # -- Commented. Prometheus scrape interval for server component


### PR DESCRIPTION
## What changed
Added serviceMonitor path parameter, if .server.extraArgs.http.pathPrefix is set - metrics patch match, otherwise fallback to default /metrics.

## Motivation
Currently if you changed pathPrefix, metrics path also change and scraping will fail - to change metrics path you had to do some relabelings magic to make it work.

This pull request adds path parameter to serviceMonitor and if it is not set at all, it handles all the cases, if user use different http.pathPrefix or not.