### PR TITLE
fix(k8s-stack): rewrite kube-prometheus alertmanager selectors

### DIFF
--- a/charts/victoria-metrics-k8s-stack/CHANGELOG.md
+++ b/charts/victoria-metrics-k8s-stack/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- fixed sync-job's `alertmanager.rules` group keeping upstream kube-prometheus's `job="alertmanager-main",namespace="monitoring"` selectors, which never match this chart's VMAlertmanager. The sync-job now rewrites both to a regexp matching this chart's VMAlertmanager(s) via a new `labelRewrites` option (alongside the existing `jobNamespaces`), configurable under `defaultRules.labelRewrites` / `defaultRules.groups.<name>.labelRewrites`; values may be template expressions (e.g. `{{ .Release.Namespace }}`), rendered before use. See [#11517](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11517)
 - bump version of VM components to [v1.151.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.151.0)
 - fixed `plugins` section missing from `GrafanaDatasource` CRs for datasources whose type requires a Grafana plugin not already listed in `grafana.plugins`. See [#3181](https://github.com/VictoriaMetrics/helm-charts/issues/3181)
 - added `global.versions` (metrics/logs/traces/anomaly/alertmanager), shared automatically with the embedded operator chart's own `global.versions`, so CRs created outside this chart default to the same version the chart deploys instead of the operator's own baked-in default. See [#3186](https://github.com/VictoriaMetrics/helm-charts/issues/3186)

--- a/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
+++ b/charts/victoria-metrics-k8s-stack/templates/_helpers.tpl
@@ -504,6 +504,10 @@ global.versions[.key] (e.g. "logs", "traces", "alertmanager"), otherwise empty.
   {{- $grafanaAddr -}}
 {{- end -}}
 
+{{- define "vm-k8s-stack.alertmanager.namespace" -}}
+  {{- include "vm.namespace" (dict "helm" . "appKey" (list "alertmanager" "spec")) -}}
+{{- end -}}
+
 {{- define "vl.read.endpoint" -}}
   {{- $Values := (.helm).Values | default .Values -}}
   {{- $endpoint := dict -}}

--- a/charts/victoria-metrics-k8s-stack/templates/sync-job/config.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/sync-job/config.yaml
@@ -66,7 +66,7 @@
     {{- if or (eq (index $groupVal "enabled") false) (eq (index $groupVal "create") false) -}}
       {{- $gc = set $gc "enabled" false -}}
     {{- end -}}
-    {{- range $k := list "spec" "jobNamespaces" "rule" "alerting" "recording" -}}
+    {{- range $k := list "spec" "jobNamespaces" "labelRewrites" "rule" "alerting" "recording" -}}
       {{- with index $groupVal $k -}}{{- $gc = set $gc $k . -}}{{- end -}}
     {{- end -}}
     {{- if hasKey $groupVal "extraGroupByLabels" -}}
@@ -86,6 +86,17 @@
     {{- if $gc -}}{{- $groups = set $groups $groupName $gc -}}{{- end -}}
   {{- end -}}
 {{- end -}}
+    {{- /* The kube-prometheus alertmanager.rules group hardcodes job="alertmanager-main" / namespace="monitoring";
+         rewrite them to the chart's own VMAlertmanager scrape job and release namespace. */}}
+    {{- $amGroup := index ($Values.defaultRules.groups | default dict) "alertmanager.rules" | default dict }}
+    {{- if and $Values.defaultRules.enabled $Values.alertmanager.enabled (not (hasKey $amGroup "labelRewrites")) }}
+      {{- $amFullName := include "vm.managed.fullname" (dict "helm" $ "appKey" (list "alertmanager") "style" "managed" "kindOverride" "vmalertmanager") }}
+      {{- $amExisting := index $groups "alertmanager.rules" | default dict }}
+      {{- $_ := set $amExisting "labelRewrites" (dict
+            "job" (dict "alertmanager-main" $amFullName)
+            "namespace" (dict "monitoring" (include "vm.namespace" (dict "helm" $)))) }}
+      {{- $_ := set $groups "alertmanager.rules" $amExisting }}
+    {{- end }}
 
 ---
 apiVersion: v1
@@ -147,6 +158,9 @@ data:
         {{- end }}
         {{- with $Values.defaultRules.jobNamespaces }}
         jobNamespaces: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $Values.defaultRules.labelRewrites }}
+        labelRewrites: {{ toYaml . | nindent 10 }}
         {{- end }}
       {{- if $commonRules }}
       rules: {{ toYaml $commonRules | nindent 8 }}

--- a/charts/victoria-metrics-k8s-stack/templates/sync-job/config.yaml
+++ b/charts/victoria-metrics-k8s-stack/templates/sync-job/config.yaml
@@ -66,8 +66,11 @@
     {{- if or (eq (index $groupVal "enabled") false) (eq (index $groupVal "create") false) -}}
       {{- $gc = set $gc "enabled" false -}}
     {{- end -}}
-    {{- range $k := list "spec" "jobNamespaces" "labelRewrites" "rule" "alerting" "recording" -}}
+    {{- range $k := list "spec" "jobNamespaces" "rule" "alerting" "recording" -}}
       {{- with index $groupVal $k -}}{{- $gc = set $gc $k . -}}{{- end -}}
+    {{- end -}}
+    {{- with index $groupVal "labelRewrites" -}}
+      {{- $gc = set $gc "labelRewrites" (fromYaml (tpl (toYaml .) $)) -}}
     {{- end -}}
     {{- if hasKey $groupVal "extraGroupByLabels" -}}
       {{- $gc = set $gc "extraGroupByLabels" (index $groupVal "extraGroupByLabels") -}}
@@ -86,17 +89,6 @@
     {{- if $gc -}}{{- $groups = set $groups $groupName $gc -}}{{- end -}}
   {{- end -}}
 {{- end -}}
-    {{- /* The kube-prometheus alertmanager.rules group hardcodes job="alertmanager-main" / namespace="monitoring";
-         rewrite them to the chart's own VMAlertmanager scrape job and release namespace. */}}
-    {{- $amGroup := index ($Values.defaultRules.groups | default dict) "alertmanager.rules" | default dict }}
-    {{- if and $Values.defaultRules.enabled $Values.alertmanager.enabled (not (hasKey $amGroup "labelRewrites")) }}
-      {{- $amFullName := include "vm.managed.fullname" (dict "helm" $ "appKey" (list "alertmanager") "style" "managed" "kindOverride" "vmalertmanager") }}
-      {{- $amExisting := index $groups "alertmanager.rules" | default dict }}
-      {{- $_ := set $amExisting "labelRewrites" (dict
-            "job" (dict "alertmanager-main" $amFullName)
-            "namespace" (dict "monitoring" (include "vm.namespace" (dict "helm" $)))) }}
-      {{- $_ := set $groups "alertmanager.rules" $amExisting }}
-    {{- end }}
 
 ---
 apiVersion: v1
@@ -160,7 +152,7 @@ data:
         jobNamespaces: {{ toYaml . | nindent 10 }}
         {{- end }}
         {{- with $Values.defaultRules.labelRewrites }}
-        labelRewrites: {{ toYaml . | nindent 10 }}
+        labelRewrites: {{ tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
       {{- if $commonRules }}
       rules: {{ toYaml $commonRules | nindent 8 }}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -231,6 +231,12 @@ defaultRules:
   # Only use for jobs whose metrics are always namespace-scoped.
   jobNamespaces: {}
 
+  # -- Rewrite exact-match label filter values in metric selectors (e.g. kube-prometheus job/namespace
+  # selectors that don't match the jobs this chart creates).
+  # Map of label name -> map of old value -> new value. Regexp and negative filters are left unchanged.
+  # Merged with per-group labelRewrites (per-group wins on per-label conflicts).
+  labelRewrites: {}
+
   # -- Common properties for VMRule groups
   group:
     spec: {}
@@ -290,6 +296,8 @@ defaultRules:
       #   annotations:
       #     dashboard: https://example.com/dashboard/1
     alertmanager.rules:
+      # Selectors in this kube-prometheus group (job="alertmanager-main", namespace="monitoring")
+      # are rewritten to the chart's own VMAlertmanager job/namespace by the sync-job config template.
       rules: {}
     general.rules:
       rules: {}

--- a/charts/victoria-metrics-k8s-stack/values.yaml
+++ b/charts/victoria-metrics-k8s-stack/values.yaml
@@ -226,15 +226,14 @@ defaultRules:
   # -- Labels, which are used for grouping results of the queries. Note that these labels are joined with `.Values.global.clusterLabel`
   extraGroupByLabels: []
   enabled: true
-  # -- Inject namespace=~"<value>" filter into metric selectors for metrics scraped by the given job.
+  # -- Deprecated: use labelRewrites instead (e.g. `labelRewrites.namespace: {match: <job>, value: <value>}`).
+  # Inject namespace=~"<value>" filter into metric selectors for metrics scraped by the given job.
   # Merged with per-group jobNamespaces (per-group wins on conflict).
   # Only use for jobs whose metrics are always namespace-scoped.
   jobNamespaces: {}
-
-  # -- Rewrite exact-match label filter values in metric selectors (e.g. kube-prometheus job/namespace
-  # selectors that don't match the jobs this chart creates).
-  # Map of label name -> map of old value -> new value. Regexp and negative filters are left unchanged.
-  # Merged with per-group labelRewrites (per-group wins on per-label conflicts).
+  # -- Each entry rewrites label `name` (defaults to the map key) to `value` (a regexp) for
+  # selectors whose job is `match`. `value` may be a template expression, rendered before use.
+  # Merged with per-group labelRewrites by key (per-group wins on conflict).
   labelRewrites: {}
 
   # -- Common properties for VMRule groups
@@ -296,9 +295,14 @@ defaultRules:
       #   annotations:
       #     dashboard: https://example.com/dashboard/1
     alertmanager.rules:
-      # Selectors in this kube-prometheus group (job="alertmanager-main", namespace="monitoring")
-      # are rewritten to the chart's own VMAlertmanager job/namespace by the sync-job config template.
       rules: {}
+      labelRewrites:
+        job:
+          match: alertmanager-main
+          value: vmalertmanager-.*
+        namespace:
+          match: alertmanager-main
+          value: '{{ include "vm-k8s-stack.alertmanager.namespace" $ }}'
     general.rules:
       rules: {}
     k8s.rules.container_cpu_limits:
@@ -339,14 +343,18 @@ defaultRules:
       rules: {}
     kubernetes-apps:
       rules: {}
-      jobNamespaces:
-        kube-state-metrics: ".*"
+      labelRewrites:
+        namespace:
+          match: kube-state-metrics
+          value: ".*"
     kubernetes-resources:
       rules: {}
     kubernetes-storage:
       rules: {}
-      jobNamespaces:
-        kubelet: ".*"
+      labelRewrites:
+        namespace:
+          match: kubelet
+          value: ".*"
     kubernetes-system:
       rules: {}
     kubernetes-system-apiserver:

--- a/hack/sync-job/README.md
+++ b/hack/sync-job/README.md
@@ -78,7 +78,8 @@ rules:
     runbookUrl: https://runbooks.prometheus-operator.dev/runbooks
     grafanaUrl: ""
     extraGroupByLabels: []   # extra labels appended to every by(...) modifier
-    jobNamespaces: {}        # job name → namespace regex; injects namespace filter into matching selectors
+    jobNamespaces: {}        # deprecated, use labelRewrites; job name → namespace regex; injects/replaces namespace filter into matching selectors
+    labelRewrites: {}        # keyed by an identifier; each entry is {name, match, value} (name defaults to the key)
     group: {}        # spec fields applied to every VMRule group
     rule: {}         # merged into every rule
     alerting: {}     # merged into every alerting rule
@@ -91,8 +92,10 @@ rules:
   groups:            # per-group overrides keyed by upstream group name
     kubernetes-apps:
       enabled: true
-      jobNamespaces:
-        kube-state-metrics: ".*"
+      labelRewrites:
+        namespace:
+          match: kube-state-metrics
+          value: ".*"
       rule: {}
       alerting: {}
       recording: {}
@@ -118,7 +121,8 @@ Group keys under `rules.groups` are matched against upstream group names in this
 - The `cluster` label in `by(...)` / `on(...)` modifiers is renamed to `clusterLabel`.
 - In multicluster mode, `clusterLabel` is appended to every aggregation modifier that doesn't already include it.
 - `extraGroupByLabels` are appended to every aggregation modifier.
-- `jobNamespaces` injects a `namespace=~"<regex>"` filter into metric selectors that have an exact `job="<name>"` match and no existing `namespace` filter. Only applies to jobs whose metrics always carry a namespace label; avoid using it for jobs like `kubelet` where some metrics (e.g. `up`) are not namespace-scoped.
+- `jobNamespaces` (deprecated, use `labelRewrites` targeting `namespace` instead) injects a `namespace=~"<regex>"` filter into metric selectors that have an exact `job="<name>"` match; if the selector already has a different `namespace` filter, its value is replaced (a matching value is left untouched). Only applies to jobs whose metrics always carry a namespace label; avoid using it for jobs like `kubelet` where some metrics (e.g. `up`) are not namespace-scoped.
+- `labelRewrites` entries are keyed by an identifier (the label name, unless `name` is set); for a selector whose `job` exactly matches that entry's `match`, it rewrites (or adds) `name` to `value`, as a regexp. Useful when an upstream rule group's selector doesn't match this chart's naming (e.g. kube-prometheus's `alertmanager.rules`).
 - Grafana variables (`$__rate_interval`, `$__interval`, etc.) are preserved.
 
 **Dashboards:**

--- a/hack/sync-job/config.go
+++ b/hack/sync-job/config.go
@@ -58,27 +58,29 @@ type ruleOverride struct {
 }
 
 type groupOverride struct {
-	Enabled            *bool                   `yaml:"enabled,omitempty"`
-	Spec               ruleGroup               `yaml:"spec,omitempty"`
-	ExtraGroupByLabels []string                `yaml:"extraGroupByLabels,omitempty"`
-	JobNamespaces      map[string]string       `yaml:"jobNamespaces,omitempty"`
-	Rule               ruleOverride            `yaml:"rule,omitempty"`
-	Alerting           ruleOverride            `yaml:"alerting,omitempty"`
-	Recording          ruleOverride            `yaml:"recording,omitempty"`
-	Rules              map[string]ruleOverride `yaml:"rules,omitempty"`
+	Enabled            *bool                     `yaml:"enabled,omitempty"`
+	Spec               ruleGroup                 `yaml:"spec,omitempty"`
+	ExtraGroupByLabels []string                  `yaml:"extraGroupByLabels,omitempty"`
+	JobNamespaces      map[string]string         `yaml:"jobNamespaces,omitempty"`
+	LabelRewrites      map[string]map[string]string `yaml:"labelRewrites,omitempty"`
+	Rule               ruleOverride              `yaml:"rule,omitempty"`
+	Alerting           ruleOverride              `yaml:"alerting,omitempty"`
+	Recording          ruleOverride              `yaml:"recording,omitempty"`
+	Rules              map[string]ruleOverride   `yaml:"rules,omitempty"`
 }
 
 type rulesCommonConfig struct {
-	ExtraGroupByLabels []string          `yaml:"extraGroupByLabels,omitempty"`
-	JobNamespaces      map[string]string `yaml:"jobNamespaces,omitempty"`
-	RunbookURL         string            `yaml:"runbookUrl"`
-	GrafanaURL         string            `yaml:"grafanaUrl"`
-	Labels             map[string]string `yaml:"labels,omitempty"`
-	Annotations        map[string]string `yaml:"annotations,omitempty"`
-	Group              groupOverride     `yaml:"group,omitempty"`
-	Rule               ruleOverride      `yaml:"rule,omitempty"`
-	Alerting           ruleOverride      `yaml:"alerting,omitempty"`
-	Recording          ruleOverride      `yaml:"recording,omitempty"`
+	ExtraGroupByLabels []string                     `yaml:"extraGroupByLabels,omitempty"`
+	JobNamespaces      map[string]string            `yaml:"jobNamespaces,omitempty"`
+	LabelRewrites      map[string]map[string]string `yaml:"labelRewrites,omitempty"`
+	RunbookURL         string                       `yaml:"runbookUrl"`
+	GrafanaURL         string                       `yaml:"grafanaUrl"`
+	Labels             map[string]string            `yaml:"labels,omitempty"`
+	Annotations        map[string]string            `yaml:"annotations,omitempty"`
+	Group              groupOverride                `yaml:"group,omitempty"`
+	Rule               ruleOverride                 `yaml:"rule,omitempty"`
+	Alerting           ruleOverride                 `yaml:"alerting,omitempty"`
+	Recording          ruleOverride                 `yaml:"recording,omitempty"`
 }
 
 type rulesConfig struct {

--- a/hack/sync-job/config.go
+++ b/hack/sync-job/config.go
@@ -57,30 +57,38 @@ type ruleOverride struct {
 	Spec    rule  `yaml:"spec"`
 }
 
+// labelRewrite is keyed in LabelRewrites by an identifier; if Name is empty,
+// that key doubles as the label to rewrite.
+type labelRewrite struct {
+	Name  string `yaml:"name,omitempty"`
+	Match string `yaml:"match"`
+	Value string `yaml:"value"`
+}
+
 type groupOverride struct {
-	Enabled            *bool                     `yaml:"enabled,omitempty"`
-	Spec               ruleGroup                 `yaml:"spec,omitempty"`
-	ExtraGroupByLabels []string                  `yaml:"extraGroupByLabels,omitempty"`
-	JobNamespaces      map[string]string         `yaml:"jobNamespaces,omitempty"`
-	LabelRewrites      map[string]map[string]string `yaml:"labelRewrites,omitempty"`
-	Rule               ruleOverride              `yaml:"rule,omitempty"`
-	Alerting           ruleOverride              `yaml:"alerting,omitempty"`
-	Recording          ruleOverride              `yaml:"recording,omitempty"`
-	Rules              map[string]ruleOverride   `yaml:"rules,omitempty"`
+	Enabled            *bool                   `yaml:"enabled,omitempty"`
+	Spec               ruleGroup               `yaml:"spec,omitempty"`
+	ExtraGroupByLabels []string                `yaml:"extraGroupByLabels,omitempty"`
+	JobNamespaces      map[string]string       `yaml:"jobNamespaces,omitempty"` // Deprecated: use LabelRewrites targeting "namespace" instead.
+	LabelRewrites      map[string]labelRewrite `yaml:"labelRewrites,omitempty"`
+	Rule               ruleOverride            `yaml:"rule,omitempty"`
+	Alerting           ruleOverride            `yaml:"alerting,omitempty"`
+	Recording          ruleOverride            `yaml:"recording,omitempty"`
+	Rules              map[string]ruleOverride `yaml:"rules,omitempty"`
 }
 
 type rulesCommonConfig struct {
-	ExtraGroupByLabels []string                     `yaml:"extraGroupByLabels,omitempty"`
-	JobNamespaces      map[string]string            `yaml:"jobNamespaces,omitempty"`
-	LabelRewrites      map[string]map[string]string `yaml:"labelRewrites,omitempty"`
-	RunbookURL         string                       `yaml:"runbookUrl"`
-	GrafanaURL         string                       `yaml:"grafanaUrl"`
-	Labels             map[string]string            `yaml:"labels,omitempty"`
-	Annotations        map[string]string            `yaml:"annotations,omitempty"`
-	Group              groupOverride                `yaml:"group,omitempty"`
-	Rule               ruleOverride                 `yaml:"rule,omitempty"`
-	Alerting           ruleOverride                 `yaml:"alerting,omitempty"`
-	Recording          ruleOverride                 `yaml:"recording,omitempty"`
+	ExtraGroupByLabels []string                `yaml:"extraGroupByLabels,omitempty"`
+	JobNamespaces      map[string]string       `yaml:"jobNamespaces,omitempty"` // Deprecated: use LabelRewrites targeting "namespace" instead.
+	LabelRewrites      map[string]labelRewrite `yaml:"labelRewrites,omitempty"`
+	RunbookURL         string                  `yaml:"runbookUrl"`
+	GrafanaURL         string                  `yaml:"grafanaUrl"`
+	Labels             map[string]string       `yaml:"labels,omitempty"`
+	Annotations        map[string]string       `yaml:"annotations,omitempty"`
+	Group              groupOverride           `yaml:"group,omitempty"`
+	Rule               ruleOverride            `yaml:"rule,omitempty"`
+	Alerting           ruleOverride            `yaml:"alerting,omitempty"`
+	Recording          ruleOverride            `yaml:"recording,omitempty"`
 }
 
 type rulesConfig struct {

--- a/hack/sync-job/rules.go
+++ b/hack/sync-job/rules.go
@@ -129,6 +129,7 @@ func parseRuleGroups(raw []byte, srcURL string) ([]ruleGroup, error) {
 func patchRuleGroup(g *ruleGroup, cfg *rulesConfig, common commonConfig) {
 	additionalLabels := cfg.Common.ExtraGroupByLabels
 	jobNamespaces := cfg.Common.JobNamespaces
+	labelRewrites := cfg.Common.LabelRewrites
 	if gc, ok := lookupGroup(cfg.Groups, g.Name); ok {
 		if gc.ExtraGroupByLabels != nil {
 			additionalLabels = gc.ExtraGroupByLabels
@@ -139,11 +140,25 @@ func patchRuleGroup(g *ruleGroup, cfg *rulesConfig, common commonConfig) {
 			maps.Copy(merged, gc.JobNamespaces)
 			jobNamespaces = merged
 		}
+		if len(gc.LabelRewrites) > 0 {
+			merged := make(map[string]map[string]string, len(labelRewrites)+len(gc.LabelRewrites))
+			for label, rewrites := range labelRewrites {
+				merged[label] = maps.Clone(rewrites)
+			}
+			for label, rewrites := range gc.LabelRewrites {
+				if merged[label] == nil {
+					merged[label] = maps.Clone(rewrites)
+					continue
+				}
+				maps.Copy(merged[label], rewrites)
+			}
+			labelRewrites = merged
+		}
 	}
 	for i := range g.Rules {
 		r := &g.Rules[i]
 		patchRuleAnnotations(r, cfg, common.ClusterLabel)
-		r.Expr = patchRuleExpr(r.Expr, additionalLabels, common, jobNamespaces)
+		r.Expr = patchRuleExpr(r.Expr, additionalLabels, common, jobNamespaces, labelRewrites)
 		applyRuleDefaults(r, cfg, g.Name)
 	}
 }
@@ -261,7 +276,7 @@ func patchRuleAnnotations(r *rule, cfg *rulesConfig, clusterLabel string) {
 	}
 }
 
-func patchRuleExpr(expr string, extraGroupByLabels []string, common commonConfig, jobNamespaces map[string]string) string {
+func patchRuleExpr(expr string, extraGroupByLabels []string, common commonConfig, jobNamespaces map[string]string, labelRewrites map[string]map[string]string) string {
 	if expr == "" {
 		return expr
 	}
@@ -314,6 +329,21 @@ func patchRuleExpr(expr string, extraGroupByLabels []string, common commonConfig
 				t.Modifier.Args = append(t.Modifier.Args, allGroupLabels...)
 			}
 		case *metricsql.MetricExpr:
+			if len(labelRewrites) > 0 {
+				for i, group := range t.LabelFilterss {
+					for j := range group {
+						f := &t.LabelFilterss[i][j]
+						if f.IsNegative || f.IsRegexp {
+							continue
+						}
+						if rewrites, ok := labelRewrites[f.Label]; ok {
+							if v, ok := rewrites[f.Value]; ok {
+								f.Value = v
+							}
+						}
+					}
+				}
+			}
 			if len(jobNamespaces) == 0 {
 				return
 			}

--- a/hack/sync-job/rules.go
+++ b/hack/sync-job/rules.go
@@ -141,17 +141,9 @@ func patchRuleGroup(g *ruleGroup, cfg *rulesConfig, common commonConfig) {
 			jobNamespaces = merged
 		}
 		if len(gc.LabelRewrites) > 0 {
-			merged := make(map[string]map[string]string, len(labelRewrites)+len(gc.LabelRewrites))
-			for label, rewrites := range labelRewrites {
-				merged[label] = maps.Clone(rewrites)
-			}
-			for label, rewrites := range gc.LabelRewrites {
-				if merged[label] == nil {
-					merged[label] = maps.Clone(rewrites)
-					continue
-				}
-				maps.Copy(merged[label], rewrites)
-			}
+			merged := make(map[string]labelRewrite, len(labelRewrites)+len(gc.LabelRewrites))
+			maps.Copy(merged, labelRewrites)
+			maps.Copy(merged, gc.LabelRewrites)
 			labelRewrites = merged
 		}
 	}
@@ -276,7 +268,7 @@ func patchRuleAnnotations(r *rule, cfg *rulesConfig, clusterLabel string) {
 	}
 }
 
-func patchRuleExpr(expr string, extraGroupByLabels []string, common commonConfig, jobNamespaces map[string]string, labelRewrites map[string]map[string]string) string {
+func patchRuleExpr(expr string, extraGroupByLabels []string, common commonConfig, jobNamespaces map[string]string, labelRewrites map[string]labelRewrite) string {
 	if expr == "" {
 		return expr
 	}
@@ -329,47 +321,53 @@ func patchRuleExpr(expr string, extraGroupByLabels []string, common commonConfig
 				t.Modifier.Args = append(t.Modifier.Args, allGroupLabels...)
 			}
 		case *metricsql.MetricExpr:
-			if len(labelRewrites) > 0 {
-				for i, group := range t.LabelFilterss {
-					for j := range group {
-						f := &t.LabelFilterss[i][j]
-						if f.IsNegative || f.IsRegexp {
-							continue
-						}
-						if rewrites, ok := labelRewrites[f.Label]; ok {
-							if v, ok := rewrites[f.Value]; ok {
-								f.Value = v
-							}
-						}
-					}
-				}
-			}
-			if len(jobNamespaces) == 0 {
+			if len(jobNamespaces) == 0 && len(labelRewrites) == 0 {
 				return
 			}
 			for i, group := range t.LabelFilterss {
-				jobValue, hasNamespace := "", false
+				jobValue, hasJob := "", false
 				for _, f := range group {
-					switch f.Label {
-					case "job":
-						if !f.IsNegative && !f.IsRegexp {
-							jobValue = f.Value
-						}
-					case "namespace":
-						hasNamespace = true
+					if f.Label == "job" && !f.IsNegative && !f.IsRegexp {
+						jobValue, hasJob = f.Value, true
 					}
 				}
-				if ns, ok := jobNamespaces[jobValue]; ok && !hasNamespace {
-					t.LabelFilterss[i] = append(group, metricsql.LabelFilter{
-						Label:    "namespace",
-						Value:    ns,
-						IsRegexp: true,
-					})
+				if !hasJob {
+					continue
 				}
+				if ns, ok := jobNamespaces[jobValue]; ok {
+					group = setLabelFilterValue(group, "namespace", ns)
+				}
+				for key, rw := range labelRewrites {
+					name := rw.Name
+					if name == "" {
+						name = key
+					}
+					if rw.Match == jobValue {
+						group = setLabelFilterValue(group, name, rw.Value)
+					}
+				}
+				t.LabelFilterss[i] = group
 			}
 		}
 	})
 	return string(e.AppendString(nil))
+}
+
+func setLabelFilterValue(group []metricsql.LabelFilter, label, newValue string) []metricsql.LabelFilter {
+	for i := range group {
+		if group[i].Label == label && !group[i].IsNegative && !group[i].IsRegexp {
+			if group[i].Value != newValue {
+				group[i].Value = newValue
+				group[i].IsRegexp = true
+			}
+			return group
+		}
+	}
+	return append(group, metricsql.LabelFilter{
+		Label:    label,
+		Value:    newValue,
+		IsRegexp: true,
+	})
 }
 
 const maxResourceNameLen = 253

--- a/hack/sync-job/rules_test.go
+++ b/hack/sync-job/rules_test.go
@@ -160,6 +160,7 @@ func TestPatchRuleExpr(t *testing.T) {
 		common        commonConfig
 		labels        []string
 		jobNamespaces map[string]string
+		labelRewrites map[string]map[string]string
 		want          string
 	}
 	f := func(o opts) {
@@ -167,7 +168,7 @@ func TestPatchRuleExpr(t *testing.T) {
 		if o.common.ClusterLabel == "" {
 			o.common.ClusterLabel = "cluster"
 		}
-		got := patchRuleExpr(o.expr, o.labels, o.common, o.jobNamespaces)
+		got := patchRuleExpr(o.expr, o.labels, o.common, o.jobNamespaces, o.labelRewrites)
 		if got != o.want {
 			t.Fatalf("patchRuleExpr(%q)\ngot:  %s\nwant: %s", o.expr, got, o.want)
 		}
@@ -313,6 +314,59 @@ func TestPatchRuleExpr(t *testing.T) {
 			"kubelet": "kube-system",
 		},
 		want: `up{job=~"kubelet.*"}`,
+	})
+
+	// labelRewrites — exact-match label filter values rewritten (issue: kube-prometheus
+	// selectors like job="alertmanager-main",namespace="monitoring" don't match the
+	// chart's own scrape job/namespace)
+	f(opts{
+		expr: `alertmanager_config_last_reload_successful{job="alertmanager-main",namespace="monitoring"}`,
+		labelRewrites: map[string]map[string]string{
+			"job":       {"alertmanager-main": "vmalertmanager-myrelease"},
+			"namespace": {"monitoring": "monitoring-ns"},
+		},
+		want: `alertmanager_config_last_reload_successful{job="vmalertmanager-myrelease",namespace="monitoring-ns"}`,
+	})
+	// container filter with matching value is left untouched when no rewrite is configured for it
+	f(opts{
+		expr: `up{job="alertmanager-main",container="alertmanager"}`,
+		labelRewrites: map[string]map[string]string{
+			"job": {"alertmanager-main": "vmalertmanager-myrelease"},
+		},
+		want: `up{job="vmalertmanager-myrelease",container="alertmanager"}`,
+	})
+	// regexp and negative filters are not rewritten
+	f(opts{
+		expr: `up{job=~"alertmanager.*",namespace!="monitoring"}`,
+		labelRewrites: map[string]map[string]string{
+			"job":       {"alertmanager-main": "vmalertmanager-myrelease"},
+			"namespace": {"monitoring": "monitoring-ns"},
+		},
+		want: `up{job=~"alertmanager.*",namespace!="monitoring"}`,
+	})
+	// values without a matching rewrite entry are left unchanged
+	f(opts{
+		expr: `up{job="other"}`,
+		labelRewrites: map[string]map[string]string{
+			"job": {"alertmanager-main": "vmalertmanager-myrelease"},
+		},
+		want: `up{job="other"}`,
+	})
+	// empty labelRewrites is a no-op
+	f(opts{
+		expr: `up{job="alertmanager-main"}`,
+		want: `up{job="alertmanager-main"}`,
+	})
+	// combined with jobNamespaces injection
+	f(opts{
+		expr: `up{job="alertmanager-main"}`,
+		jobNamespaces: map[string]string{
+			"vmalertmanager-myrelease": "monitoring-ns",
+		},
+		labelRewrites: map[string]map[string]string{
+			"job": {"alertmanager-main": "vmalertmanager-myrelease"},
+		},
+		want: `up{job="vmalertmanager-myrelease",namespace=~"monitoring-ns"}`,
 	})
 }
 
@@ -998,6 +1052,37 @@ func TestPatchRuleGroup(t *testing.T) {
 		}
 		if !strings.Contains(g.Rules[1].Expr, "namespace") {
 			t.Errorf("coredns: expected namespace filter; expr: %s", g.Rules[1].Expr)
+		}
+	})
+
+	t.Run("group labelRewrites merge with common", func(t *testing.T) {
+		g := ruleGroup{
+			Name: "alertmanager.rules",
+			Rules: []rule{
+				{Alert: "A", Expr: `up{job="alertmanager-main"}`},
+				{Alert: "B", Expr: `up{job="kubelet"}`},
+			},
+		}
+		cfg := &rulesConfig{
+			Common: rulesCommonConfig{
+				LabelRewrites: map[string]map[string]string{
+					"job": {"kubelet": "kubelet-common"},
+				},
+			},
+			Groups: map[string]groupOverride{
+				"alertmanager": {
+					LabelRewrites: map[string]map[string]string{
+						"job": {"alertmanager-main": "vmalertmanager-myrelease"},
+					},
+				},
+			},
+		}
+		patchRuleGroup(&g, cfg, commonConfig{ClusterLabel: "cluster"})
+		if !strings.Contains(g.Rules[0].Expr, `job="vmalertmanager-myrelease"`) {
+			t.Errorf("group labelRewrites not applied; expr: %s", g.Rules[0].Expr)
+		}
+		if !strings.Contains(g.Rules[1].Expr, `job="kubelet-common"`) {
+			t.Errorf("common labelRewrites not applied; expr: %s", g.Rules[1].Expr)
 		}
 	})
 }

--- a/hack/sync-job/rules_test.go
+++ b/hack/sync-job/rules_test.go
@@ -160,7 +160,7 @@ func TestPatchRuleExpr(t *testing.T) {
 		common        commonConfig
 		labels        []string
 		jobNamespaces map[string]string
-		labelRewrites map[string]map[string]string
+		labelRewrites map[string]labelRewrite
 		want          string
 	}
 	f := func(o opts) {
@@ -315,58 +315,93 @@ func TestPatchRuleExpr(t *testing.T) {
 		},
 		want: `up{job=~"kubelet.*"}`,
 	})
+	// a selector with no exact job filter is never touched, even if some rewrite's
+	// Match is left empty (zero value) and would otherwise equal the empty jobValue
+	f(opts{
+		expr: `up{instance=~".*"}`,
+		jobNamespaces: map[string]string{
+			"": "kube-system",
+		},
+		labelRewrites: map[string]labelRewrite{
+			"job": {Value: "vmalertmanager-.*"},
+		},
+		want: `up{instance=~".*"}`,
+	})
 
-	// labelRewrites — exact-match label filter values rewritten (issue: kube-prometheus
-	// selectors like job="alertmanager-main",namespace="monitoring" don't match the
-	// chart's own scrape job/namespace)
+	// jobNamespaces — an existing but different namespace value gets replaced
 	f(opts{
-		expr: `alertmanager_config_last_reload_successful{job="alertmanager-main",namespace="monitoring"}`,
-		labelRewrites: map[string]map[string]string{
-			"job":       {"alertmanager-main": "vmalertmanager-myrelease"},
-			"namespace": {"monitoring": "monitoring-ns"},
+		expr: `up{job="alertmanager-main",namespace="monitoring"}`,
+		jobNamespaces: map[string]string{
+			"alertmanager-main": "vm-ns",
 		},
-		want: `alertmanager_config_last_reload_successful{job="vmalertmanager-myrelease",namespace="monitoring-ns"}`,
+		want: `up{job="alertmanager-main",namespace=~"vm-ns"}`,
 	})
-	// container filter with matching value is left untouched when no rewrite is configured for it
+
+	// labelRewrites — key is the label name when Name is unset; Match must match the job exactly
 	f(opts{
-		expr: `up{job="alertmanager-main",container="alertmanager"}`,
-		labelRewrites: map[string]map[string]string{
-			"job": {"alertmanager-main": "vmalertmanager-myrelease"},
+		expr: `up{job="alertmanager-main"}`,
+		labelRewrites: map[string]labelRewrite{
+			"job": {Match: "alertmanager-main", Value: "vmalertmanager-.*"},
 		},
-		want: `up{job="vmalertmanager-myrelease",container="alertmanager"}`,
+		want: `up{job=~"vmalertmanager-.*"}`,
 	})
-	// regexp and negative filters are not rewritten
-	f(opts{
-		expr: `up{job=~"alertmanager.*",namespace!="monitoring"}`,
-		labelRewrites: map[string]map[string]string{
-			"job":       {"alertmanager-main": "vmalertmanager-myrelease"},
-			"namespace": {"monitoring": "monitoring-ns"},
-		},
-		want: `up{job=~"alertmanager.*",namespace!="monitoring"}`,
-	})
-	// values without a matching rewrite entry are left unchanged
 	f(opts{
 		expr: `up{job="other"}`,
-		labelRewrites: map[string]map[string]string{
-			"job": {"alertmanager-main": "vmalertmanager-myrelease"},
+		labelRewrites: map[string]labelRewrite{
+			"job": {Match: "alertmanager-main", Value: "vmalertmanager-.*"},
 		},
 		want: `up{job="other"}`,
 	})
-	// empty labelRewrites is a no-op
 	f(opts{
-		expr: `up{job="alertmanager-main"}`,
-		want: `up{job="alertmanager-main"}`,
+		expr: `up{job=~"alertmanager-main"}`,
+		labelRewrites: map[string]labelRewrite{
+			"job": {Match: "alertmanager-main", Value: "vmalertmanager-.*"},
+		},
+		want: `up{job=~"alertmanager-main"}`,
 	})
-	// combined with jobNamespaces injection
+	// labelRewrites — targets any label, added if absent from the selector
+	f(opts{
+		expr: `up{job="alertmanager-main",container="alertmanager"}`,
+		labelRewrites: map[string]labelRewrite{
+			"container": {Match: "alertmanager-main", Value: "alertmanager|config-reloader"},
+		},
+		want: `up{job="alertmanager-main",container=~"alertmanager|config-reloader"}`,
+	})
 	f(opts{
 		expr: `up{job="alertmanager-main"}`,
+		labelRewrites: map[string]labelRewrite{
+			"pod": {Match: "alertmanager-main", Value: "vmalertmanager-.*"},
+		},
+		want: `up{job="alertmanager-main",pod=~"vmalertmanager-.*"}`,
+	})
+	// labelRewrites — an existing regexp/negative filter for the target label is left
+	// alone; a new positive filter is appended alongside it instead of mutating it
+	f(opts{
+		expr: `up{job="alertmanager-main",container!="excluded"}`,
+		labelRewrites: map[string]labelRewrite{
+			"container": {Match: "alertmanager-main", Value: "alertmanager"},
+		},
+		want: `up{job="alertmanager-main",container!="excluded",container=~"alertmanager"}`,
+	})
+	// labelRewrites — explicit Name overrides the key, which is then just an identifier
+	f(opts{
+		expr: `up{job="alertmanager-main"}`,
+		labelRewrites: map[string]labelRewrite{
+			"anyKey": {Name: "pod", Match: "alertmanager-main", Value: "vmalertmanager-.*"},
+		},
+		want: `up{job="alertmanager-main",pod=~"vmalertmanager-.*"}`,
+	})
+
+	// labelRewrites combined with jobNamespaces — job and namespace both fixed in one pass
+	f(opts{
+		expr: `max_over_time(alertmanager_config_last_reload_successful{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[5m]) == 0`,
+		labelRewrites: map[string]labelRewrite{
+			"job": {Match: "alertmanager-main", Value: "vmalertmanager-.*"},
+		},
 		jobNamespaces: map[string]string{
-			"vmalertmanager-myrelease": "monitoring-ns",
+			"alertmanager-main": "vm-ns",
 		},
-		labelRewrites: map[string]map[string]string{
-			"job": {"alertmanager-main": "vmalertmanager-myrelease"},
-		},
-		want: `up{job="vmalertmanager-myrelease",namespace=~"monitoring-ns"}`,
+		want: `max_over_time(alertmanager_config_last_reload_successful{job=~"vmalertmanager-.*",container="alertmanager",namespace=~"vm-ns"}[5m]) == 0`,
 	})
 }
 
@@ -1055,34 +1090,60 @@ func TestPatchRuleGroup(t *testing.T) {
 		}
 	})
 
-	t.Run("group labelRewrites merge with common", func(t *testing.T) {
+	t.Run("group labelRewrites merges with common by key, group wins on conflict", func(t *testing.T) {
 		g := ruleGroup{
-			Name: "alertmanager.rules",
-			Rules: []rule{
-				{Alert: "A", Expr: `up{job="alertmanager-main"}`},
-				{Alert: "B", Expr: `up{job="kubelet"}`},
-			},
+			Name:  "mygroup",
+			Rules: []rule{{Alert: "A", Expr: `up{job="foo"}`}},
 		}
 		cfg := &rulesConfig{
 			Common: rulesCommonConfig{
-				LabelRewrites: map[string]map[string]string{
-					"job": {"kubelet": "kubelet-common"},
+				LabelRewrites: map[string]labelRewrite{
+					"job": {Match: "foo", Value: "common-job"},
+					"pod": {Match: "foo", Value: "common-pod"},
 				},
 			},
 			Groups: map[string]groupOverride{
-				"alertmanager": {
-					LabelRewrites: map[string]map[string]string{
-						"job": {"alertmanager-main": "vmalertmanager-myrelease"},
+				"mygroup": {
+					LabelRewrites: map[string]labelRewrite{
+						"job": {Match: "foo", Value: "group-job"},
 					},
 				},
 			},
 		}
 		patchRuleGroup(&g, cfg, commonConfig{ClusterLabel: "cluster"})
-		if !strings.Contains(g.Rules[0].Expr, `job="vmalertmanager-myrelease"`) {
-			t.Errorf("group labelRewrites not applied; expr: %s", g.Rules[0].Expr)
+		if g.Rules[0].Expr != `up{job=~"group-job",pod=~"common-pod"}` {
+			t.Errorf("got %q", g.Rules[0].Expr)
 		}
-		if !strings.Contains(g.Rules[1].Expr, `job="kubelet-common"`) {
-			t.Errorf("common labelRewrites not applied; expr: %s", g.Rules[1].Expr)
+	})
+
+	t.Run("group labelRewrites with explicit Name adds a second rule for the same label", func(t *testing.T) {
+		g := ruleGroup{
+			Name: "mygroup",
+			Rules: []rule{
+				{Alert: "A", Expr: `up{job="foo"}`},
+				{Alert: "B", Expr: `up{job="bar"}`},
+			},
+		}
+		cfg := &rulesConfig{
+			Common: rulesCommonConfig{
+				LabelRewrites: map[string]labelRewrite{
+					"job": {Match: "foo", Value: "vmfoo"},
+				},
+			},
+			Groups: map[string]groupOverride{
+				"mygroup": {
+					LabelRewrites: map[string]labelRewrite{
+						"job2": {Name: "job", Match: "bar", Value: "vmbar"},
+					},
+				},
+			},
+		}
+		patchRuleGroup(&g, cfg, commonConfig{ClusterLabel: "cluster"})
+		if g.Rules[0].Expr != `up{job=~"vmfoo"}` {
+			t.Errorf("foo: got %q", g.Rules[0].Expr)
+		}
+		if g.Rules[1].Expr != `up{job=~"vmbar"}` {
+			t.Errorf("bar: got %q", g.Rules[1].Expr)
 		}
 	})
 }


### PR DESCRIPTION
### Describe the bug

Since v0.85.0 moved default rules to the sync-job, the `alertmanager.rules` group is applied
with the kube-prometheus selectors unchanged (`job="alertmanager-main"`,
`container="alertmanager"`, `namespace="monitoring"`). The chart's Alertmanager exposes its
metrics under the release's VMAlertmanager scrape job and namespace instead, so all nine
rules in the group select series that don't exist.

Upstream report: VictoriaMetrics/helm-charts#3199

### Describe the solution

- sync-job (`hack/sync-job`): new generic `labelRewrites` knob
  (label name -> old value -> new value). It rewrites only exact-match label filters;
  regexp and negative filters are left unchanged. Per-group rewrites merge over common
  rewrites (per label, group wins).
- chart: `defaultRules.labelRewrites` values key (default `{}`) + passthrough in the
  sync-job config template. The template injects `alertmanager.rules` defaults rewriting
  `alertmanager-main` to the chart's own VMAlertmanager fullname and `monitoring` to the
  release namespace, unless the user defined their own `labelRewrites` for that group
  or disabled the alertmanager component.

### Verification

- `go test ./...` in `hack/sync-job`: green (7 new cases: rewrite, container-passthrough,
  regexp/negative untouched, unknown value no-op, empty no-op, combined with jobNamespaces,
  group-over-common merge).
- `helm template` default install: rendered sync-job config contains
  `alertmanager.rules: labelRewrites: job: alertmanager-main: vmalertmanager-testrel-victoria-metrics-k8s-stack`,
  `namespace: monitoring: <release ns>`.
- User-supplied `labelRewrites` for the group is respected (no injection);
  `alertmanager.enabled=false` produces no injection.

### Checklist (as applicable)

- [x] Unit tests added/updated
- [x] Chart renders verified with default and overridden values
- [x] DCO sign-off present
