### PR TITLE
fix(victoria-metrics-operator): grant networkpolicies in ClusterRole

### DIFF
--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- TODO
+- added `networkpolicies` permission to the operator ClusterRole. Without it the operator cannot sync its NetworkPolicy informer and stops reconciling every CR, even when no CR sets `.spec.networkPolicy`. See [#3129](https://github.com/VictoriaMetrics/helm-charts/issues/3129).
 
 ## v0.67.0
 

--- a/charts/victoria-metrics-operator/templates/role.yaml
+++ b/charts/victoria-metrics-operator/templates/role.yaml
@@ -158,6 +158,7 @@ rules:
   resources:
   - ingresses
   - ingresses/finalizers
+  - networkpolicies
   verbs:
   - "*"
 {{- if .Values.operator.gateway_support }}


### PR DESCRIPTION
Fixes #3129.

Adds `networkpolicies` to the operator ClusterRole's existing `networking.k8s.io` rule, matching the operator repo's own `config/rbac/role.yaml` at v0.74.0.

Operator v0.74.0 grants itself this permission and the release notes ship it as a BUGFIX, but the chart was never updated, so a chart-installed 0.67.0 operator cannot list or watch NetworkPolicy.

**The breakage is not limited to users of the new `.spec.networkPolicy` field.** Every factory's cleanup path takes the `== nil` branch unconditionally (`vmsingle.go:730`, `vmagent.go:1291`, `vmalert.go:844`, `vmauth.go:687`, `vmalertmanager/alertmanager.go:146`, `vmanomaly/statefulset.go:223`, `vlagent.go:782`, `vlsingle.go:394`, `vtsingle.go:380`) and hands a NetworkPolicy to `finalize.SafeDeleteWithFinalizer`, whose opening `rclient.Get` makes controller-runtime start a NetworkPolicy informer. Without `list`/`watch` that informer never syncs and reconciles park on it — the operator stops reconciling everything while its pod stays `Ready 1/1` with `up=1`, `restartCount 0` and a renewing leader lease. `controller_runtime_reconcile_total` goes flat and `reconcile_errors_total` stays at `0`. See #3129 for the full trace.

Because the informer starts regardless of whether the feature is used, the grant is deliberately **unconditional** rather than gated behind a values flag like `gateway_support`/`vpa_support` — a flag-gated grant would leave the default install broken.

**Verification**

- `helm lint` passes.
- Default values render the rule as `[ingresses, ingresses/finalizers, networkpolicies]` with verbs `["*"]`.
- `--set operator.gateway_support=true --set operator.vpa_support=true` renders unchanged apart from the new resource — the `gateway.networking.k8s.io` and `autoscaling.k8s.io` blocks are untouched.
- `rbac.create=false` behaviour is unchanged.
- Live-confirmed on K3s v1.36.2: granting the operator's ServiceAccount `networkpolicies` restores reconciliation immediately, with no pod restart.

Only `templates/role.yaml` and the chart `CHANGELOG.md` change; `values.yaml` is untouched, so `helm-docs` produces no README diff.
