### PR TITLE
updated common dependency in all charts to 0.4.0

### DIFF
--- a/charts/victoria-logs-agent/Chart.lock
+++ b/charts/victoria-logs-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:41:31.654497184Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:49:52.622397816Z"

--- a/charts/victoria-logs-agent/Chart.yaml
+++ b/charts/victoria-logs-agent/Chart.yaml
@@ -31,5 +31,5 @@ annotations:
       url: https://docs.victoriametrics.com/victorialogs/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-agent/templates/server.yaml
+++ b/charts/victoria-logs-agent/templates/server.yaml
@@ -1,9 +1,9 @@
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vlagent" }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "vm.fullname" $ctx }}
+  name: {{ include "vm.plain.fullname" $ctx }}
   namespace: {{ include "vm.namespace" $ctx }}
   {{- $_ := set $ctx "extraLabels" .Values.extraLabels }}
   labels: {{ include "vm.labels" $ctx | nindent 4 }}
@@ -16,7 +16,7 @@ metadata:
 spec:
   selector:
     matchLabels: {{ include "vm.selectorLabels" $ctx | nindent 6 }}
-  serviceName: {{ include "vm.fullname" $ctx }}
+  serviceName: {{ include "vm.plain.fullname" $ctx }}
   {{- $hpa := .Values.horizontalPodAutoscaling | default .Values.horizontalPodAutoscaler }}
   {{- if not $hpa.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/victoria-logs-agent/templates/service.yaml
+++ b/charts/victoria-logs-agent/templates/service.yaml
@@ -1,13 +1,13 @@
 {{- $service := .Values.service }}
 {{- if $service.enabled -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vlagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "vm.fullname" $ctx }}
+  name: {{ $fullname }}
   namespace: {{ include "vm.namespace" $ctx }}
   {{- with $service.annotations }}
   annotations: {{ toYaml . | nindent 4}}

--- a/charts/victoria-logs-agent/templates/vpa.yaml
+++ b/charts/victoria-logs-agent/templates/vpa.yaml
@@ -1,6 +1,6 @@
 {{- $vpa := .Values.verticalPodAutoscaling | default .Values.verticalPodAutoscaler }}
 {{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") $vpa.enabled }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vlagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: autoscaling.k8s.io/v1

--- a/charts/victoria-logs-agent/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-logs-agent/tests/useLegacyNaming_test.yaml
@@ -22,21 +22,21 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-victoria-logs-agent
         template: service.yaml
-  - it: "resource names, useLegacyNaming=false (currently a no-op on this chart -- server.yaml uses vm.fullname directly, not useLegacyNaming-aware; service.yaml's vm.plain.fullname has no appKey/kindOverride so it also falls back to the legacy name)"
+  - it: "resource names, useLegacyNaming=false"
     set:
       useLegacyNaming: false
     asserts:
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-victoria-logs-agent
+          value: vlagent-RELEASE-NAME
         documentSelector:
           path: metadata.name
-          value: RELEASE-NAME-victoria-logs-agent
+          value: vlagent-RELEASE-NAME
         template: server.yaml
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-victoria-logs-agent
+          value: vlagent-RELEASE-NAME
         documentSelector:
           path: metadata.name
-          value: RELEASE-NAME-victoria-logs-agent
+          value: vlagent-RELEASE-NAME
         template: service.yaml

--- a/charts/victoria-logs-cluster/Chart.lock
+++ b/charts/victoria-logs-cluster/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.58.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.16
-digest: sha256:24d1b12d07b71fbe87eaa5dd1a1f2f762bc767d1e32455f632e8c8931150c287
-generated: "2026-08-27T06:03:35.540938293Z"
+  version: 0.4.2
+digest: sha256:abeeaa42451d54b8417c1ebab589fb472b86f715ecdc67341a16a19195614684
+generated: "2026-08-31T10:49:55.766385672Z"

--- a/charts/victoria-logs-cluster/Chart.yaml
+++ b/charts/victoria-logs-cluster/Chart.yaml
@@ -36,5 +36,5 @@ dependencies:
     repository: https://helm.vector.dev
     condition: vector.enabled
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-cluster/templates/serviceaccount.yaml
+++ b/charts/victoria-logs-cluster/templates/serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- $sa := .Values.serviceAccount }}
 {{- if $sa.create }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vlcluster" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-logs-cluster/templates/vlinsert-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlinsert-server.yaml
@@ -3,7 +3,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vlinsert" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vlcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/victoria-logs-cluster/templates/vlselect-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlselect-server.yaml
@@ -3,7 +3,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vlselect" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vlcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/victoria-logs-cluster/templates/vlstorage-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vlstorage-server.yaml
@@ -4,7 +4,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vlstorage" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vlcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/charts/victoria-logs-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-logs-cluster/templates/vmauth-server.yaml
@@ -3,7 +3,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vmauth" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vlcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/victoria-logs-cluster/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-logs-cluster/tests/useLegacyNaming_test.yaml
@@ -520,7 +520,7 @@ tests:
         template: vlinsert-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-victoria-logs-cluster
+          value: vlcluster-RELEASE-NAME
         template: vlinsert-server.yaml
       - equal:
           path: metadata.name
@@ -531,7 +531,7 @@ tests:
         template: vlselect-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-victoria-logs-cluster
+          value: vlcluster-RELEASE-NAME
         template: vlselect-server.yaml
       - equal:
           path: metadata.name
@@ -542,7 +542,7 @@ tests:
         template: vlstorage-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-victoria-logs-cluster
+          value: vlcluster-RELEASE-NAME
         template: vlstorage-server.yaml
       - equal:
           path: metadata.name
@@ -560,5 +560,5 @@ tests:
         template: vmauth-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-victoria-logs-cluster
+          value: vlcluster-RELEASE-NAME
         template: vmauth-server.yaml

--- a/charts/victoria-logs-collector/Chart.lock
+++ b/charts/victoria-logs-collector/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:41:38.344309954Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:49:59.134789941Z"

--- a/charts/victoria-logs-collector/Chart.yaml
+++ b/charts/victoria-logs-collector/Chart.yaml
@@ -31,5 +31,5 @@ annotations:
       url: https://docs.victoriametrics.com/victorialogs/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-mcp/Chart.lock
+++ b/charts/victoria-logs-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:41:41.422731599Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:02.467492144Z"

--- a/charts/victoria-logs-mcp/Chart.yaml
+++ b/charts/victoria-logs-mcp/Chart.yaml
@@ -28,5 +28,5 @@ annotations:
       url: https://docs.victoriametrics.com/helm/victoria-logs-mcp/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-multilevel/Chart.lock
+++ b/charts/victoria-logs-multilevel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:41:44.366353168Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:05.284628484Z"

--- a/charts/victoria-logs-multilevel/Chart.yaml
+++ b/charts/victoria-logs-multilevel/Chart.yaml
@@ -32,5 +32,5 @@ annotations:
       url: https://docs.victoriametrics.com/victorialogs/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-multilevel/templates/serviceaccount.yaml
+++ b/charts/victoria-logs-multilevel/templates/serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- $sa := .Values.serviceAccount }}
 {{- if $sa.create }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vlmultilevel" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-logs-multilevel/templates/vlselect-server.yaml
+++ b/charts/victoria-logs-multilevel/templates/vlselect-server.yaml
@@ -3,7 +3,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vlselect" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vlmultilevel") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/victoria-logs-multilevel/templates/vmauth-server.yaml
+++ b/charts/victoria-logs-multilevel/templates/vmauth-server.yaml
@@ -3,7 +3,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vmauth" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vlmultilevel") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/victoria-logs-multilevel/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-logs-multilevel/tests/useLegacyNaming_test.yaml
@@ -285,7 +285,7 @@ tests:
         template: vlselect-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-victoria-logs-multilevel
+          value: vlmultilevel-RELEASE-NAME
         template: vlselect-server.yaml
       - equal:
           path: metadata.name
@@ -303,5 +303,5 @@ tests:
         template: vmauth-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-victoria-logs-multilevel
+          value: vlmultilevel-RELEASE-NAME
         template: vmauth-server.yaml

--- a/charts/victoria-logs-single/Chart.lock
+++ b/charts/victoria-logs-single/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.58.0
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.16
-digest: sha256:24d1b12d07b71fbe87eaa5dd1a1f2f762bc767d1e32455f632e8c8931150c287
-generated: "2026-08-27T06:03:44.042385598Z"
+  version: 0.4.2
+digest: sha256:abeeaa42451d54b8417c1ebab589fb472b86f715ecdc67341a16a19195614684
+generated: "2026-08-31T10:50:08.161831975Z"

