### PR TITLE
feat: derive operator ClusterRole rules from operator-role.yaml

### DIFF
--- a/charts/victoria-metrics-operator/CHANGELOG.md
+++ b/charts/victoria-metrics-operator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- TODO
+- operator ClusterRole rules are now derived from `operator-role.yaml`, synced from the operator repo on release, instead of being maintained by hand. Same approach the chart already uses for CRDs via `crd.yaml`. See [#3129](https://github.com/VictoriaMetrics/helm-charts/issues/3129) and [#3102](https://github.com/VictoriaMetrics/helm-charts/issues/3102)
+- the operator ClusterRole no longer grants `escalate`, `bind`, `impersonate` or `deletecollection`, and drops unused `pods` `create`/`update` and `customresourcedefinitions` `get`/`list`. None are used by the operator. The legacy `extensions` apiGroup is kept for backwards compatibility with operator releases before v0.75.0 and will be removed once those are no longer supported
 
 ## v0.67.3
 

--- a/charts/victoria-metrics-operator/operator-role.yaml
+++ b/charts/victoria-metrics-operator/operator-role.yaml
@@ -1,0 +1,326 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operator
+rules:
+- nonResourceURLs:
+  - /metrics
+  - /metrics/resources
+  - /metrics/slis
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - configmaps/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - persistentvolumeclaims/finalizers
+  - secrets
+  - secrets/finalizers
+  - serviceaccounts/finalizers
+  - services
+  - services/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - nodes
+  - nodes/metrics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - daemonsets/finalizers
+  - deployments
+  - deployments/finalizers
+  - replicasets
+  - statefulsets
+  - statefulsets/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - '*'
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - '*'
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - image.openshift.io
+  - route.openshift.io
+  resources:
+  - registry/metrics
+  - routers/metrics
+  verbs:
+  - get
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagerconfigs
+  - podmonitors
+  - probes
+  - prometheusrules
+  - scrapeconfigs
+  - servicemonitors
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagerconfigs/status
+  - podmonitors/status
+  - probes/status
+  - prometheusrules/status
+  - scrapeconfigs/status
+  - servicemonitors/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/finalizers
+  - networkpolicies
+  verbs:
+  - '*'
+- apiGroups:
+  - operator.victoriametrics.com
+  resources:
+  - vlagents
+  - vlclusters
+  - vldistributed
+  - vlogs
+  - vlsingles
+  - vmagents
+  - vmalertmanagerconfigs
+  - vmalertmanagers
+  - vmalerts
+  - vmanomalies
+  - vmanomalyconfigs
+  - vmauths
+  - vmclusters
+  - vmdistributed
+  - vmpodscrapes
+  - vmprobes
+  - vmrules
+  - vmscrapeconfigs
+  - vmservicescrapes
+  - vmsingles
+  - vmstaticscrapes
+  - vmusers
+  - vtagents
+  - vtclusters
+  - vtsingles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.victoriametrics.com
+  resources:
+  - vlagents/finalizers
+  - vlogs/finalizers
+  - vmagents/finalizers
+  - vmalertmanagerconfigs/finalizers
+  - vmalertmanagers/finalizers
+  - vmalerts/finalizers
+  - vmanomalies/finalizers
+  - vmauths/finalizers
+  - vmclusters/finalizers
+  - vmnodescrapes
+  - vmnodescrapes/finalizers
+  - vmpodscrapes/finalizers
+  - vmprobes/finalizers
+  - vmrules/finalizers
+  - vmscrapeconfigs/finalizers
+  - vmservicescrapes/finalizers
+  - vmsingles/finalizers
+  - vmstaticscrapes/finalizers
+  - vmusers/finalizers
+  - vtagents/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - operator.victoriametrics.com
+  resources:
+  - vlagents/status
+  - vlclusters/status
+  - vldistributed/status
+  - vlogs/status
+  - vlsingles/status
+  - vmagents/status
+  - vmalertmanagerconfigs/status
+  - vmalertmanagers/status
+  - vmalerts/status
+  - vmanomalies/status
+  - vmanomalyconfigs/status
+  - vmauths/status
+  - vmclusters/status
+  - vmdistributed/status
+  - vmnodescrapes/status
+  - vmpodscrapes/status
+  - vmprobes/status
+  - vmrules/status
+  - vmscrapeconfigs/status
+  - vmservicescrapes/status
+  - vmsingles/status
+  - vmstaticscrapes/status
+  - vmusers/status
+  - vtagents/status
+  - vtclusters/status
+  - vtsingles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - operator.victoriametrics.com
+  resources:
+  - vlclusters/finalizers
+  - vldistributed/finalizers
+  - vlsingles/finalizers
+  - vmdistributed/finalizers
+  - vtclusters/finalizers
+  - vtsingles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  - poddisruptionbudgets/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings/finalizers
+  - clusterroles/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/victoria-metrics-operator/templates/role.yaml
+++ b/charts/victoria-metrics-operator/templates/role.yaml
@@ -64,135 +64,47 @@ rules:
   - watch
   - list
 {{- end }}
+{{- /* do not add permissions here, please add a +kubebuilder:rbac marker in the operator repo */ -}}
+{{- /* these rules come from /victoria-metrics-operator/operator-role.yaml, synced on operator release */}}
+{{- $gated := dict
+      "autoscaling.k8s.io/verticalpodautoscalers"        .Values.operator.vpa_support
+      "gateway.networking.k8s.io/httproutes"             .Values.operator.gateway_support
+      "gateway.networking.k8s.io/httproutes/finalizers"  .Values.operator.gateway_support }}
+{{- $gatedGroups := list "autoscaling.k8s.io" "gateway.networking.k8s.io" }}
+{{- $opRole := required "operator-role.yaml is missing or empty" (.Files.Get "operator-role.yaml") | fromYaml }}
+{{- range $r := $opRole.rules }}
+{{- if and $r.resources (not (has "operator.victoriametrics.com" $r.apiGroups)) }}
+{{- $keep := list }}
+{{- range $res := $r.resources }}
+{{- $enabled := true }}
+{{- range $g := $r.apiGroups }}
+{{- $key := printf "%s/%s" $g $res }}
+{{- if hasKey $gated $key }}{{- $enabled = get $gated $key }}
+{{- else if has $g $gatedGroups }}{{- fail (printf "unclassified resource %q in feature-gated apiGroup %q - add it to the $gated map in templates/role.yaml" $res $g) }}
+{{- end }}
+{{- end }}
+{{- if $enabled }}{{- $keep = append $keep $res }}{{- end }}
+{{- end }}
+{{- if $keep }}
+- apiGroups: {{ toYaml $r.apiGroups | nindent 2 }}
+  resources: {{ toYaml $keep | nindent 2 }}
+  verbs: {{ toYaml $r.verbs | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- /* backwards compatibility: operator releases before v0.75.0 request the legacy */ -}}
+{{- /* extensions apiGroup when building the cluster-wide ClusterRole for VMAgent, or */ -}}
+{{- /* for VMSingle with ingestOnlyMode: false. Since the rules above no longer grant */ -}}
+{{- /* escalate, this chart must hold that permission to grant it onward. */ -}}
+{{- /* not needed for operator v0.75.0+; remove when support for older releases is dropped */}}
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - configmaps/finalizers
-  - endpoints
-  - events
-  - persistentvolumeclaims
-  - persistentvolumeclaims/finalizers
-  - pods
-  - pods/eviction
-  - secrets
-  - secrets/finalizers
-  - services
-  - services/finalizers
-  - serviceaccounts
-  - serviceaccounts/finalizers
-  verbs:
-  - "*"
-- apiGroups:
-  - ""
-  resources:
-  - configmaps/status
-  - nodes
-  - nodes/metrics
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - daemonsets/finalizers
-  - deployments
-  - deployments/finalizers
-  - replicasets
-  - statefulsets
-  - statefulsets/finalizers
-  - statefulsets/status
-  verbs:
-  - "*"
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - "*"
-  verbs:
-  - "*"
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - clusterrolebindings/finalizers
-  - clusterroles
-  - clusterroles/finalizers
-  - roles
-  - rolebindings
-  verbs:
-  - "*"
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - list
-  - get
-  - watch
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  - poddisruptionbudgets/finalizers
-  verbs:
-  - "*"
-- apiGroups:
-  - route.openshift.io
-  - image.openshift.io
-  resources:
-  - routers/metrics
-  - registry/metrics
-  verbs:
-  - get
-- apiGroups:
-  - autoscaling
-  verbs:
-  - "*"
-  resources:
-  - horizontalpodautoscalers
-- apiGroups:
-  - networking.k8s.io
+  - extensions
   resources:
   - ingresses
-  - ingresses/finalizers
-  - networkpolicies
-  verbs:
-  - "*"
-{{- if .Values.operator.gateway_support }}
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
-  - httproutes
-  - httproutes/finalizers
-  verbs:
-  - '*'
-{{- end }}
-{{- if .Values.operator.vpa_support }}
-- apiGroups:
-  - autoscaling.k8s.io
-  verbs:
-  - "*"
-  resources:
-  - verticalpodautoscalers
-{{- end }}
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
   verbs:
   - get
-  - list
-- apiGroups:
-  - discovery.k8s.io
-  resources:
-  - endpointslices
-  verbs:
   - list
   - watch
-  - get
 {{- with $rules.admin }}
 {{ toYaml . }}
 {{- end }}

--- a/charts/victoria-metrics-operator/tests/__snapshot__/role_test.yaml.snap
+++ b/charts/victoria-metrics-operator/tests/__snapshot__/role_test.yaml.snap
@@ -1,0 +1,3155 @@
+role should match snapshot:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator
+      namespace: NAMESPACE
+    rules:
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - create
+          - get
+          - update
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator
+    rules:
+      - nonResourceURLs:
+          - /metrics
+          - /metrics/resources
+          - /metrics/slis
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - configmaps/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - persistentvolumeclaims/finalizers
+          - secrets
+          - secrets/finalizers
+          - serviceaccounts/finalizers
+          - services
+          - services/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+          - nodes
+          - nodes/metrics
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods/eviction
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+          - daemonsets/finalizers
+          - deployments
+          - deployments/finalizers
+          - replicasets
+          - statefulsets
+          - statefulsets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - apps
+        resources:
+          - statefulsets/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - autoscaling
+        resources:
+          - horizontalpodautoscalers
+        verbs:
+          - '*'
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - image.openshift.io
+          - route.openshift.io
+        resources:
+          - registry/metrics
+          - routers/metrics
+        verbs:
+          - get
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - '*'
+        verbs:
+          - '*'
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs
+          - podmonitors
+          - probes
+          - prometheusrules
+          - scrapeconfigs
+          - servicemonitors
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs/status
+          - podmonitors/status
+          - probes/status
+          - prometheusrules/status
+          - scrapeconfigs/status
+          - servicemonitors/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses/finalizers
+          - networkpolicies
+        verbs:
+          - '*'
+      - apiGroups:
+          - policy
+        resources:
+          - poddisruptionbudgets
+          - poddisruptionbudgets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings/finalizers
+          - clusterroles/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - storageclasses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-admin
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  4: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-view
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - get
+          - list
+          - watch
+role should match snapshot when watching own namespace only:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator
+      namespace: NAMESPACE
+    rules:
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - create
+          - get
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - configmaps/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - persistentvolumeclaims/finalizers
+          - secrets
+          - secrets/finalizers
+          - serviceaccounts/finalizers
+          - services
+          - services/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+          - nodes
+          - nodes/metrics
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods/eviction
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+          - daemonsets/finalizers
+          - deployments
+          - deployments/finalizers
+          - replicasets
+          - statefulsets
+          - statefulsets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - apps
+        resources:
+          - statefulsets/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - autoscaling
+        resources:
+          - horizontalpodautoscalers
+        verbs:
+          - '*'
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - image.openshift.io
+          - route.openshift.io
+        resources:
+          - registry/metrics
+          - routers/metrics
+        verbs:
+          - get
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - '*'
+        verbs:
+          - '*'
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs
+          - podmonitors
+          - probes
+          - prometheusrules
+          - scrapeconfigs
+          - servicemonitors
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs/status
+          - podmonitors/status
+          - probes/status
+          - prometheusrules/status
+          - scrapeconfigs/status
+          - servicemonitors/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses/finalizers
+          - networkpolicies
+        verbs:
+          - '*'
+      - apiGroups:
+          - policy
+        resources:
+          - poddisruptionbudgets
+          - poddisruptionbudgets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings/finalizers
+          - clusterroles/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - storageclasses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-admin
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-view
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - get
+          - list
+          - watch
+role should match snapshot with all feature flags:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator
+      namespace: NAMESPACE
+    rules:
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - create
+          - get
+          - update
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator
+    rules:
+      - nonResourceURLs:
+          - /metrics
+          - /metrics/resources
+          - /metrics/slis
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - configmaps/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - persistentvolumeclaims/finalizers
+          - secrets
+          - secrets/finalizers
+          - serviceaccounts/finalizers
+          - services
+          - services/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+          - nodes
+          - nodes/metrics
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods/eviction
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+          - daemonsets/finalizers
+          - deployments
+          - deployments/finalizers
+          - replicasets
+          - statefulsets
+          - statefulsets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - apps
+        resources:
+          - statefulsets/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - autoscaling
+        resources:
+          - horizontalpodautoscalers
+        verbs:
+          - '*'
+      - apiGroups:
+          - autoscaling.k8s.io
+        resources:
+          - verticalpodautoscalers
+        verbs:
+          - '*'
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - httproutes
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - image.openshift.io
+          - route.openshift.io
+        resources:
+          - registry/metrics
+          - routers/metrics
+        verbs:
+          - get
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - '*'
+        verbs:
+          - '*'
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs
+          - podmonitors
+          - probes
+          - prometheusrules
+          - scrapeconfigs
+          - servicemonitors
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs/status
+          - podmonitors/status
+          - probes/status
+          - prometheusrules/status
+          - scrapeconfigs/status
+          - servicemonitors/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses/finalizers
+          - networkpolicies
+        verbs:
+          - '*'
+      - apiGroups:
+          - policy
+        resources:
+          - poddisruptionbudgets
+          - poddisruptionbudgets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings/finalizers
+          - clusterroles/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - storageclasses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-admin
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  4: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-view
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - get
+          - list
+          - watch
+role should match snapshot with cleanup hook and aggregated roles:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator
+      namespace: NAMESPACE
+    rules:
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - create
+          - get
+          - update
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator
+    rules:
+      - nonResourceURLs:
+          - /metrics
+          - /metrics/resources
+          - /metrics/slis
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - configmaps/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - persistentvolumeclaims/finalizers
+          - secrets
+          - secrets/finalizers
+          - serviceaccounts/finalizers
+          - services
+          - services/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+          - nodes
+          - nodes/metrics
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods/eviction
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+          - daemonsets/finalizers
+          - deployments
+          - deployments/finalizers
+          - replicasets
+          - statefulsets
+          - statefulsets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - apps
+        resources:
+          - statefulsets/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - autoscaling
+        resources:
+          - horizontalpodautoscalers
+        verbs:
+          - '*'
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - image.openshift.io
+          - route.openshift.io
+        resources:
+          - registry/metrics
+          - routers/metrics
+        verbs:
+          - get
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - '*'
+        verbs:
+          - '*'
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs
+          - podmonitors
+          - probes
+          - prometheusrules
+          - scrapeconfigs
+          - servicemonitors
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs/status
+          - podmonitors/status
+          - probes/status
+          - prometheusrules/status
+          - scrapeconfigs/status
+          - servicemonitors/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses/finalizers
+          - networkpolicies
+        verbs:
+          - '*'
+      - apiGroups:
+          - policy
+        resources:
+          - poddisruptionbudgets
+          - poddisruptionbudgets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings/finalizers
+          - clusterroles/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - storageclasses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations:
+        helm.sh/hook: pre-delete
+        helm.sh/hook-delete-policy: before-hook-creation
+        helm.sh/hook-weight: "-5"
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator-cleanup-hook
+      namespace: NAMESPACE
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  4: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-admin
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  5: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-view
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - get
+          - list
+          - watch
+role should match snapshot with gateway_support:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator
+      namespace: NAMESPACE
+    rules:
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - create
+          - get
+          - update
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator
+    rules:
+      - nonResourceURLs:
+          - /metrics
+          - /metrics/resources
+          - /metrics/slis
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - configmaps/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - persistentvolumeclaims/finalizers
+          - secrets
+          - secrets/finalizers
+          - serviceaccounts/finalizers
+          - services
+          - services/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+          - nodes
+          - nodes/metrics
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods/eviction
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+          - daemonsets/finalizers
+          - deployments
+          - deployments/finalizers
+          - replicasets
+          - statefulsets
+          - statefulsets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - apps
+        resources:
+          - statefulsets/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - autoscaling
+        resources:
+          - horizontalpodautoscalers
+        verbs:
+          - '*'
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - httproutes
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - image.openshift.io
+          - route.openshift.io
+        resources:
+          - registry/metrics
+          - routers/metrics
+        verbs:
+          - get
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - '*'
+        verbs:
+          - '*'
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs
+          - podmonitors
+          - probes
+          - prometheusrules
+          - scrapeconfigs
+          - servicemonitors
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs/status
+          - podmonitors/status
+          - probes/status
+          - prometheusrules/status
+          - scrapeconfigs/status
+          - servicemonitors/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses/finalizers
+          - networkpolicies
+        verbs:
+          - '*'
+      - apiGroups:
+          - policy
+        resources:
+          - poddisruptionbudgets
+          - poddisruptionbudgets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings/finalizers
+          - clusterroles/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - storageclasses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-admin
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  4: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-view
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - get
+          - list
+          - watch
+role should match snapshot with vpa_support:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator
+      namespace: NAMESPACE
+    rules:
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - create
+          - get
+          - update
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+      name: RELEASE-NAME-victoria-metrics-operator
+    rules:
+      - nonResourceURLs:
+          - /metrics
+          - /metrics/resources
+          - /metrics/slis
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - configmaps/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - persistentvolumeclaims/finalizers
+          - secrets
+          - secrets/finalizers
+          - serviceaccounts/finalizers
+          - services
+          - services/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+          - nodes
+          - nodes/metrics
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - pods/eviction
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+          - daemonsets/finalizers
+          - deployments
+          - deployments/finalizers
+          - replicasets
+          - statefulsets
+          - statefulsets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - apps
+        resources:
+          - statefulsets/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - autoscaling
+        resources:
+          - horizontalpodautoscalers
+        verbs:
+          - '*'
+      - apiGroups:
+          - autoscaling.k8s.io
+        resources:
+          - verticalpodautoscalers
+        verbs:
+          - '*'
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - image.openshift.io
+          - route.openshift.io
+        resources:
+          - registry/metrics
+          - routers/metrics
+        verbs:
+          - get
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - '*'
+        verbs:
+          - '*'
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs
+          - podmonitors
+          - probes
+          - prometheusrules
+          - scrapeconfigs
+          - servicemonitors
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - alertmanagerconfigs/status
+          - podmonitors/status
+          - probes/status
+          - prometheusrules/status
+          - scrapeconfigs/status
+          - servicemonitors/status
+        verbs:
+          - get
+          - patch
+          - update
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses/finalizers
+          - networkpolicies
+        verbs:
+          - '*'
+      - apiGroups:
+          - policy
+        resources:
+          - poddisruptionbudgets
+          - poddisruptionbudgets/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterrolebindings/finalizers
+          - clusterroles/finalizers
+        verbs:
+          - '*'
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - storageclasses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-admin
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - '*'
+  4: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/version: v0.74.1
+        helm.sh/chart: victoria-metrics-operator-0.67.3
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: RELEASE-NAME-victoria-metrics-operator-victoriametrics-view
+    rules:
+      - apiGroups:
+          - operator.victoriametrics.com
+        resources:
+          - vlagents
+          - vlagents/finalizers
+          - vlagents/status
+          - vlclusters
+          - vlclusters/finalizers
+          - vlclusters/status
+          - vldistributed
+          - vldistributed/finalizers
+          - vldistributed/status
+          - vlogs
+          - vlogs/finalizers
+          - vlogs/status
+          - vlsingles
+          - vlsingles/finalizers
+          - vlsingles/status
+          - vmagents
+          - vmagents/finalizers
+          - vmagents/status
+          - vmalertmanagerconfigs
+          - vmalertmanagerconfigs/finalizers
+          - vmalertmanagerconfigs/status
+          - vmalertmanagers
+          - vmalertmanagers/finalizers
+          - vmalertmanagers/status
+          - vmalerts
+          - vmalerts/finalizers
+          - vmalerts/status
+          - vmanomalies
+          - vmanomalies/finalizers
+          - vmanomalies/status
+          - vmanomalyconfigs
+          - vmanomalyconfigs/finalizers
+          - vmanomalyconfigs/status
+          - vmauths
+          - vmauths/finalizers
+          - vmauths/status
+          - vmclusters
+          - vmclusters/finalizers
+          - vmclusters/status
+          - vmdistributed
+          - vmdistributed/finalizers
+          - vmdistributed/status
+          - vmnodescrapes
+          - vmnodescrapes/finalizers
+          - vmnodescrapes/status
+          - vmpodscrapes
+          - vmpodscrapes/finalizers
+          - vmpodscrapes/status
+          - vmprobes
+          - vmprobes/finalizers
+          - vmprobes/status
+          - vmrules
+          - vmrules/finalizers
+          - vmrules/status
+          - vmscrapeconfigs
+          - vmscrapeconfigs/finalizers
+          - vmscrapeconfigs/status
+          - vmservicescrapes
+          - vmservicescrapes/finalizers
+          - vmservicescrapes/status
+          - vmsingles
+          - vmsingles/finalizers
+          - vmsingles/status
+          - vmstaticscrapes
+          - vmstaticscrapes/finalizers
+          - vmstaticscrapes/status
+          - vmusers
+          - vmusers/finalizers
+          - vmusers/status
+          - vtclusters
+          - vtclusters/finalizers
+          - vtclusters/status
+          - vtsingles
+          - vtsingles/finalizers
+          - vtsingles/status
+        verbs:
+          - get
+          - list
+          - watch

--- a/charts/victoria-metrics-operator/tests/role_test.yaml
+++ b/charts/victoria-metrics-operator/tests/role_test.yaml
@@ -1,0 +1,131 @@
+suite: operator role templates test
+templates:
+  - role.yaml
+tests:
+  # Snapshots. These pin the full rendered ClusterRole/Role set so that any change
+  # to the operator's permissions shows up as a reviewable diff rather than silently.
+  - it: role should match snapshot
+    asserts:
+      - matchSnapshot: {}
+  - it: role should match snapshot with vpa_support
+    set:
+      operator.vpa_support: true
+    asserts:
+      - matchSnapshot: {}
+  - it: role should match snapshot with gateway_support
+    set:
+      operator.gateway_support: true
+    asserts:
+      - matchSnapshot: {}
+  - it: role should match snapshot with all feature flags
+    set:
+      operator.vpa_support: true
+      operator.gateway_support: true
+    asserts:
+      - matchSnapshot: {}
+  - it: role should match snapshot with cleanup hook and aggregated roles
+    set:
+      crds.cleanup.enabled: true
+      rbac.aggregatedClusterRoles.enabled: true
+    asserts:
+      - matchSnapshot: {}
+  - it: role should match snapshot when watching own namespace only
+    set:
+      watchNamespaces:
+        - NAMESPACE
+    asserts:
+      - matchSnapshot: {}
+
+  # Capability invariants. Unlike the snapshots above these must never change:
+  # each corresponds to a permission the operator actually exercises, where
+  # losing it makes the operator hang or silently no-op rather than error.
+  - it: grants the permissions the operator needs at runtime
+    documentIndex: 1
+    asserts:
+      # networkpolicies - VictoriaMetrics/helm-charts#3129
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["networking.k8s.io"]
+            resources: ["ingresses/finalizers", "networkpolicies"]
+            verbs: ["*"]
+      # VMAuth creates an Ingress; read-only here meant it silently could not
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["networking.k8s.io"]
+            resources: ["ingresses"]
+            verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+      # vmalert rule reload patches pods; that error is logged, not returned
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods"]
+            verbs: ["delete", "get", "list", "patch", "watch"]
+      # always-cached types need watch, or the informer parks and Get never returns
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["storage.k8s.io"]
+            resources: ["storageclasses"]
+            verbs: ["get", "list", "watch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["discovery.k8s.io"]
+            resources: ["endpointslices"]
+            verbs: ["get", "list", "watch"]
+
+  - it: gates verticalpodautoscalers behind operator.vpa_support
+    documentIndex: 1
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["autoscaling.k8s.io"]
+            resources: ["verticalpodautoscalers"]
+            verbs: ["*"]
+  - it: grants verticalpodautoscalers when operator.vpa_support is set
+    documentIndex: 1
+    set:
+      operator.vpa_support: true
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["autoscaling.k8s.io"]
+            resources: ["verticalpodautoscalers"]
+            verbs: ["*"]
+
+  - it: gates httproutes behind operator.gateway_support
+    documentIndex: 1
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["httproutes"]
+            verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - it: grants httproutes when operator.gateway_support is set
+    documentIndex: 1
+    set:
+      operator.gateway_support: true
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["httproutes"]
+            verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+
+
+  - it: retains the legacy extensions apiGroup for operator releases before v0.75.0
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["extensions"]
+            resources: ["ingresses"]
+            verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Changes:
- pulls the operator's non-CRD ClusterRole rules from `operator-role.yaml` instead of hand-maintaining a copy of them in `templates/role.yaml`
- Adds `operator-role.yaml`, pulled from operator `v0.75.0-rc1`
- Adds `tests/role_test.yaml`: 6 snapshots across feature-flag, cleanup-hook, aggregated-role and watchNamespaces permutations, plus 5 capability invariants

## Description:

Follow-up to VictoriaMetrics/operator#2602, which syncs `config/rbac/role.yaml` into this chart on release. This is the PR that consumes that file.

The chart's copy drifts from the operator's  #3129 (`networkpolicies`) and
#3102 (`verticalpodautoscalers`). The chart already derives CRD permissions from the
bundled `crd.yaml`

Tested on `kind` with operator v0.74.1 and v0.75.0-rc1: VMSingle, VMAgent, VMAlert and
VMAuth all reconcile, no RBAC denials on either.