### PR TITLE
chore: add renovate config for helm testing images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+# renovate: image=alpine/helm
 HELM_IMAGE = alpine/helm:4.2.3
 HELM_DOCS_IMAGE = local/helm-docs:v1.14.2
+# renovate: image=quay.io/helmpack/chart-testing
 CT_IMAGE = quay.io/helmpack/chart-testing:v3.14.0
 HELM?=helm-docker
 CT?=ct-docker

--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,14 @@
         "# renovate: image=(?<depName>[^\\s]+)\\n\\s+- \"(?<currentValue>v[^\"]+)\""
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Makefile$/"],
+      "matchStrings": [
+        "# renovate: image=(?<depName>[^\\s]+)\\n(?:HELM_IMAGE|CT_IMAGE) = [^:]+:(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [
@@ -74,6 +82,10 @@
     {
       "description": "Only track plain vX.Y.Z releases, exclude enterprise/scratch variants",
       "matchManagers": ["custom.regex"],
+      "matchFileNames": [
+        "charts/**/Chart.yaml",
+        ".github/workflows/run-testing.yaml"
+      ],
       "allowedVersions": "/^v[0-9]+\\.[0-9]+\\.[0-9]+$/"
     },
     {


### PR DESCRIPTION
Chart test image bump seems necessary for https://github.com/VictoriaMetrics/helm-charts/pull/3176