### PR TITLE
Docs: Add SEO descriptions for individual pages

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,6 +1,7 @@
 ---
 weight: 99
 title: Requirements
+description: "Helm chart requirements and prerequisites."
 menu:
   docs:
     weight: 99

--- a/_index.md
+++ b/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 0
 title: Helm Charts
+description: "All VictoriaMetrics Helm charts. Add repo, install, and upgrade."
 menu:
   docs:
     weight: 35

--- a/charts/victoria-logs-agent/_changelog.md
+++ b/charts/victoria-logs-agent/_changelog.md
@@ -1,4 +1,6 @@
+---
 title: CHANGELOG
+description: "Release history for the VictoriaLogs Agent Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-logs-agent/_index.md.gotmpl
+++ b/charts/victoria-logs-agent/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: VictoriaLogs Agent
+description: "Deploy vlagent on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-logs-cluster/_changelog.md
+++ b/charts/victoria-logs-cluster/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Changelog for VictoriaLogs Cluster."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-logs-cluster/_index.md.gotmpl
+++ b/charts/victoria-logs-cluster/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: VictoriaLogs Cluster
+description: "Deploy clustered VictoriaLogs on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-logs-collector/_changelog.md
+++ b/charts/victoria-logs-collector/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaLogs Collector Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-logs-collector/_index.md.gotmpl
+++ b/charts/victoria-logs-collector/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: VictoriaLogs Collector
+description: "Collect logs from Kubernetes containers to VictoriaLogs."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-logs-mcp/_index.md.gotmpl
+++ b/charts/victoria-logs-mcp/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 17
 title: VictoriaLogs MCP
+description: "Deploy the VictoriaLogs MCP server on Kubernetes with Helm."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-logs-multilevel/_changelog.md
+++ b/charts/victoria-logs-multilevel/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Changelog for VictoriaLogs Multilevel."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-logs-multilevel/_index.md.gotmpl
+++ b/charts/victoria-logs-multilevel/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: VictoriaLogs Multilevel
+description: "Multi-level read for multiple storage groups."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-logs-single/_changelog.md
+++ b/charts/victoria-logs-single/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Changelog for VictoriaLogs Single."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-logs-single/_index.md.gotmpl
+++ b/charts/victoria-logs-single/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: VictoriaLogs Single
+description: "Deploy single-node VictoriaLogs on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-agent/_changelog.md
+++ b/charts/victoria-metrics-agent/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics Agent Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-agent/_index.md.gotmpl
+++ b/charts/victoria-metrics-agent/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 5
 title: VictoriaMetrics Agent
+description: "Deploy vmagent on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-alert/_changelog.md
+++ b/charts/victoria-metrics-alert/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics Alert Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-alert/_index.md.gotmpl
+++ b/charts/victoria-metrics-alert/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 6
 title: VictoriaMetrics Alert
+description: "Deploy vmalert on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-anomaly/_changelog.md
+++ b/charts/victoria-metrics-anomaly/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics Anomaly Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-anomaly/_index.md.gotmpl
+++ b/charts/victoria-metrics-anomaly/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 7
 title: VictoriaMetrics Anomaly
+description: "Deploy vmanomaly on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-auth/_changelog.md
+++ b/charts/victoria-metrics-auth/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics Auth Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-auth/_index.md.gotmpl
+++ b/charts/victoria-metrics-auth/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 8
 title: VictoriaMetrics Auth
+description: "Deploy vmauth on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-cluster/_changelog.md
+++ b/charts/victoria-metrics-cluster/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics Cluster Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-cluster/_index.md.gotmpl
+++ b/charts/victoria-metrics-cluster/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 4
 title: VictoriaMetrics Cluster
+description: "Deploy cluster version on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-common/_changelog.md
+++ b/charts/victoria-metrics-common/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics Common Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-common/_index.md.gotmpl
+++ b/charts/victoria-metrics-common/_index.md.gotmpl
@@ -1,5 +1,6 @@
 ---
 title: VictoriaMetrics Common