--- a/charts/victoria-logs-single/Chart.yaml
+++ b/charts/victoria-logs-single/Chart.yaml
@@ -37,5 +37,5 @@ dependencies:
     repository: https://helm.vector.dev
     condition: vector.enabled
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-logs-single/templates/NOTES.txt
+++ b/charts/victoria-logs-single/templates/NOTES.txt
@@ -1,6 +1,6 @@
 {{- if .Values.printNotes }}
 {{- if .Values.server.enabled }}
-{{- $ctx := dict "helm" . "appKey" "server" "style" "plain" }}
+{{- $ctx := dict "helm" . "appKey" "server" "style" "plain" "kindOverride" "vlsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- $url := include "vm.url" $ctx }}

--- a/charts/victoria-logs-single/templates/dashboard.yaml
+++ b/charts/victoria-logs-single/templates/dashboard.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Create custom template context
 */}}
-{{- $ctx := dict "helm" . "appKey" "server" -}}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vlsingle" -}}
 
 {{- /*
 Loop through all dashboard files

--- a/charts/victoria-logs-single/templates/ingress.yaml
+++ b/charts/victoria-logs-single/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $ingress := $app.ingress }}
 {{- if and $app.enabled $ingress.enabled  }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vlsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: networking.k8s.io/v1

--- a/charts/victoria-logs-single/templates/monitor.yaml
+++ b/charts/victoria-logs-single/templates/monitor.yaml
@@ -1,5 +1,5 @@
 {{- $app := .Values.server }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vlsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- $port := "http" -}}

--- a/charts/victoria-logs-single/templates/networkpolicy.yaml
+++ b/charts/victoria-logs-single/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
 {{- $np := .Values.networkPolicy }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vlsingle" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/victoria-logs-single/templates/pdb.yaml
+++ b/charts/victoria-logs-single/templates/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $pdb := .Values.podDisruptionBudget }}
 {{- if $pdb.enabled }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vlsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: policy/v1

--- a/charts/victoria-logs-single/templates/pvc.yaml
+++ b/charts/victoria-logs-single/templates/pvc.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $pvc := $app.persistentVolume }}
 {{- if and $pvc.enabled (not $pvc.existingClaim) (eq $app.mode "deployment") -}}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vlsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx}}
 ---

--- a/charts/victoria-logs-single/templates/route.yaml
+++ b/charts/victoria-logs-single/templates/route.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $route := $app.route }}
 {{- if and $app.enabled $route.enabled  }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vlsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-logs-single/templates/server.yaml
+++ b/charts/victoria-logs-single/templates/server.yaml
@@ -4,7 +4,7 @@
 {{- $mode := $app.mode }}
 {{- if and $mode $app.enabled (hasKey $app $mode) }}
 {{- $modeOpts := index $app $mode }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vlsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- if and (ne $mode "statefulSet") (gt (int $app.replicaCount) 1) }}

--- a/charts/victoria-logs-single/templates/service.yaml
+++ b/charts/victoria-logs-single/templates/service.yaml
@@ -2,7 +2,7 @@
 {{- $mode := $app.mode }}
 {{- $service := $app.service }}
 {{- if $app.enabled -}}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vlsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-logs-single/templates/serviceaccount.yaml
+++ b/charts/victoria-logs-single/templates/serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- $sa := .Values.serviceAccount }}
 {{- if $sa.create }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vlsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-logs-single/templates/vector-config.yaml
+++ b/charts/victoria-logs-single/templates/vector-config.yaml
@@ -3,7 +3,7 @@
 {{- $defaultConfig := $vector.customConfigName }}
 {{- if and (or $vector.enabled $vector.customConfigNamespace) (has $defaultConfig $vector.existingConfigMaps) }}
   {{- $config := ($vector).customConfig | default dict }}
-  {{- $ctx := dict "helm" . "appKey" "server" "style" "plain" }}
+  {{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vlsingle" "style" "plain" }}
   {{- if $app.enabled }}
     {{- $port := int $app.service.servicePort -}}
     {{- range $sinkName, $sinkConfig := $config.sinks }}

--- a/charts/victoria-metrics-agent/Chart.lock
+++ b/charts/victoria-metrics-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:41:51.221637154Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:11.135795603Z"

--- a/charts/victoria-metrics-agent/Chart.yaml
+++ b/charts/victoria-metrics-agent/Chart.yaml
@@ -37,5 +37,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-agent/templates/configmap.yaml
+++ b/charts/victoria-metrics-agent/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- if and (empty .Values.configMap) .Values.config }}

--- a/charts/victoria-metrics-agent/templates/hpa.yaml
+++ b/charts/victoria-metrics-agent/templates/hpa.yaml
@@ -1,6 +1,6 @@
 {{- $hpa := .Values.horizontalPodAutoscaler }}
 {{- if $hpa.enabled }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: autoscaling/v2

--- a/charts/victoria-metrics-agent/templates/ingress.yaml
+++ b/charts/victoria-metrics-agent/templates/ingress.yaml
@@ -4,8 +4,8 @@
 {{- if not $app.service.enabled }}
   {{- fail "It's required to set .Values.service.enabled: true when .Values.ingress.enabled: true"}}
 {{- end }}
-{{- $ctx := dict "helm" . }}
-{{- $fullname := include "vm.fullname" $ctx }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
+{{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/victoria-metrics-agent/templates/monitor.yaml
+++ b/charts/victoria-metrics-agent/templates/monitor.yaml
@@ -1,6 +1,6 @@
 {{- $serviceMonitor := .Values.serviceMonitor -}}
 {{- if $serviceMonitor.enabled -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- $port := "http" -}}

--- a/charts/victoria-metrics-agent/templates/networkpolicy.yaml
+++ b/charts/victoria-metrics-agent/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
 {{- $np := .Values.networkPolicy }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/victoria-metrics-agent/templates/pdb.yaml
+++ b/charts/victoria-metrics-agent/templates/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $pdb := .Values.podDisruptionBudget }}
 {{- if $pdb.enabled }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: policy/v1

--- a/charts/victoria-metrics-agent/templates/pvc.yaml
+++ b/charts/victoria-metrics-agent/templates/pvc.yaml
@@ -1,8 +1,8 @@
 {{- $app := .Values }}
 {{- $pvc := $app.persistentVolume }}
 {{- if and $pvc.enabled (not $pvc.existingClaim) (eq $app.mode "deployment") }}
-{{- $ctx := dict "helm" . }}
-{{- $fullname := include "vm.fullname" $ctx }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
+{{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---
 apiVersion: v1

--- a/charts/victoria-metrics-agent/templates/rbac.yaml
+++ b/charts/victoria-metrics-agent/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $namespaced := .Values.rbac.namespaced }}
 {{- $ns := include "vm.namespace" $ctx }}

--- a/charts/victoria-metrics-agent/templates/route.yaml
+++ b/charts/victoria-metrics-agent/templates/route.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values }}
 {{- $route := $app.route }}
 {{- if $route.enabled  }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-agent/templates/server.yaml
+++ b/charts/victoria-metrics-agent/templates/server.yaml
@@ -4,7 +4,7 @@
 {{- $mode := $app.mode }}
 {{- if and $mode (hasKey $app $mode) }}
 {{- $modeOpts := index $app $mode }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1

--- a/charts/victoria-metrics-agent/templates/service.yaml
+++ b/charts/victoria-metrics-agent/templates/service.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values }}
 {{- $service := $app.service }}
 {{- if $service.enabled -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-agent/templates/serviceaccount.yaml
+++ b/charts/victoria-metrics-agent/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-agent/templates/vpa.yaml
+++ b/charts/victoria-metrics-agent/templates/vpa.yaml
@@ -1,6 +1,6 @@
 {{- $vpa := .Values.verticalPodAutoscaling | default .Values.verticalPodAutoscaler }}
 {{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") $vpa.enabled }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmagent" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: autoscaling.k8s.io/v1

--- a/charts/victoria-metrics-agent/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-agent/tests/useLegacyNaming_test.yaml
@@ -187,10 +187,10 @@ tests:
         template: hpa.yaml
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-agent
+          value: vmagent-RELEASE-NAME
         documentSelector:
           path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-agent
+          value: vmagent-RELEASE-NAME
         template: ingress.yaml
       - equal:
           path: metadata.name
@@ -215,10 +215,10 @@ tests:
         template: pdb.yaml
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-agent
+          value: vmagent-RELEASE-NAME
         documentSelector:
           path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-agent
+          value: vmagent-RELEASE-NAME
         template: pvc.yaml
       - equal:
           path: metadata.name

--- a/charts/victoria-metrics-alert/Chart.lock
+++ b/charts/victoria-metrics-alert/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:41:54.244646956Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:14.020707151Z"

--- a/charts/victoria-metrics-alert/Chart.yaml
+++ b/charts/victoria-metrics-alert/Chart.yaml
@@ -37,5 +37,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-alert/templates/_helpers.tpl
+++ b/charts/victoria-metrics-alert/templates/_helpers.tpl
@@ -35,6 +35,7 @@
       {{- $ctx = dict "helm" . }}
     {{- end -}}
     {{- $_ := set $ctx "appKey" "alertmanager" -}}
+    {{- $_ := set $ctx "kindOverride" "vmalertmanager" -}}
     {{- $_ := set $ctx "style" "plain" -}}
     {{- $fullname := include "vm.plain.fullname" $ctx -}}
     {{- $alertmanager := deepCopy $app }}
@@ -109,7 +110,7 @@
 {{- end }}
 
 {{- define "vmalert.args" -}}
-  {{- $ctx := . }}
+  {{- $ctx := merge (dict) . }}
   {{- $Values := (.helm).Values | default .Values -}}
   {{- $app := $Values.server -}}
   {{- $datasource := list (include "vmalert.fromLegacyArgs" $app.datasource | fromYaml) -}}
@@ -135,6 +136,7 @@
     {{- $alertmanager := deepCopy $Values.alertmanager }}
     {{- $_ := set $ctx "style" "plain" -}}
     {{- $_ := set $ctx "appKey" "alertmanager" -}}
+    {{- $_ := set $ctx "kindOverride" "vmalertmanager" -}}
     {{- $appSecure := not (empty ($alertmanager.webConfig).tls_server_config) -}}
     {{- $_ := set $ctx "appSecure" $appSecure -}}
     {{- $_ := set $ctx "appRoute" $alertmanager.baseURLPrefix -}}

--- a/charts/victoria-metrics-alert/templates/alert-configmap.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-configmap.yaml
@@ -1,6 +1,6 @@
 {{- $app := .Values.server }}
 {{- if empty $app.configMap }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmalert" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-alert/templates/alert-ingress.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-ingress.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $ingress := $app.ingress }}
 {{- if $ingress.enabled  }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmalert" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: networking.k8s.io/v1

--- a/charts/victoria-metrics-alert/templates/alert-networkpolicy.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if (.Values.server.networkPolicy).enabled }}
 {{- $np := .Values.server.networkPolicy }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmalert" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/victoria-metrics-alert/templates/alert-pdb.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-pdb.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $pdb := $app.podDisruptionBudget }}
 {{- if $pdb.enabled }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmalert" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: policy/v1

--- a/charts/victoria-metrics-alert/templates/alert-route.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-route.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $route := $app.route }}
 {{- if $route.enabled  }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmalert" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-alert/templates/alert-server.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-server.yaml
@@ -7,7 +7,7 @@
 {{- if empty $app.datasource.url -}}
   {{- fail "server.datasource.url datasource URL must be specified" -}}
 {{- end }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmalert" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- $sa := include "vm.fullname" . }}

--- a/charts/victoria-metrics-alert/templates/alert-service.yaml
+++ b/charts/victoria-metrics-alert/templates/alert-service.yaml
@@ -1,6 +1,6 @@
 {{- $app := .Values.server }}
 {{- $service := $app.service }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmalert" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-alert/templates/alertmanager-configmap.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-configmap.yaml
@@ -1,6 +1,6 @@
 {{- $app := .Values.alertmanager }}
 {{- if and $app.enabled (empty $app.configMap) }}
-{{- $ctx := dict "helm" . "appKey" "alertmanager" }}
+{{- $ctx := dict "helm" . "appKey" "alertmanager" "kindOverride" "vmalertmanager" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-alert/templates/alertmanager-ingress.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-ingress.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.alertmanager }}
 {{- $ingress := $app.ingress }}
 {{- if and $app.enabled $ingress.enabled  }}
-{{- $ctx := dict "helm" . "appKey" "alertmanager" }}
+{{- $ctx := dict "helm" . "appKey" "alertmanager" "kindOverride" "vmalertmanager" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: networking.k8s.io/v1

--- a/charts/victoria-metrics-alert/templates/alertmanager-networkpolicy.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.alertmanager.enabled (.Values.alertmanager.networkPolicy).enabled }}
 {{- $np := .Values.alertmanager.networkPolicy }}
-{{- $ctx := dict "helm" . "appKey" "alertmanager" }}
+{{- $ctx := dict "helm" . "appKey" "alertmanager" "kindOverride" "vmalertmanager" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/victoria-metrics-alert/templates/alertmanager-pvc.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-pvc.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.alertmanager }}
 {{- $pvc := $app.persistentVolume }}
 {{- if and $pvc.enabled (not $pvc.existingClaim) (eq $app.mode "deployment") -}}
-{{- $ctx := dict "helm" . "appKey" "alertmanager" }}
+{{- $ctx := dict "helm" . "appKey" "alertmanager" "kindOverride" "vmalertmanager" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-alert/templates/alertmanager-route.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-route.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.alertmanager }}
 {{- $route := $app.route }}
 {{- if $route.enabled  }}
-{{- $ctx := dict "helm" . "appKey" "alertmanager" }}
+{{- $ctx := dict "helm" . "appKey" "alertmanager" "kindOverride" "vmalertmanager" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-alert/templates/alertmanager-server.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-server.yaml
@@ -4,7 +4,7 @@
 {{- $mode := $app.mode }}
 {{- if and $mode $app.enabled (hasKey $app $mode) -}}
 {{- $modeOpts := index $app $mode }}
-{{- $ctx := dict "helm" . "appKey" "alertmanager" }}
+{{- $ctx := dict "helm" . "appKey" "alertmanager" "kindOverride" "vmalertmanager" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- $sa := include "vm.fullname" . }}

--- a/charts/victoria-metrics-alert/templates/alertmanager-service.yaml
+++ b/charts/victoria-metrics-alert/templates/alertmanager-service.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.alertmanager }}
 {{- $mode := $app.mode }}
 {{- $service := $app.service }}
-{{- $ctx := dict "helm" . "appKey" "alertmanager" }}
+{{- $ctx := dict "helm" . "appKey" "alertmanager" "kindOverride" "vmalertmanager" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- if $app.enabled -}}

--- a/charts/victoria-metrics-alert/templates/monitor.yaml
+++ b/charts/victoria-metrics-alert/templates/monitor.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.serviceMonitor.enabled -}}
 {{- $serviceMonitor := .Values.serviceMonitor -}}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmalert" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: monitoring.coreos.com/v1

--- a/charts/victoria-metrics-alert/templates/vpa.yaml
+++ b/charts/victoria-metrics-alert/templates/vpa.yaml
@@ -1,6 +1,6 @@
 {{- $vpa := .Values.server.verticalPodAutoscaler }}
 {{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") $vpa.enabled }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmalert" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: autoscaling.k8s.io/v1

--- a/charts/victoria-metrics-anomaly/Chart.lock
+++ b/charts/victoria-metrics-anomaly/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:41:57.437871677Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:16.941353222Z"

--- a/charts/victoria-metrics-anomaly/Chart.yaml
+++ b/charts/victoria-metrics-anomaly/Chart.yaml
@@ -36,5 +36,5 @@ annotations:
       url: https://docs.victoriametrics.com/anomaly-detection/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-anomaly/templates/ingress.yaml
+++ b/charts/victoria-metrics-anomaly/templates/ingress.yaml
@@ -4,7 +4,7 @@
 {{- if $shardingEnabled }}
   {{- fail ".Values.ingress.enabled is not allowed when sharding is enabled" }}
 {{- end }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmanomaly" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: networking.k8s.io/v1

--- a/charts/victoria-metrics-anomaly/templates/route.yaml
+++ b/charts/victoria-metrics-anomaly/templates/route.yaml
@@ -4,7 +4,7 @@
 {{- if $shardingEnabled }}
   {{- fail ".Values.route.enabled is not allowed when sharding is enabled" }}
 {{- end }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmanomaly" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-anomaly/templates/service.yaml
+++ b/charts/victoria-metrics-anomaly/templates/service.yaml
@@ -6,7 +6,7 @@
 {{- end }}
 {{- $pvc := .Values.persistentVolume }}
 {{- $mode := ternary "statefulSet" "deployment" $pvc.enabled }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmanomaly" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-auth/Chart.lock
+++ b/charts/victoria-metrics-auth/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:42:00.544614738Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:19.893134393Z"

--- a/charts/victoria-metrics-auth/Chart.yaml
+++ b/charts/victoria-metrics-auth/Chart.yaml
@@ -38,5 +38,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-auth/templates/NOTES.txt
+++ b/charts/victoria-metrics-auth/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- $ctx := dict "helm" . "style" "plain" }}
+{{- $ctx := dict "helm" . "style" "plain" "kindOverride" "vmauth" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 Write API:

--- a/charts/victoria-metrics-auth/templates/ingress.yaml
+++ b/charts/victoria-metrics-auth/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- $app := .Values }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmauth" }}
 {{- $ingresses := dict "" $app.ingress "internal" $app.ingressInternal }}
 {{- range $suffix, $ingress := $ingresses }}
 {{- if $ingress.enabled }}

--- a/charts/victoria-metrics-auth/templates/monitor.yaml
+++ b/charts/victoria-metrics-auth/templates/monitor.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.serviceMonitor.enabled -}}
 {{- $serviceMonitor := .Values.serviceMonitor -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmauth" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $port := "http" -}}
 {{- range .Values.http -}}

--- a/charts/victoria-metrics-auth/templates/networkpolicy.yaml
+++ b/charts/victoria-metrics-auth/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
 {{- $np := .Values.networkPolicy }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmauth" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/victoria-metrics-auth/templates/pdb.yaml
+++ b/charts/victoria-metrics-auth/templates/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $pdb := .Values.podDisruptionBudget }}
 {{- if $pdb.enabled }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmauth" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: policy/v1

--- a/charts/victoria-metrics-auth/templates/route.yaml
+++ b/charts/victoria-metrics-auth/templates/route.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values }}
 {{- $route := $app.route }}
 {{- if $route.enabled  }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmauth" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-auth/templates/secret.yaml
+++ b/charts/victoria-metrics-auth/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.secretName "" }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmauth" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-auth/templates/server.yaml
+++ b/charts/victoria-metrics-auth/templates/server.yaml
@@ -2,7 +2,7 @@
 {{- $mode := $app.mode }}
 {{- if and $mode (hasKey $app $mode) }}
 {{- $modeOpts := index $app $mode }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmauth" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1

--- a/charts/victoria-metrics-auth/templates/service.yaml
+++ b/charts/victoria-metrics-auth/templates/service.yaml
@@ -1,6 +1,6 @@
 {{- $service := .Values.service }}
 {{- if $service.enabled -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmauth" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-auth/templates/serviceaccount.yaml
+++ b/charts/victoria-metrics-auth/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
-{{- $ctx := dict "helm" . -}}
+{{- $ctx := dict "helm" . "kindOverride" "vmauth" -}}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-cluster/Chart.lock
+++ b/charts/victoria-metrics-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:42:03.497694835Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:22.733524983Z"

--- a/charts/victoria-metrics-cluster/Chart.yaml
+++ b/charts/victoria-metrics-cluster/Chart.yaml
@@ -39,5 +39,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-cluster/templates/serviceaccount.yaml
+++ b/charts/victoria-metrics-cluster/templates/serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- $sa := .Values.serviceAccount }}
 {{- if $sa.create }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmcluster" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmauth-server.yaml
@@ -3,7 +3,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vmauth" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vmcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vminsert-server.yaml
@@ -4,7 +4,7 @@
 {{- $ctx := dict "helm" . "appKey" "vminsert" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $relabelConfig := include "vminsert.relabel.config.name" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vmcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/victoria-metrics-cluster/templates/vmselect-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmselect-server.yaml
@@ -7,7 +7,7 @@
 {{- $modeOpts := index $app $mode }}
 {{- $ctx := dict "helm" . "appKey" "vmselect" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vmcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: {{ title $mode }}

--- a/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
+++ b/charts/victoria-metrics-cluster/templates/vmstorage-server.yaml
@@ -4,7 +4,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vmstorage" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vmcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/charts/victoria-metrics-cluster/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-cluster/tests/useLegacyNaming_test.yaml
@@ -527,7 +527,7 @@ tests:
         template: vmauth-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-victoria-metrics-cluster
+          value: vmcluster-RELEASE-NAME
         template: vmauth-server.yaml
       - equal:
           path: metadata.name
@@ -538,7 +538,7 @@ tests:
         template: vminsert-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-victoria-metrics-cluster
+          value: vmcluster-RELEASE-NAME
         template: vminsert-server.yaml
       - equal:
           path: metadata.name
@@ -549,7 +549,7 @@ tests:
         template: vmselect-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-victoria-metrics-cluster
+          value: vmcluster-RELEASE-NAME
         template: vmselect-server.yaml
       - equal:
           path: metadata.name
@@ -560,5 +560,5 @@ tests:
         template: vmstorage-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-victoria-metrics-cluster
+          value: vmcluster-RELEASE-NAME
         template: vmstorage-server.yaml

--- a/charts/victoria-metrics-distributed/Chart.lock
+++ b/charts/victoria-metrics-distributed/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
+  version: 0.4.2
 - name: victoria-metrics-k8s-stack
   repository: oci://ghcr.io/victoriametrics/helm-charts
   version: 0.72.6
-digest: sha256:89166e7351805be3e9a2c151416ace9b47eca42fe70283454e95b08e0a5c2165
-generated: "2026-07-02T11:42:09.616069143Z"
+digest: sha256:7a40b9703a49d93182aabcc5d5088221182f2d2d7b322b3ae313067fc99e6437
+generated: "2026-08-31T10:50:28.233537166Z"

--- a/charts/victoria-metrics-distributed/Chart.yaml
+++ b/charts/victoria-metrics-distributed/Chart.yaml
@@ -39,7 +39,7 @@ annotations:
       url: https://docs.victoriametrics.com/helm/victoria-metrics-operator/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts
   - name: victoria-metrics-k8s-stack
     version: "0.72.*"

--- a/charts/victoria-metrics-distributed/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-distributed/tests/useLegacyNaming_test.yaml
@@ -1,0 +1,34 @@
+suite: useLegacyNaming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+set:
+  victoria-metrics-k8s-stack.defaultRules.enabled: false
+  victoria-metrics-k8s-stack.defaultRules.create: false
+templates:
+  - vmauth-write.yaml
+tests:
+  - it: "useLegacyNaming: true is rejected -- vm.cr.fullname requires CR names to stay stable"
+    set:
+      useLegacyNaming: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "useLegacyNaming: true is not supported by this chart; CR names must remain stable regardless of naming style"
+        template: vmauth-write.yaml
+
+  - it: "useLegacyNaming: true on the matching appKey (vmauth) is also rejected"
+    set:
+      vmauth.useLegacyNaming: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "useLegacyNaming: true is not supported by this chart; CR names must remain stable regardless of naming style"
+        template: vmauth-write.yaml
+
+  - it: "useLegacyNaming: true on an unrelated key (write) does not affect vmauth's CR"
+    set:
+      write.useLegacyNaming: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmauth-global-write-RELEASE-NAME-vm-distributed
+        template: vmauth-write.yaml

--- a/charts/victoria-metrics-estimator/Chart.lock
+++ b/charts/victoria-metrics-estimator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.16
-digest: sha256:13766e02897fb4b428cafe2b65e5a5d63f1037a7f1bca86ec0fe0690b8cce491
-generated: "2026-08-23T10:24:01.104548+08:00"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:31.784799104Z"

--- a/charts/victoria-metrics-estimator/Chart.yaml
+++ b/charts/victoria-metrics-estimator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: victoria-metrics-estimator
 description: A Helm chart for VictoriaMetrics vmestimator
-version: 0.0.0
+version: 0.1.0
 # renovate: image=victoriametrics/vmestimator
 appVersion: v0.1.15
 sources:
@@ -35,5 +35,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/vmestimator/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-estimator/templates/_helpers.tpl
+++ b/charts/victoria-metrics-estimator/templates/_helpers.tpl
@@ -5,31 +5,35 @@
   {{- if and (eq .Values.mode "cluster") (lt (int .Values.storage.replicaCount) 1) -}}
     {{- fail ".Values.storage.replicaCount must be at least 1 in cluster mode" -}}
   {{- end -}}
+  {{- if .Values.useLegacyNaming -}}
+    {{- fail "useLegacyNaming: true is not supported by the victoria-metrics-estimator chart; it only supports operator-style resource naming" -}}
+  {{- end -}}
+  {{- $components := ternary (list "single") (list "storage" "select") (eq .Values.mode "single") -}}
+  {{- range $component := $components -}}
+    {{- if (index $.Values $component).useLegacyNaming -}}
+      {{- fail (printf "%s.useLegacyNaming: true is not supported by the victoria-metrics-estimator chart; it only supports operator-style resource naming" $component) -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "vmestimator.configMapName" -}}
   {{- .Values.config.existingConfigMap | default (include "vmestimator.fullname" (dict "root" .)) -}}
 {{- end -}}
 
+{{- /*
+vmestimator.fullname resolves the fully qualified name of a chart resource.
+Pass "component" as one of "single", "storage" or "select" for a
+per-component resource, or omit it for a chart-wide shared resource
+(ConfigMap, ServiceAccount, NetworkPolicy) — the latter honors a root-level
+fullnameOverride/global.fullnameOverride, matching every other chart.
+*/ -}}
 {{- define "vmestimator.fullname" -}}
