### PR TITLE
Operator: add /metrics/slis to allowedMetricsEndpoints default

### DIFF
--- a/charts/victoria-metrics-operator/values.yaml
+++ b/charts/victoria-metrics-operator/values.yaml
@@ -197,6 +197,7 @@ logLevel: "info"
 allowedMetricsEndpoints:
   - /metrics
   - /metrics/resources
+  - /metrics/slis
 
 rbac:
   # -- Specifies whether the RBAC resources should be created


### PR DESCRIPTION
## Changes:
- Adds `/metrics/slis` to `allowedMetricsEndpoints` default

## Description:
In follow-up to VictoriaMetrics/operator#2543 

The operator passes `/metrics`, `/metrics/resources` and `/metrics/slis` onward to the
VMAgent/VMSingle scrape roles, but the chart's default only held the first two.