### PR TITLE
victoria-metrics-auth: support passing raw configs

### DIFF
--- a/charts/victoria-metrics-auth/CHANGELOG.md
+++ b/charts/victoria-metrics-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `configRaw` for templated vmauth config, allowing reusable backend blocks and maintenance toggles.
 
 ## 0.36.0
 

--- a/charts/victoria-metrics-auth/templates/secret.yaml
+++ b/charts/victoria-metrics-auth/templates/secret.yaml
@@ -13,5 +13,5 @@ metadata:
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
 type: Opaque
 data:
-  auth.yml: |{{ toYaml .Values.config | b64enc | nindent 4 }}
+  auth.yml: |{{- if .Values.configRaw }}{{ tpl .Values.configRaw . | b64enc | nindent 4 }}{{- else }}{{ toYaml .Values.config | b64enc | nindent 4 }}{{- end }}
 {{- end }}

--- a/charts/victoria-metrics-auth/values.yaml
+++ b/charts/victoria-metrics-auth/values.yaml
@@ -18,7 +18,7 @@ global:
   extraLabels: {}
   # -- Annotations added to all resources
   extraAnnotations: {}
-      
+
 # -- Number of replicas of vmauth
 replicaCount: 1
 
@@ -367,6 +367,10 @@ config:
     # - username: "cluster-insert-account-42"
     #    password: "***"
     #    url_prefix: "http://vminsert:8480/insert/42/prometheus"
+
+# -- Raw config file content. Overrides `.Values.config` when set. Supports Helm templating,
+# YAML anchors, and comments.
+configRaw: ""
 
 # -- Annotations for config secret
 configAnnotations: {}


### PR DESCRIPTION
Instead of generating config indirectly via values we should support passing the config directly. This would allow advanced users to reuse repeatable blocks and template configuration