### PR TITLE
Docs: Add 'docs-check-links' target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ docs-check-links: gen-docs docs-image
 		--rm \
 		--name vmdocs \
 		--platform $(DOCKER_PLATFORM) \
+		$(CONTAINER_USER_OPTION) \
 		-v $(REPODIR)/_index.md:/opt/docs/content/helm/_index.md$(CONTAINER_VOLUME_OPTION_SUFFIX) \
 		$(foreach chart,$(wildcard charts/*), -v $(REPODIR)/$(chart):/opt/docs/content/helm/$(notdir $(chart))$(CONTAINER_VOLUME_OPTION_SUFFIX)) \
 		-v $(REPODIR)/.helm/docs/public:/opt/docs/public$(CONTAINER_VOLUME_OPTION_SUFFIX) \

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,23 @@ docs-debug: gen-docs docs-image
 		$(foreach chart,$(wildcard charts/*), -v ./$(chart):/opt/docs/content/helm/$(basename $(chart))) \
 		vmdocs
 
+docs-check-links: gen-docs docs-image
+	rm -rf $(REPODIR)/.helm/docs/public
+	mkdir -p $(REPODIR)/.helm/docs/public
+	$(CONTAINER_TOOL) run \
+		--rm \
+		--name vmdocs \
+		--platform $(DOCKER_PLATFORM) \
+		-v $(REPODIR)/_index.md:/opt/docs/content/helm/_index.md$(CONTAINER_VOLUME_OPTION_SUFFIX) \
+		$(foreach chart,$(wildcard charts/*), -v $(REPODIR)/$(chart):/opt/docs/content/helm/$(notdir $(chart))$(CONTAINER_VOLUME_OPTION_SUFFIX)) \
+		-v $(REPODIR)/.helm/docs/public:/opt/docs/public$(CONTAINER_VOLUME_OPTION_SUFFIX) \
+		--entrypoint /bin/sh \
+		vmdocs \
+		-c "yarn install && hugo --minify && yarn run check-links"; \
+		status=$$?; \
+		rm -rf $(REPODIR)/.helm/docs/public; \
+		exit $$status
+
 docs-images-to-webp: docs-image
 	$(CONTAINER_TOOL) run \
 		--rm \


### PR DESCRIPTION
We have a `check-links` target in the vmdocs repository. This is a good start but it only detects broken links after changes in docs are merged into master in this repository.

It would be nice to have a way to check the documentation in this repository (before creating a PR for instance). This PR introduces a `docs-check-links` target to Makefile. This lets us see if we have any new broken links in the current branch/PR before merging into main.

We've already implemented this on VictoriaMetrics here: https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11121 and I'm trying to add this check to every repository that contributes to vmdocs and ultimately gets published. 

Right now vmdocs is clean, so checking out this branch and running `make docs-check-links` should give 0 broken links:

```
$ linkinator .
→ crawling .
✓ Successfully scanned 627 links in 29.101 seconds.
```