-  {{- $root := .root -}}
-  {{- $component := .component | default "" -}}
-  {{- $ctx := dict "helm" $root -}}
-  {{- $fullnameOverride := $root.Values.fullnameOverride | default $root.Values.global.fullnameOverride -}}
-  {{- if $component -}}
-    {{- $appKey := printf "vmestimator-%s" $component -}}
-    {{- $app := deepCopy (index $root.Values $component) -}}
-    {{- if and $fullnameOverride (not (hasKey $app "fullnameOverride")) -}}
-      {{- $_ := set $app "fullnameOverride" (printf "%s-%s" $fullnameOverride $component) -}}
-    {{- end -}}
-    {{- $_ := set $root.Values $appKey $app -}}
-    {{- $_ := set $ctx "appKey" $appKey -}}
-    {{- $_ := set $ctx $appKey $app -}}
-  {{- else if $fullnameOverride -}}
-    {{- $_ := set $ctx "appKey" "vmestimator" -}}
-    {{- $_ := set $ctx "vmestimator" (dict "fullnameOverride" $fullnameOverride) -}}
+  {{- if not .component -}}
+    {{- include "vm.plain.fullname" (dict "helm" .root "kindOverride" "vmestimator") -}}
+  {{- else -}}
+    {{- $kindOverrides := dict "single" "vmestimator-single" "storage" "vmestimator-storage" "select" "vmestimator-select" -}}
+    {{- include "vm.plain.fullname" (dict "helm" .root "appKey" .component "kindOverride" (index $kindOverrides .component)) -}}
   {{- end -}}
