### PR TITLE
Fix incorrect default usage for imagePullSecrets fallback.

### DIFF
--- a/charts/victoria-metrics-auth/templates/server.yaml
+++ b/charts/victoria-metrics-auth/templates/server.yaml
@@ -52,7 +52,7 @@ spec:
       {{- if $app.podSecurityContext.enabled }}
       securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.podSecurityContext "helm" .) | nindent 8 }}
       {{- end }}
-      {{- with ($app.imagePullSecrets | default .Values.global.imagePullSecrets) }}
+      {{- with ($app.imagePullSecrets | default (.Values.global).imagePullSecrets) }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with $app.initContainers }}

--- a/charts/victoria-metrics-auth/templates/server.yaml
+++ b/charts/victoria-metrics-auth/templates/server.yaml
@@ -52,7 +52,7 @@ spec:
       {{- if $app.podSecurityContext.enabled }}
       securityContext: {{ include "vm.securityContext" (dict "securityContext" $app.podSecurityContext "helm" .) | nindent 8 }}
       {{- end }}
-      {{- with ($app.imagePullSecrets | default "" (.Values.global).imagePullSecrets) }}
+      {{- with ($app.imagePullSecrets | default .Values.global.imagePullSecrets) }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with $app.initContainers }}


### PR DESCRIPTION
Fix the Helm template logic for imagePullSecrets fallback handling.

The current template uses an invalid default function invocation:

{{- with ($app.imagePullSecrets | default "" (.Values.global).imagePullSecrets) }}

This causes an incorrect argument passing to the default function because the pipeline value is implicitly appended as the last argument.

This change updates the template to:

{{- with ($app.imagePullSecrets | default .Values.global.imagePullSecrets) }}

With this fix, app.imagePullSecrets will correctly take precedence, and global.imagePullSecrets will be used as the fallback value when no application-level value is configured.