### PR TITLE
Fixes shortcode from "v0.85.0" to "0.85.0"

### DIFF
--- a/charts/victoria-metrics-k8s-stack/_index.md.gotmpl
+++ b/charts/victoria-metrics-k8s-stack/_index.md.gotmpl
@@ -212,7 +212,7 @@ kubelet:
 
 ### Logs storage and collection
 
-This chart supports {{"{{%"}} available_from "v0.85.0" "helm-metrics-k8s-stack" {{"%}}"}} deploying [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/) alongside VictoriaMetrics for logs storage and collection.
+This chart supports {{"{{%"}} available_from "0.85.0" "helm-metrics-k8s-stack" {{"%}}"}} deploying [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/) alongside VictoriaMetrics for logs storage and collection.
 
 #### Logs storage
 
@@ -292,7 +292,7 @@ No additional configuration is needed — the routing is handled transparently. 
 
 ### Traces storage
 
-This chart supports {{"{{%"}} available_from "v0.85.0" "helm-metrics-k8s-stack" {{"%}}"}} deploying [VictoriaTraces](https://docs.victoriametrics.com/victorialogs/) alongside VictoriaMetrics for distributed traces storage.
+This chart supports {{"{{%"}} available_from "0.85.0" "helm-metrics-k8s-stack" {{"%}}"}} deploying [VictoriaTraces](https://docs.victoriametrics.com/victorialogs/) alongside VictoriaMetrics for distributed traces storage.
 
 #### VTSingle (single-node)
 


### PR DESCRIPTION
Fixes shortcode from "v0.85.0" to "0.85.0" which is the correct format (for all changelogs in this repo)

In combination with https://github.com/VictoriaMetrics/vmdocs/pull/249 this fixes two broken links found in the docs:

```
helm/victoria-metrics-k8s-stack/
  [#] helm/victoriametrics-k8s-stack/changelog/#v0850
  [#] helm/victoriametrics-k8s-stack/changelog/#v0850
```