### PR TITLE
ci: update tested k8s version to the latest supported set

### DIFF
--- a/.github/workflows/run-testing.yaml
+++ b/.github/workflows/run-testing.yaml
@@ -42,8 +42,9 @@ jobs:
         k8s_version:
           # renovate: image=kindest/node
           - "v1.37.0"
-          - "v1.34.3"
-          - "v1.33.7"
+          - "v1.36.4"
+          - "v1.35.8"
+          - "v1.34.11"
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
Followup for #3176