-  {{- include "vm.plain.fullname" $ctx -}}
 {{- end -}}
 
 {{- define "vmestimator.args" -}}
@@ -46,7 +50,7 @@
     {{- $storageName := include "vmestimator.fullname" (dict "root" $root "component" "storage") -}}
     {{- $ns := include "vm.namespace" (dict "helm" $root "appKey" "storage") -}}
     {{- $nodes := list -}}
-    {{- range $i := until (int $root.Values.storage.replicaCount) -}}
+    {{- range $i := until (int $storage.replicaCount) -}}
       {{- $fqdn := printf "%s-%d.%s.%s.svc" $storageName $i $storageName $ns -}}
       {{- with $root.Values.global.cluster.dnsDomain -}}
         {{- $fqdn = printf "%s.%s" $fqdn . -}}

--- a/charts/victoria-metrics-estimator/tests/service_test.yaml
+++ b/charts/victoria-metrics-estimator/tests/service_test.yaml
@@ -25,8 +25,7 @@ tests:
   - it: preserves the insert suffix for long names
     set:
       mode: cluster
-      useLegacyNaming: true
-      fullnameOverride: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk
+      storage.fullnameOverride: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk
     asserts:
       - equal:
           path: metadata.name

--- a/charts/victoria-metrics-estimator/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-estimator/tests/useLegacyNaming_test.yaml
@@ -103,91 +103,10 @@ tests:
           path: metadata.name
           value: vmestimator-storage-RELEASE-NAME
         template: workload.yaml
