### PR TITLE
victoria-metrics-mcp: fix namespaceSelector to actually target the namespace

### DIFF
--- a/charts/victoria-metrics-mcp/CHANGELOG.md
+++ b/charts/victoria-metrics-mcp/CHANGELOG.md
@@ -3,6 +3,7 @@
 - add ability to override container command.
 - add `nodePort` support for `Service` resources
 - added `global.extraLabels` and `global.extraAnnotations` to apply common labels and annotations to all workload resources and pod templates
+- fix `VMServiceScrape` to target the correct namespace
 
 ## 0.3.0
 

--- a/charts/victoria-metrics-mcp/templates/scrape.yaml
+++ b/charts/victoria-metrics-mcp/templates/scrape.yaml
@@ -15,7 +15,7 @@ spec:
       port: http
   namespaceSelector:
     matchNames:
-      - {{ include "vm.release" $ctx }}
+      - {{ $ns }}
   selector:
     matchLabels: {{ include "vm.commonLabels" $ctx | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
Currently it is set to target the release name, which is incorrect and not what victoria-logs-mcp does. This fixes it to actually use the `$ns` variable defined.