+description: "Shared helpers and templates used by VictoriaMetrics Helm charts."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-distributed/_changelog.md
+++ b/charts/victoria-metrics-distributed/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics Distributed Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-distributed/_index.md.gotmpl
+++ b/charts/victoria-metrics-distributed/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 10
 title: VictoriaMetrics Distributed
+description: "Deploy distributed VictoriaMetrics components on Kubernetes with Helm."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-gateway/_changelog.md
+++ b/charts/victoria-metrics-gateway/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics Gateway Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-gateway/_index.md.gotmpl
+++ b/charts/victoria-metrics-gateway/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 11
 title: VictoriaMetrics Gateway
+description: "Deploy vmgateway on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-k8s-stack/_changelog.md
+++ b/charts/victoria-metrics-k8s-stack/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics K8s Stack Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-k8s-stack/_index.md.gotmpl
+++ b/charts/victoria-metrics-k8s-stack/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 12
 title: VictoriaMetrics K8s Stack
+description: "Full Kubernetes monitoring stack with Operator, Grafana dashboards, ServiceScrapes, and VMRules."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-mcp/_index.md.gotmpl
+++ b/charts/victoria-metrics-mcp/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 16
 title: VictoriaMetrics MCP
+description: "Deploy the MCP server for AI assistant integration."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-operator-crds/_changelog.md
+++ b/charts/victoria-metrics-operator-crds/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics Operator CRDs Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-operator-crds/_index.md.gotmpl
+++ b/charts/victoria-metrics-operator-crds/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 14
 title: VictoriaMetrics Operator CRDs
+description: "Install Operator CRDs without the full Operator."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-operator/_changelog.md
+++ b/charts/victoria-metrics-operator/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics Operator Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-operator/_index.md.gotmpl
+++ b/charts/victoria-metrics-operator/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 13
 title: VictoriaMetrics Operator
+description: "Deploy the Operator itself on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-metrics-single/_changelog.md
+++ b/charts/victoria-metrics-single/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaMetrics Single Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-metrics-single/_index.md.gotmpl
+++ b/charts/victoria-metrics-single/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 3
 title: VictoriaMetrics Single
+description: "Deploy single-node VictoriaMetrics on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-traces-cluster/_changelog.md
+++ b/charts/victoria-traces-cluster/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaTraces Cluster Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-traces-cluster/_index.md.gotmpl
+++ b/charts/victoria-traces-cluster/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: VictoriaTraces Cluster
+description: "Deploy clustered VictoriaTraces on Kubernetes."
 menu:
   docs:
     parent: helm

--- a/charts/victoria-traces-single/_changelog.md
+++ b/charts/victoria-traces-single/_changelog.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: CHANGELOG
+description: "Release history for the VictoriaTraces Single Helm chart."
 menu:
   docs:
     weight: 1

--- a/charts/victoria-traces-single/_index.md.gotmpl
+++ b/charts/victoria-traces-single/_index.md.gotmpl
@@ -1,6 +1,7 @@
 ---
 weight: 15
 title: VictoriaTraces Single
+description: "Deploy single-node VictoriaTraces on Kubernetes."
 menu:
   docs:
     parent: helm


### PR DESCRIPTION

This PR add meta descriptions to every page in the docs in this repository. Right now, we have one general meta description for every page. This PR adds page-specific descriptions.

Meta descriptions are not likely to improve rankings on search engines but can improve CTRs. They can also be used to keep LLMs.txt updated as new pages are added (by adding an automation later).

The descriptions were taken from LLMs.txt, so they were already reviewed in https://github.com/VictoriaMetrics/vmdocs/pull/251
I only tweaked those that needed trimming to fit into the 160 SEO character limit. We also revised them with our SEO specialist (Jonathan). So I think it's a good staring point.

I'm going to open a PR for every repository that contributes to the docs and add descriptions so eventually every page in the docs has a dedicated meta descriptions.