-  - it: "resource names (useLegacyNaming: true)"
+  - it: "useLegacyNaming: true is rejected -- this chart only supports operator-style naming"
     set:
       useLegacyNaming: true
     asserts:
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator
-        template: configmap.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-select
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-select
-        template: ingress.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-select
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-select
-        template: monitor.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator
-        template: networkpolicy.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-storage
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-storage
-        template: pdb.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-select
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-select
-        template: pdb.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-storage
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-storage
-        template: service.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-stor-insert
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-stor-insert
-        template: service.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-select
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-select
-        template: service.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator
-        template: serviceaccount.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-select
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-select
-        template: workload.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-storage
-        documentSelector:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-estimator-vmestimator-storage
+      - failedTemplate:
+          errorMessage: "useLegacyNaming: true is not supported by the victoria-metrics-estimator chart; it only supports operator-style resource naming"
         template: workload.yaml

--- a/charts/victoria-metrics-estimator/tests/workload_test.yaml
+++ b/charts/victoria-metrics-estimator/tests/workload_test.yaml
@@ -53,6 +53,14 @@ tests:
         documentIndex: 1
   - it: preserves component fullname overrides
     set:
+      single.fullnameOverride: custom-single
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-single
+
+  - it: component fullname override wins over the chart-level fullnameOverride
+    set:
       fullnameOverride: shared
       single.fullnameOverride: custom-single
     asserts:

--- a/charts/victoria-metrics-estimator/values.yaml
+++ b/charts/victoria-metrics-estimator/values.yaml
@@ -22,7 +22,8 @@ mode: single
 
 # -- Override chart name
 nameOverride: ""
-# -- Override fully qualified chart name
+# -- Override the base name used for chart-wide shared resources (ConfigMap, ServiceAccount, NetworkPolicy)
+# and, unless a component sets its own fullnameOverride, as the base for that component's resource names too
 fullnameOverride: ""
 
 image:
@@ -74,6 +75,8 @@ single:
     loggerFormat: json
   # -- Override the container command
   command: []
+  # -- Overrides the full name of the single-node component
+  fullnameOverride: ""
   # -- Additional environment variables
   env: []
   # -- Additional environment sources
@@ -127,6 +130,8 @@ storage:
     envflag.prefix: VM_
     loggerFormat: json
   command: []
+  # -- Overrides the full name of the storage component
+  fullnameOverride: ""
   env: []
   envFrom: []
   podAnnotations: {}
@@ -161,6 +166,8 @@ select:
     envflag.prefix: VM_
     loggerFormat: json
   command: []
+  # -- Overrides the full name of the select component
+  fullnameOverride: ""
   env: []
   envFrom: []
   podAnnotations: {}

--- a/charts/victoria-metrics-gateway/Chart.lock
+++ b/charts/victoria-metrics-gateway/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:42:13.878068518Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:34.507763979Z"

--- a/charts/victoria-metrics-gateway/Chart.yaml
+++ b/charts/victoria-metrics-gateway/Chart.yaml
@@ -39,5 +39,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-gateway/templates/configmap.yaml
+++ b/charts/victoria-metrics-gateway/templates/configmap.yaml
@@ -1,6 +1,6 @@
 {{- if empty .Values.configMap }}
 {{- if .Values.rateLimiter.enabled }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmgateway" }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/victoria-metrics-gateway/templates/ingress.yaml
+++ b/charts/victoria-metrics-gateway/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values }}
 {{- $ingress := $app.ingress }}
 {{- if $ingress.enabled }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmgateway" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: networking.k8s.io/v1

--- a/charts/victoria-metrics-gateway/templates/monitor.yaml
+++ b/charts/victoria-metrics-gateway/templates/monitor.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.serviceMonitor.enabled -}}
 {{- $serviceMonitor := .Values.serviceMonitor -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmgateway" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: monitoring.coreos.com/v1

--- a/charts/victoria-metrics-gateway/templates/networkpolicy.yaml
+++ b/charts/victoria-metrics-gateway/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
 {{- $np := .Values.networkPolicy }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmgateway" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/victoria-metrics-gateway/templates/pdb.yaml
+++ b/charts/victoria-metrics-gateway/templates/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $pdb := .Values.podDisruptionBudget }}
 {{- if $pdb.enabled }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmgateway" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: policy/v1

--- a/charts/victoria-metrics-gateway/templates/server.yaml
+++ b/charts/victoria-metrics-gateway/templates/server.yaml
@@ -23,7 +23,7 @@
 {{- $isExtraVolumes := or $isHost (gt (len .Values.extraVolumes) 0)  -}}
 {{- $isVolumes := or $isExtraVolumes .Values.rateLimiter.enabled  (and .Values.license.secret.name .Values.license.secret.key) -}}
 
-{{- $ctx := dict "helm" . -}}
+{{- $ctx := dict "helm" . "kindOverride" "vmgateway" -}}
 {{- $fullname := include "vm.plain.fullname" $ctx -}}
 {{- $ns := include "vm.namespace" $ctx }}
 

--- a/charts/victoria-metrics-gateway/templates/service.yaml
+++ b/charts/victoria-metrics-gateway/templates/service.yaml
@@ -1,6 +1,6 @@
 {{- $service := .Values.service }}
 {{- if $service.enabled -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmgateway" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-gateway/templates/serviceaccount.yaml
+++ b/charts/victoria-metrics-gateway/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmgateway" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-k8s-stack/Chart.lock
+++ b/charts/victoria-metrics-k8s-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.16
+  version: 0.4.2
 - name: victoria-metrics-operator
   repository: oci://ghcr.io/victoriametrics/helm-charts
   version: 0.67.3
@@ -14,5 +14,5 @@ dependencies:
 - name: grafana
   repository: oci://ghcr.io/grafana-community/helm-charts
   version: 12.7.3
-digest: sha256:7a3611415bede4af5a2e8edf8a0d59d7151d518eceadc22a48b51024b57ed8ce
-generated: "2026-09-06T13:37:24.870815+03:00"
+digest: sha256:d4bcc85ac3d724fbf57540b7bf519bb631273f7333900ce9118bdb9d3645e2f4
+generated: "2026-09-07T08:39:50.287755+03:00"

--- a/charts/victoria-metrics-k8s-stack/Chart.yaml
+++ b/charts/victoria-metrics-k8s-stack/Chart.yaml
@@ -39,7 +39,7 @@ annotations:
       url: https://docs.victoriametrics.com/helm/victoria-metrics-operator/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts
   - name: victoria-metrics-operator
     version: "0.67.*"

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -122,6 +122,7 @@ global.versions[.key] (e.g. "logs", "traces", "alertmanager"), otherwise empty.
     {{- $notifiers := list -}}
     {{- $appSecure := not (empty ((($Values.alertmanager).spec).webConfig).tls_server_config) -}}
     {{- $_ := set $ctx "appKey" (list "alertmanager" "spec") -}}
+    {{- $_ := set $ctx "kindOverride" "vmalertmanager" -}}
     {{- $_ := set $ctx "appSecure" $appSecure -}}
     {{- $_ := set $ctx "appRoute" (($Values.alertmanager).spec).routePrefix -}}
     {{- $alertManagerReplicas := $Values.alertmanager.spec.replicaCount | default 1 | int -}}
@@ -470,6 +471,8 @@ global.versions[.key] (e.g. "logs", "traces", "alertmanager"), otherwise empty.
     {{- range $ds := $Values.defaultDatasources.alertmanager.datasources }}
       {{- $appSecure := not (empty ((($Values.alertmanager).spec).webConfig).tls_server_config) -}}
       {{- $_ := set $ctx "appKey" (list "alertmanager" "spec") -}}
+      {{- $_ := set $ctx "kindOverride" "vmalertmanager" -}}
+      {{- $_ := set $ctx "style" "managed" -}}
       {{- $_ := set $ctx "appSecure" $appSecure -}}
       {{- $_ := set $ctx "appRoute" (($Values.alertmanager).spec).routePrefix -}}
       {{- $_ := set $ds "url" (include "vm.url" $ctx) -}}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/notifiers.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalert/notifiers.yaml
@@ -18,6 +18,7 @@ stringData:
       {{- $ctx := dict "helm" . "appKey" "alertmanager" }}
       {{- $_ := set $ctx "appSecure" (not (empty (((.Values.alertmanager).spec).webConfig).tls_server_config)) -}}
       {{- $_ := set $ctx "appKey" (list "alertmanager" "spec") -}}
+      {{- $_ := set $ctx "kindOverride" "vmalertmanager" -}}
       {{- $_ := set $ctx "appRoute" ((.Values.alertmanager).spec).routePrefix -}}
       {{- $_ := set $ctx "style" "managed" -}}
       {{- range until $replicas -}}

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalertmanager/custom-templates.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalertmanager/custom-templates.yaml
@@ -1,6 +1,6 @@
 {{- $app := .Values.alertmanager }}
 {{- if and $app.enabled $app.templateFiles }}
-{{- $ctx := dict "helm" . "appKey" (list "alertmanager" "spec") "style" "managed" }}
+{{- $ctx := dict "helm" . "appKey" (list "alertmanager" "spec") "style" "managed" "kindOverride" "vmalertmanager" }}
 {{- $fullname := include "vm.managed.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 kind: ConfigMap

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalertmanager/monzo-template.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalertmanager/monzo-template.yaml
@@ -1,6 +1,6 @@
 {{- $app := .Values.alertmanager }}
 {{- if and $app.enabled $app.monzoTemplate.enabled }}
-{{- $ctx := dict "helm" . "appKey" (list "alertmanager" "spec") "style" "managed" }}
+{{- $ctx := dict "helm" . "appKey" (list "alertmanager" "spec") "style" "managed" "kindOverride" "vmalertmanager" }}
 {{- $fullname := include "vm.managed.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalertmanager/vmalertmanager.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/victoria-metrics-operator/vmalertmanager/vmalertmanager.yaml
@@ -1,6 +1,6 @@
 {{- $app := .Values.alertmanager }}
 {{- if $app.enabled }}
-  {{- $ctx := dict "helm" . "appKey" (list "alertmanager" "spec") "style" "managed" }}
+  {{- $ctx := dict "helm" . "appKey" (list "alertmanager" "spec") "style" "managed" "kindOverride" "vmalertmanager" }}
   {{- $ns := include "vm.namespace" $ctx }}
   {{- if and $app.spec.configRawYaml $app.config }}
     {{- fail "ERROR: Both .Values.alertmanager.spec.configRawYaml and .Values.alertmanager.config are set, but only one is allowed." }}

--- a/charts/victoria-metrics-k8s-stack/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/useLegacyNaming_test.yaml
@@ -11,6 +11,8 @@ set:
 templates:
   - victoria-metrics-operator/vmagent/rbac.yaml
   - victoria-metrics-operator/vlagent/rbac.yaml
+  - victoria-metrics-operator/vmsingle/vmsingle.yml
+  - victoria-metrics-operator/vmagent/vmagent.yaml
 tests:
   - it: "resource names (default -- vm.managed.fullname defaults to operator-style prefix naming here, unlike vm.plain.fullname elsewhere)"
     asserts:
@@ -42,35 +44,18 @@ tests:
           path: kind
           value: RoleBinding
         template: victoria-metrics-operator/vlagent/rbac.yaml
-  - it: "resource names, useLegacyNaming=true"
+  - it: "useLegacyNaming: true is rejected -- vm.cr.fullname requires CR names to stay stable"
     set:
       useLegacyNaming: true
     asserts:
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-k8s-stack-vmagent
-        documentSelector:
-          path: kind
-          value: Role
-        template: victoria-metrics-operator/vmagent/rbac.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-k8s-stack-vmagent
-        documentSelector:
-          path: kind
-          value: RoleBinding
-        template: victoria-metrics-operator/vmagent/rbac.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-k8s-stack-vlagent
-        documentSelector:
-          path: kind
-          value: Role
-        template: victoria-metrics-operator/vlagent/rbac.yaml
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-victoria-metrics-k8s-stack-vlagent
-        documentSelector:
-          path: kind
-          value: RoleBinding
-        template: victoria-metrics-operator/vlagent/rbac.yaml
+      - failedTemplate:
+          errorMessage: "useLegacyNaming: true is not supported by this chart; CR names must remain stable regardless of naming style"
+        template: victoria-metrics-operator/vmsingle/vmsingle.yml
+
+  - it: "component-level useLegacyNaming: true is also rejected (vm.useLegacyNaming resolves per-appKey)"
+    set:
+      vmagent.useLegacyNaming: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "useLegacyNaming: true is not supported by this chart; CR names must remain stable regardless of naming style"
+        template: victoria-metrics-operator/vmagent/vmagent.yaml

--- a/charts/victoria-metrics-k8s-stack/tests/vmalertmanager_test.yaml
+++ b/charts/victoria-metrics-k8s-stack/tests/vmalertmanager_test.yaml
@@ -1,0 +1,80 @@
+suite: vmalertmanager naming tests
+chart:
+  version: 0.1.1
+  appVersion: 0.1.0
+templates:
+  - victoria-metrics-operator/vmalertmanager/vmalertmanager.yaml
+  - victoria-metrics-operator/vmalert/vmalert.yaml
+  - victoria-metrics-operator/vmalert/notifiers.yaml
+  - grafana/datasource.yaml
+tests:
+  - it: VMAlertmanager config Secret and its spec.configSecret reference use the vmalertmanager name
+    set:
+      alertmanager:
+        enabled: true
+        spec:
+          replicaCount: 2
+    asserts:
+      - equal:
+          path: metadata.name
+          value: vmalertmanager-RELEASE-NAME-victoria-metrics-k8s-stack
+        template: victoria-metrics-operator/vmalertmanager/vmalertmanager.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.configSecret
+          value: vmalertmanager-RELEASE-NAME-victoria-metrics-k8s-stack
+        template: victoria-metrics-operator/vmalertmanager/vmalertmanager.yaml
+        documentIndex: 1
+
+  - it: vmalert notifier targets the vmalertmanager Service per replica
+    set:
+      alertmanager:
+        enabled: true
+        spec:
+          replicaCount: 2
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - contains:
+          path: spec.notifiers
+          content:
+            url: http://vmalertmanager-RELEASE-NAME-victoria-metrics-k8s-stack-0.vmalertmanager-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:9093
+        template: victoria-metrics-operator/vmalert/vmalert.yaml
+      - contains:
+          path: spec.notifiers
+          content:
+            url: http://vmalertmanager-RELEASE-NAME-victoria-metrics-k8s-stack-1.vmalertmanager-RELEASE-NAME-victoria-metrics-k8s-stack.NAMESPACE.svc.cluster.local.:9093
+        template: victoria-metrics-operator/vmalert/vmalert.yaml
+
+  - it: vmalert additional notifier config secret targets the vmalertmanager Service
+    set:
+      alertmanager:
+        enabled: true
+        spec:
+          replicaCount: 2
+      vmalert:
+        additionalNotifierConfigs:
+          static_configs:
+    asserts:
+      - matchRegex:
+          path: stringData["notifier-configs.yaml"]
+          pattern: 'vmalertmanager-RELEASE-NAME-victoria-metrics-k8s-stack-0\.vmalertmanager-RELEASE-NAME-victoria-metrics-k8s-stack\.NAMESPACE\.svc\.cluster\.local\.:9093'
+        template: victoria-metrics-operator/vmalert/notifiers.yaml
+
+  - it: Grafana alertmanager datasource URL targets the vmalertmanager Service
+    set:
+      grafana:
+        forceDeployDatasource: true
+      alertmanager:
+        enabled: true
+      vmalert:
+        spec:
+          extraArgs:
+            notifier.blackhole: "true"
+    asserts:
+      - matchRegex:
+          path: data["datasource.yaml"]
+          pattern: 'http://vmalertmanager-RELEASE-NAME-victoria-metrics-k8s-stack\.NAMESPACE\.svc\.cluster\.local\.:9093'
+        template: grafana/datasource.yaml

--- a/charts/victoria-metrics-mcp/Chart.lock
+++ b/charts/victoria-metrics-mcp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:42:24.756554986Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:45.158208661Z"

--- a/charts/victoria-metrics-mcp/Chart.yaml
+++ b/charts/victoria-metrics-mcp/Chart.yaml
@@ -29,5 +29,5 @@ annotations:
       url: https://docs.victoriametrics.com/helm/victoria-metrics-mcp/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-operator/Chart.lock
+++ b/charts/victoria-metrics-operator/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
+  version: 0.4.2
 - name: crds
   repository: ""
   version: 0.0.*
-digest: sha256:c311f27ec4bd554cdfb7914593c9d507bae7b59661394ba8a637a8a1ffe68a51
-generated: "2026-07-02T11:42:32.861937155Z"
+digest: sha256:2abb0c53a8a7ee899044a66dd94206684207f0c1f9d2f06d7259aa584d8945b2
+generated: "2026-08-31T10:50:50.245274586Z"

--- a/charts/victoria-metrics-operator/Chart.yaml
+++ b/charts/victoria-metrics-operator/Chart.yaml
@@ -38,7 +38,7 @@ annotations:
       url: https://docs.victoriametrics.com/operator/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts
   - name: crds
     version: "0.0.*"

--- a/charts/victoria-metrics-operator/templates/cleanup.yaml
+++ b/charts/victoria-metrics-operator/templates/cleanup.yaml
@@ -6,7 +6,7 @@
 {{- else if not (kindIs "string" ($app.image).tag) }}
   {{- fail "`crd.cleanup.image.tag` is not string, most probably you need to enquote provided value" -}}
 {{- end }}
-{{- $ctx := dict "helm" . "noEnterprise" true }}
+{{- $ctx := dict "helm" . "noEnterprise" true "kindOverride" "vmoperator" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-operator/templates/crb.yaml
+++ b/charts/victoria-metrics-operator/templates/crb.yaml
@@ -1,4 +1,4 @@
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmoperator" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- if .Values.rbac.create }}

--- a/charts/victoria-metrics-operator/templates/monitor.yaml
+++ b/charts/victoria-metrics-operator/templates/monitor.yaml
@@ -2,7 +2,7 @@
 {{- if $monitor.enabled -}}
 {{- $annotations := mustMerge $monitor.annotations .Values.annotations -}}
 {{- $labels := mustMerge $monitor.extraLabels .Values.extraLabels -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmoperator" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: {{ ternary "operator.victoriametrics.com/v1beta1" "monitoring.coreos.com/v1" $monitor.vm }}

--- a/charts/victoria-metrics-operator/templates/pdb.yaml
+++ b/charts/victoria-metrics-operator/templates/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $pdb := .Values.podDisruptionBudget }}
 {{- if $pdb.enabled }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmoperator" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: policy/v1

--- a/charts/victoria-metrics-operator/templates/rb.yaml
+++ b/charts/victoria-metrics-operator/templates/rb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmoperator" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 kind: RoleBinding

--- a/charts/victoria-metrics-operator/templates/role.yaml
+++ b/charts/victoria-metrics-operator/templates/role.yaml
@@ -19,7 +19,7 @@
   {{- end }}
 {{- end -}}
 
-{{- $ctx := dict "helm" . "extraLabels" .Values.extraLabels }}
+{{- $ctx := dict "helm" . "extraLabels" .Values.extraLabels "kindOverride" "vmoperator" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 

--- a/charts/victoria-metrics-operator/templates/server.yaml
+++ b/charts/victoria-metrics-operator/templates/server.yaml
@@ -1,4 +1,4 @@
-{{- $ctx := dict "helm" . "noEnterprise" true }}
+{{- $ctx := dict "helm" . "noEnterprise" true "kindOverride" "vmoperator" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- $env := dict -}}

--- a/charts/victoria-metrics-operator/templates/service.yaml
+++ b/charts/victoria-metrics-operator/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- $service := .Values.service }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmoperator" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-operator/templates/serviceaccount.yaml
+++ b/charts/victoria-metrics-operator/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vmoperator" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- $sa := .Values.serviceAccount }}

--- a/charts/victoria-metrics-operator/templates/webhook.yaml
+++ b/charts/victoria-metrics-operator/templates/webhook.yaml
@@ -1,6 +1,6 @@
 {{- $webhooks := .Values.admissionWebhooks }}
 {{- if $webhooks.enabled }}
-{{- $ctx := dict "helm" . "extraLabels" .Values.extraLabels }}
+{{- $ctx := dict "helm" . "extraLabels" .Values.extraLabels "kindOverride" "vmoperator" }}
 {{- $tls := fromYaml (include "vm-operator.certs" $ctx) }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $domain := ((.Values.global).cluster).dnsDomain }}

--- a/charts/victoria-metrics-single/Chart.lock
+++ b/charts/victoria-metrics-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:42:36.35437803Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:53.243419925Z"

--- a/charts/victoria-metrics-single/Chart.yaml
+++ b/charts/victoria-metrics-single/Chart.yaml
@@ -35,5 +35,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriametrics/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-metrics-single/templates/NOTES.txt
+++ b/charts/victoria-metrics-single/templates/NOTES.txt
@@ -1,6 +1,6 @@
 {{- if .Values.printNotes }}
 {{- if .Values.server.enabled }}
-{{- $ctx := dict "helm" . "appKey" "server" "style" "plain" }}
+{{- $ctx := dict "helm" . "appKey" "server" "style" "plain" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 The VictoriaMetrics write api can be accessed via port {{ .Values.server.service.servicePort | default (include "vm.port.from.flag" (dict "flag" (include "vm.addr.primary" .Values.server.http) "default" "8428")) }} on the following DNS name from within your cluster:

--- a/charts/victoria-metrics-single/templates/ingress.yaml
+++ b/charts/victoria-metrics-single/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $ingress := $app.ingress }}
 {{- if and $app.enabled $ingress.enabled  }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: networking.k8s.io/v1

--- a/charts/victoria-metrics-single/templates/monitor.yaml
+++ b/charts/victoria-metrics-single/templates/monitor.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- if and $app.enabled $app.serviceMonitor.enabled -}}
 {{- $serviceMonitor := $app.serviceMonitor -}}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $port := "http" -}}
 {{- range $app.http -}}

--- a/charts/victoria-metrics-single/templates/networkpolicy.yaml
+++ b/charts/victoria-metrics-single/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
 {{- $np := .Values.networkPolicy }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/victoria-metrics-single/templates/pdb.yaml
+++ b/charts/victoria-metrics-single/templates/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $pdb := .Values.podDisruptionBudget }}
 {{- if $pdb.enabled }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: policy/v1

--- a/charts/victoria-metrics-single/templates/pvc.yaml
+++ b/charts/victoria-metrics-single/templates/pvc.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $pvc := $app.persistentVolume }}
 {{- if and $pvc.enabled (not $pvc.existingClaim) (eq $app.mode "deployment") -}}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-single/templates/rbac.yaml
+++ b/charts/victoria-metrics-single/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create (not .Values.rbac.namespaced) .Values.server.scrape.enabled }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-single/templates/relabel-configmap.yaml
+++ b/charts/victoria-metrics-single/templates/relabel-configmap.yaml
@@ -1,6 +1,6 @@
 {{- $app := .Values.server }}
 {{- if and $app.relabel.enabled (empty $app.relabel.configMap) }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-single/templates/route.yaml
+++ b/charts/victoria-metrics-single/templates/route.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $route := $app.route }}
 {{- if and $app.enabled $route.enabled  }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-metrics-single/templates/scrape-configmap.yaml
+++ b/charts/victoria-metrics-single/templates/scrape-configmap.yaml
@@ -1,6 +1,6 @@
 {{- $app := .Values.server }}
 {{- if and $app.scrape.enabled (empty $app.scrape.configMap) }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-single/templates/server.yaml
+++ b/charts/victoria-metrics-single/templates/server.yaml
@@ -4,7 +4,7 @@
 {{- $mode := $app.mode }}
 {{- if and $mode $app.enabled (hasKey $app $mode) }}
 {{- $modeOpts := index $app $mode }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1

--- a/charts/victoria-metrics-single/templates/service.yaml
+++ b/charts/victoria-metrics-single/templates/service.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $service := $app.service }}
 {{- if $app.enabled -}}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-metrics-single/templates/serviceaccount.yaml
+++ b/charts/victoria-metrics-single/templates/serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- $sa := .Values.serviceAccount }}
 {{- if $sa.create }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vmsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-traces-cluster/Chart.lock
+++ b/charts/victoria-traces-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:42:39.660625645Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:56.429690818Z"

--- a/charts/victoria-traces-cluster/Chart.yaml
+++ b/charts/victoria-traces-cluster/Chart.yaml
@@ -31,5 +31,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriatraces/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-traces-cluster/templates/serviceaccount.yaml
+++ b/charts/victoria-traces-cluster/templates/serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- $sa := .Values.serviceAccount }}
 {{- if $sa.create }}
-{{- $ctx := dict "helm" . }}
+{{- $ctx := dict "helm" . "kindOverride" "vtcluster" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1

--- a/charts/victoria-traces-cluster/templates/vmauth-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vmauth-server.yaml
@@ -3,7 +3,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vmauth" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vtcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/victoria-traces-cluster/templates/vtinsert-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtinsert-server.yaml
@@ -3,7 +3,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vtinsert" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vtcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/victoria-traces-cluster/templates/vtselect-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtselect-server.yaml
@@ -3,7 +3,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vtselect" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vtcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/victoria-traces-cluster/templates/vtstorage-server.yaml
+++ b/charts/victoria-traces-cluster/templates/vtstorage-server.yaml
@@ -4,7 +4,7 @@
 {{- if $app.enabled -}}
 {{- $ctx := dict "helm" . "appKey" "vtstorage" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
-{{- $sa := include "vm.fullname" . }}
+{{- $sa := include "vm.plain.fullname" (dict "helm" . "kindOverride" "vtcluster") }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/charts/victoria-traces-cluster/tests/useLegacyNaming_test.yaml
+++ b/charts/victoria-traces-cluster/tests/useLegacyNaming_test.yaml
@@ -527,7 +527,7 @@ tests:
         template: vmauth-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-vt-cluster
+          value: vtcluster-RELEASE-NAME
         template: vmauth-server.yaml
       - equal:
           path: metadata.name
@@ -538,7 +538,7 @@ tests:
         template: vtinsert-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-vt-cluster
+          value: vtcluster-RELEASE-NAME
         template: vtinsert-server.yaml
       - equal:
           path: metadata.name
@@ -549,7 +549,7 @@ tests:
         template: vtselect-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-vt-cluster
+          value: vtcluster-RELEASE-NAME
         template: vtselect-server.yaml
       - equal:
           path: metadata.name
@@ -560,5 +560,5 @@ tests:
         template: vtstorage-server.yaml
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-vt-cluster
+          value: vtcluster-RELEASE-NAME
         template: vtstorage-server.yaml

--- a/charts/victoria-traces-single/Chart.lock
+++ b/charts/victoria-traces-single/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: victoria-metrics-common
   repository: oci://ghcr.io/victoriametrics/helm-charts
-  version: 0.3.15
-digest: sha256:98442d5a197ba18dff949bc8d41853b20924289cf24337a5c55c5666da30679a
-generated: "2026-07-02T11:42:43.488383901Z"
+  version: 0.4.2
+digest: sha256:cc77d1a7947687b30f5e13a3f1521587c382902cc9ca32ca1207e06d913d3605
+generated: "2026-08-31T10:50:59.321719295Z"

--- a/charts/victoria-traces-single/Chart.yaml
+++ b/charts/victoria-traces-single/Chart.yaml
@@ -32,5 +32,5 @@ annotations:
       url: https://docs.victoriametrics.com/victoriatraces/changelog/
 dependencies:
   - name: victoria-metrics-common
-    version: "0.3.*"
+    version: "0.4.*"
     repository: oci://ghcr.io/victoriametrics/helm-charts

--- a/charts/victoria-traces-single/templates/NOTES.txt
+++ b/charts/victoria-traces-single/templates/NOTES.txt
@@ -1,6 +1,6 @@
 {{- if .Values.printNotes }}
 {{- if .Values.server.enabled }}
-{{- $ctx := dict "helm" . "appKey" "server" "style" "plain" }}
+{{- $ctx := dict "helm" . "appKey" "server" "style" "plain" "kindOverride" "vtsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- $url := include "vm.url" $ctx }}

--- a/charts/victoria-traces-single/templates/ingress.yaml
+++ b/charts/victoria-traces-single/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $ingress := $app.ingress }}
 {{- if and $app.enabled $ingress.enabled  }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vtsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: networking.k8s.io/v1

--- a/charts/victoria-traces-single/templates/monitor.yaml
+++ b/charts/victoria-traces-single/templates/monitor.yaml
@@ -1,5 +1,5 @@
 {{- $app := .Values.server }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vtsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- $port := "http" -}}

--- a/charts/victoria-traces-single/templates/networkpolicy.yaml
+++ b/charts/victoria-traces-single/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
 {{- $np := .Values.networkPolicy }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vtsingle" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/victoria-traces-single/templates/pdb.yaml
+++ b/charts/victoria-traces-single/templates/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $pdb := .Values.podDisruptionBudget }}
 {{- if $pdb.enabled }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vtsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: policy/v1

--- a/charts/victoria-traces-single/templates/pvc.yaml
+++ b/charts/victoria-traces-single/templates/pvc.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $pvc := $app.persistentVolume }}
 {{- if and $pvc.enabled (not $pvc.existingClaim) (eq $app.mode "deployment") -}}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vtsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx}}
 ---

--- a/charts/victoria-traces-single/templates/route.yaml
+++ b/charts/victoria-traces-single/templates/route.yaml
@@ -1,7 +1,7 @@
 {{- $app := .Values.server }}
 {{- $route := $app.route }}
 {{- if and $app.enabled $route.enabled  }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vtsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-traces-single/templates/server.yaml
+++ b/charts/victoria-traces-single/templates/server.yaml
@@ -4,7 +4,7 @@
 {{- $mode := $app.mode }}
 {{- if and $mode $app.enabled (hasKey $app $mode) }}
 {{- $modeOpts := index $app $mode }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vtsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 {{- if and (ne $mode "statefulSet") (gt (int $app.replicaCount) 1) }}

--- a/charts/victoria-traces-single/templates/service.yaml
+++ b/charts/victoria-traces-single/templates/service.yaml
@@ -2,7 +2,7 @@
 {{- $mode := $app.mode }}
 {{- $service := $app.service }}
 {{- if $app.enabled -}}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vtsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 ---

--- a/charts/victoria-traces-single/templates/serviceaccount.yaml
+++ b/charts/victoria-traces-single/templates/serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- $sa := .Values.serviceAccount }}
 {{- if $sa.create }}
-{{- $ctx := dict "helm" . "appKey" "server" }}
+{{- $ctx := dict "helm" . "appKey" "server" "kindOverride" "vtsingle" }}
 {{- $fullname := include "vm.plain.fullname" $ctx }}
 {{- $ns := include "vm.namespace" $ctx }}
 apiVersion: v1


### PR DESCRIPTION
- Bump every chart's `victoria-metrics-common` dependency from `0.3.*` to `0.4.*`, which requires an explicit `kindOverride` instead of guessing a resource-name prefix (see prior `common:` commit).
- Pass `kindOverride` explicitly wherever a chart relied on that guessing, so names are unchanged: `victoria-metrics-agent`, `-anomaly`, `-auth`, `-cluster`, `-gateway`, `-operator`, `-alert`, `-estimator`, `-k8s-stack`, `victoria-logs-agent`, `-cluster`, `-multilevel`, `victoria-traces-cluster`. The other 7 charts only needed the dependency bump.
- Add test coverage for the alertmanager naming path that was previously untested.